### PR TITLE
Add support for Shelly B&T Gen3 sensors and similar

### DIFF
--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -182,6 +182,27 @@ def _create_rpc_sensors(
                     coordinator, device_id, desc, 0, "cloud", "connected"
                 ))
 
+    # External power supply presence (battery devices)
+    for key in status:
+        if match := re.match(r"devicepower:(\d+)", key):
+            idx = int(match.group(1))
+            component = status[key]
+            external = component.get("external") if isinstance(component, dict) else None
+            if isinstance(external, dict) and "present" in external:
+                desc = RPC_BINARY_SENSORS.get("external_power")
+                if desc:
+                    uid = f"{device_id}_external_power_{idx}"
+                    if uid not in created:
+                        created.add(uid)
+                        entities.append(RpcBinarySensor(
+                            coordinator,
+                            device_id,
+                            desc,
+                            idx,
+                            key,
+                            "external",
+                        ))
+
     return entities
 
 
@@ -374,6 +395,16 @@ class RpcBinarySensor(ShellyBaseEntity, BinarySensorEntity):
 
         value = component.get(self._attr_key)
         if value is None:
+            return None
+
+        # ``devicepower:<id>.external`` uses a nested object like
+        # {"present": bool}; this keeps the generic RPC entity reusable.
+        if isinstance(value, dict) and "present" in value:
+            present = value.get("present")
+            if isinstance(present, bool):
+                return present
+            if isinstance(present, (int, float)):
+                return present > 0
             return None
 
         if isinstance(value, bool):

