### PR TITLE
feat(sensor): Shelly BLU Door/Window entities — window open + tilt angle (#9)

### DIFF
--- a/custom_components/shelly_cloud_diy/entities/descriptions.py
+++ b/custom_components/shelly_cloud_diy/entities/descriptions.py
@@ -930,6 +930,18 @@ BLE_SENSORS: Final[dict[str, BleSensorDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:compass-outline",
     ),
+    # Shelly BLU Door/Window (SBDW-002C), bridged via a BLU gateway. Reports a
+    # ``tilt:0`` key with an ``angle`` field (opening angle in degrees). HA has
+    # no device_class for a raw angle, so we mirror the native Shelly Gen1
+    # tilt sensor: degrees + MEASUREMENT, no device_class. (Its ``window:0``
+    # open/closed contact is a binary sensor; battery is covered above.)
+    "tilt": BleSensorDescription(
+        name="Tilt",
+        value_field="angle",
+        native_unit_of_measurement="°",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:angle-acute",
+    ),
 }
 
 
@@ -960,5 +972,14 @@ BLE_BINARY_SENSORS: Final[dict[str, BleBinarySensorDescription]] = {
         name="Motion",
         value_field="motion",
         device_class=BinarySensorDeviceClass.MOTION,
+    ),
+    # Shelly BLU Door/Window (SBDW-002C), bridged via a BLU gateway. Reports a
+    # ``window:0`` key with an ``open`` field (true = open). We mirror the
+    # native Shelly Door/Window device_class (OPENING). ``is_on`` already
+    # coerces bool or numeric, so a 0/1 payload is handled too.
+    "window": BleBinarySensorDescription(
+        name="Door/Window",
+        value_field="open",
+        device_class=BinarySensorDeviceClass.OPENING,
     ),
 }

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.7"
+  "version": "0.6.8-beta1"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Test configuration for shelly_cloud_diy.
+
+Ensures the repo root is importable so ``custom_components.shelly_cloud_diy``
+resolves regardless of how pytest is invoked.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/test_blu_door_window.py
+++ b/tests/test_blu_door_window.py
@@ -1,0 +1,151 @@
+"""Unit tests for Shelly BLU Door/Window entities (issue #9, part 1).
+
+A BLU Door/Window sensor bridged via a BLU gateway (``_dev_info.gen == "GBLE"``)
+reports ``window:0 = {"open": bool}`` and ``tilt:0 = {"angle": deg}`` in the
+cloud status snapshot. These tests exercise the real production code paths
+(``_create_ble_sensors`` / ``_create_ble_binary_sensors`` and the ``BleSensor`` /
+``BleBinarySensor`` value logic) with a lightweight fake coordinator — no running
+Home Assistant instance required, so they run identically against any HA version.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.sensor import SensorStateClass
+
+from custom_components.shelly_cloud_diy.binary_sensor import (
+    BleBinarySensor,
+    _create_ble_binary_sensors,
+)
+from custom_components.shelly_cloud_diy.sensor import BleSensor, _create_ble_sensors
+
+DEVICE_ID = "abc123def456"
+
+
+class _FakeCoordinator:
+    """Minimal coordinator: entities only read ``.devices[id]['status']``."""
+
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {
+            device_id: {
+                "status": status,
+                "device_code": "SBDW-002C",
+                "online": True,
+            }
+        }
+        self.data = self.devices
+        self.last_update_success = True
+
+
+def _build(status: dict[str, Any]):
+    """Run both BLE creation loops against a status and index by unique_id."""
+    coord = _FakeCoordinator(DEVICE_ID, status)
+    sensors = _create_ble_sensors(DEVICE_ID, status, set(), coord)
+    binaries = _create_ble_binary_sensors(DEVICE_ID, status, set(), coord)
+    by_uid = {e.unique_id: e for e in [*sensors, *binaries]}
+    return sensors, binaries, by_uid
+
+
+def _full_blu_dw_status(open_state: Any = True, angle: Any = 37) -> dict[str, Any]:
+    return {
+        "window:0": {"open": open_state},
+        "tilt:0": {"angle": angle},
+        "illuminance:0": {"lux": 12},
+        "devicepower:0": {"battery": {"percent": 88, "V": 3.0}},
+        "_dev_info": {"gen": "GBLE"},
+    }
+
+
+# ── Part A: the two new entities appear, with correct metadata ──────────────
+
+
+def test_window_binary_sensor_created_with_opening_class():
+    _s, _b, by_uid = _build(_full_blu_dw_status())
+    win = by_uid[f"{DEVICE_ID}_ble_window_0"]
+    assert isinstance(win, BleBinarySensor)
+    assert win.device_class == BinarySensorDeviceClass.OPENING
+    assert win._attr_name == "Door/Window"
+    assert win.is_on is True
+
+
+def test_tilt_sensor_created_with_degrees_and_no_device_class():
+    _s, _b, by_uid = _build(_full_blu_dw_status(angle=37))
+    tilt = by_uid[f"{DEVICE_ID}_ble_tilt_0"]
+    assert isinstance(tilt, BleSensor)
+    assert tilt.native_value == 37
+    assert tilt.native_unit_of_measurement == "°"
+    assert tilt.state_class == SensorStateClass.MEASUREMENT
+    assert tilt.device_class is None  # HA has no device_class for a raw angle
+    assert tilt._attr_name == "Tilt"
+
+
+def test_no_regression_battery_and_illuminance_still_created():
+    _s, _b, by_uid = _build(_full_blu_dw_status())
+    assert f"{DEVICE_ID}_ble_illuminance_0" in by_uid
+    assert f"{DEVICE_ID}_ble_battery_percent" in by_uid
+    assert f"{DEVICE_ID}_ble_battery_voltage" in by_uid
+
+
+# ── open-state coercion (bool AND numeric 0/1) ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "open_state,expected",
+    [(True, True), (False, False), (1, True), (0, False)],
+)
+def test_window_open_coercion(open_state, expected):
+    _s, _b, by_uid = _build(_full_blu_dw_status(open_state=open_state))
+    assert by_uid[f"{DEVICE_ID}_ble_window_0"].is_on is expected
+
+
+# ── null / missing handling ─────────────────────────────────────────────────
+
+
+def test_tilt_null_angle_returns_none():
+    _s, _b, by_uid = _build(_full_blu_dw_status(angle=None))
+    assert by_uid[f"{DEVICE_ID}_ble_tilt_0"].native_value is None
+
+
+def test_absent_fields_create_no_entities():
+    """Presence-gated: empty component dicts must not spawn phantom entities."""
+    status = {"window:0": {}, "tilt:0": {}, "_dev_info": {"gen": "GBLE"}}
+    sensors, binaries, _ = _build(status)
+    assert not any(e.unique_id.endswith("_ble_tilt_0") for e in sensors)
+    assert not any(e.unique_id.endswith("_ble_window_0") for e in binaries)
+
+
+def test_unrelated_key_does_not_create_window_or_tilt():
+    status = {"illuminance:0": {"lux": 5}, "_dev_info": {"gen": "GBLE"}}
+    sensors, binaries, _ = _build(status)
+    assert not any("_ble_window_" in e.unique_id for e in binaries)
+    assert not any("_ble_tilt_" in e.unique_id for e in sensors)
+    # illuminance itself is unaffected
+    assert any(e.unique_id.endswith("_ble_illuminance_0") for e in sensors)
+
+
+# ── multi-channel naming / uniqueness ───────────────────────────────────────
+
+
+def test_multichannel_window_and_tilt():
+    status = {
+        "window:0": {"open": True},
+        "window:1": {"open": False},
+        "tilt:0": {"angle": 5},
+        "tilt:1": {"angle": 90},
+        "_dev_info": {"gen": "GBLE"},
+    }
+    _s, _b, by_uid = _build(status)
+    assert by_uid[f"{DEVICE_ID}_ble_window_1"]._attr_name == "Door/Window 2"
+    assert by_uid[f"{DEVICE_ID}_ble_tilt_1"]._attr_name == "Tilt 2"
+    assert by_uid[f"{DEVICE_ID}_ble_window_1"].is_on is False
+    assert by_uid[f"{DEVICE_ID}_ble_tilt_1"].native_value == 90
+    # all four unique_ids are distinct
+    assert len({
+        f"{DEVICE_ID}_ble_window_0",
+        f"{DEVICE_ID}_ble_window_1",
+        f"{DEVICE_ID}_ble_tilt_0",
+        f"{DEVICE_ID}_ble_tilt_1",
+    } & set(by_uid)) == 4


### PR DESCRIPTION
Closes part 1 of #9 (BLU Door/Window). Part 2 (Virtual Components) tracked separately in the issue.

## What
Shelly **BLU Door/Window** sensors (bridged via a BLU gateway, `_dev_info.gen == "GBLE"`) report `window:0 = {"open": bool}` and `tilt:0 = {"angle": deg}` in the cloud status snapshot, but the integration only created **Battery + Illuminance** entities. This adds:

- **Door/Window** binary sensor ← `window:0.open` (`BinarySensorDeviceClass.OPENING`)
- **Tilt** sensor ← `tilt:0.angle` (degrees, `MEASUREMENT`, no device_class — mirrors the native Shelly Gen1 tilt sensor)

## How
Two table-driven entries in `entities/descriptions.py` (`BLE_SENSORS["tilt"]`, `BLE_BINARY_SENSORS["window"]`), consumed by the existing generic `_create_ble_*` loops. No loop or entity-class changes.

## Safety
- **Presence-gated**: entities are created only when `open`/`angle` are present in the payload → no phantom entities for other BLU devices.
- `is_on` already coerces bool *and* numeric `0/1`; `native_value` is null-safe.
- BLU tables are consumed only on the mutually-exclusive `GBLE` dispatch branch, so Gen1/Gen2 devices are untouched (no regression).
- Adversarial-critic reviewed: **SHIP**, no confirmed bugs.

Shipping as prerelease **v0.6.8-beta1** for @LEDuser to confirm on real hardware before promotion to stable v0.6.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4dzfQjD5o7SyMex336GJE