--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -94,16 +94,13 @@ PLATFORMS: list[Platform] = [
 
 # ── Device-generation detection ────────────────────────────────────
 
-# Gen2/Gen3 RPC devices expose keys like ``switch:0``, ``light:0``, etc.
-# Battery sensor devices (e.g. Shelly H&T Gen3) expose only sensor
-# components such as ``temperature:0``, ``humidity:0`` and ``devicepower:0``.
-# Gen1 devices use legacy keys like ``relays``, ``meters``. BLE devices
-# reported through Shelly BLU Gateway use the same ``humidity:0`` /
-# ``temperature:0`` shape but are distinguished by ``_dev_info.gen == "GBLE"``
-# (checked first in ``device_gen`` before this structural fallback).
-_GEN2_PATTERN = re.compile(
-    r"(switch|light|cover|input|cloud|sys|temperature|humidity"
-    r"|devicepower|voltmeter):\d+"
+# Gen2/Gen3 RPC devices expose component keys like ``switch:0`` or
+# ``temperature:0`` and may also include top-level blocks like ``cloud`` / ``sys``.
+# Gen1 devices use legacy keys like ``relays``, ``meters``.
+# BLE devices reported through Shelly BLU Gateway also use ``<type>:<id>`` keys,
+# but should carry ``_dev_info.gen == \"GBLE\"`` which ``device_gen`` checks first.
+_GEN2_COMPONENT_KEY = re.compile(
+    r"^(switch|light|cover|input|temperature|humidity|voltmeter|devicepower):\d+$"
 )
 
 
@@ -111,7 +108,17 @@ def is_gen2_status(status: dict[str, Any]) -> bool:
     """Return True if the status dict looks like a Gen2/Gen3 RPC device."""
     if not status:
         return False
-    return any(_GEN2_PATTERN.match(key) for key in status)
+    if any(_GEN2_COMPONENT_KEY.match(key) for key in status):
+        return True
+
+    # Sensor-only Gen2 devices may expose mostly top-level RPC blocks plus
+    # one or two component keys. Treat cloud/sys/wifi presence as supporting
+    # evidence rather than a sole signal.
+    has_rpc_blocks = any(key in status for key in ("cloud", "sys", "wifi"))
+    has_legacy_gen1_blocks = any(
+        key in status for key in ("relays", "rollers", "meters", "emeters")
+    )
+    return has_rpc_blocks and not has_legacy_gen1_blocks
 
 
 def device_gen(status: dict[str, Any]) -> str:

--- a/custom_components/shelly_cloud_diy/entities/descriptions.py
+++ b/custom_components/shelly_cloud_diy/entities/descriptions.py
@@ -533,6 +533,13 @@ RPC_BINARY_SENSORS: Final[dict[str, RpcBinarySensorDescription]] = {
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    "external_power": RpcBinarySensorDescription(
+        key="devicepower",
+        sub_key="external",
+        name="External Power",
+        device_class=BinarySensorDeviceClass.POWER,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 }
 
 

--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -11,7 +11,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from homeassistant.const import PERCENTAGE, UnitOfElectricPotential, EntityCategory
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfElectricPotential,
+    EntityCategory,
+)
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
 from .const import DOMAIN, device_gen, is_gen2_status
@@ -228,7 +233,7 @@ def _create_rpc_sensors(
                         coordinator, device_id, desc, idx, key, "tC"
                     ))
 
-    # Humidity sensors (e.g. Shelly H&T Gen3) — reading under ``rh``.
+    # Humidity sensors
     for key in status:
         if match := re.match(r"humidity:(\d+)", key):
             idx = int(match.group(1))
@@ -240,24 +245,6 @@ def _create_rpc_sensors(
                     entities.append(RpcSensor(
                         coordinator, device_id, desc, idx, key, "rh"
                     ))
-
-    # Battery — ``devicepower:<idx>.battery.percent`` (nested shape). The
-    # ``battery`` description's value_fn extracts ``percent`` from the dict
-    # returned by ``component.get("battery")``.
-    for key in status:
-        if match := re.match(r"devicepower:(\d+)", key):
-            idx = int(match.group(1))
-            data = status[key]
-            if isinstance(data, dict) and isinstance(data.get("battery"), dict):
-                desc = RPC_SENSORS.get("battery")
-                if desc:
-                    uid = f"{device_id}_devicepower_{idx}_battery"
-                    if uid not in created:
-                        created.add(uid)
-                        entities.append(RpcSensor(
-                            coordinator, device_id, desc, idx, key, "battery"
-                        ))
-
     # Voltmeter — analog voltage input (e.g. Shelly Plus Uni, Plus Add-on).
     # The component id is in the add-on range (100+) but each device has a
     # single analog input, so name it cleanly without a channel suffix.
@@ -274,6 +261,43 @@ def _create_rpc_sensors(
                         entities.append(RpcSensor(
                             coordinator, device_id, desc, 0, key, "voltage"
                         ))
+
+    # Device power (battery-backed sensors)
+    for key in status:
+        if match := re.match(r"devicepower:(\d+)", key):
+            idx = int(match.group(1))
+            data = status[key]
+            battery = data.get("battery") if isinstance(data, dict) else None
+            if isinstance(battery, dict):
+                if "percent" in battery:
+                    desc = RPC_SENSORS.get("battery")
+                    if desc:
+                        uid = f"{device_id}_battery_{idx}"
+                        if uid not in created:
+                            created.add(uid)
+                            entities.append(RpcSensor(
+                                coordinator, device_id, desc, idx, key, "battery"
+                            ))
+
+                if "V" in battery:
+                    uid = f"{device_id}_battery_voltage_{idx}"
+                    if uid not in created:
+                        created.add(uid)
+                        entities.append(RpcBatteryVoltageSensor(
+                            coordinator, device_id, idx, key
+                        ))
+
+    # Wi-Fi RSSI diagnostics
+    wifi = status.get("wifi")
+    if isinstance(wifi, dict) and "rssi" in wifi:
+        desc = RPC_SENSORS.get("rssi")
+        if desc:
+            uid = f"{device_id}_wifi_rssi"
+            if uid not in created:
+                created.add(uid)
+                entities.append(RpcSensor(
+                    coordinator, device_id, desc, 0, "wifi", "rssi"
+                ))
 
     return entities
 
@@ -455,6 +479,43 @@ class RpcSensor(ShellyBaseEntity, SensorEntity):
             value = self._description.value_fn(value)
 
         return value
+
+
+class RpcBatteryVoltageSensor(ShellyBaseEntity, SensorEntity):
+    """Gen2/Gen3 battery voltage from ``devicepower:<id>.battery.V``."""
+
+    _attr_name = "Battery Voltage"
+    _attr_device_class = SensorDeviceClass.VOLTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_suggested_display_precision = 2
+
+    def __init__(
+        self,
+        coordinator: ShellyCloudCoordinator,
+        device_id: str,
+        channel: int,
+        component_key: str,
+    ) -> None:
+        super().__init__(coordinator, device_id, channel)
+        self._component_key = component_key
+        self._attr_unique_id = f"{device_id}_{component_key}_battery_voltage"
+        if channel != 0:
+            self._attr_name = f"Battery Voltage {channel + 1}"
+
+    @property
+    def native_value(self) -> float | None:
+        component = self.device_status.get(self._component_key)
+        if not isinstance(component, dict):
+            return None
+        battery = component.get("battery")
+        if not isinstance(battery, dict):
+            return None
+        value = battery.get("V")
+        if isinstance(value, (int, float)):
+            return float(value)
+        return None
 
 
 class BleSensor(ShellyBaseEntity, SensorEntity):


### PR DESCRIPTION
* Adjust gen1/2 vs gen3 detection for sensor-only devices
* Add humidity sensor info
* Add WiFi RSSI as sensor info
* Add battery voltage sensor info
* Add external power supply indicator

Assisted-by: GPT-5.3-Codex
Fixes: #4 