### PR TITLE
feat: read-only Shelly virtual components (#9 part 2)

### DIFF
--- a/custom_components/shelly_cloud_diy/api/cloud_control.py
+++ b/custom_components/shelly_cloud_diy/api/cloud_control.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -58,6 +59,15 @@ _DEFAULT_TIMEOUT_S = 10
 # keeps the window open while rejected requests keep arriving; ~1.5 s reliably
 # clears a single trip in testing (1.2 s was borderline). (#6)
 _RATE_LIMIT_BACKOFF_S = 1.5
+
+# Virtual-component status/config keys look like ``number:200`` / ``boolean:201``.
+# Only these are kept from the v2 ``settings`` block; switch/script/sys/etc. are
+# dropped so the cached config stays small. (#9)
+_VIRTUAL_COMPONENT_KEY_RE = re.compile(r"^(number|enum|text|boolean):\d+$")
+
+# Max device ids per v2 ``/devices/api/get`` request. Shelly caps the batch;
+# 10 is conservative and keeps each request light. (#9)
+_V2_CONFIG_BATCH = 10
 
 
 class ShellyCloudError(Exception):
@@ -382,6 +392,79 @@ class ShellyCloudControl:
             isok=(body.get("isok") is not False),
             well_formed=well_formed,
         )
+
+    async def get_device_configs(
+        self, ids: list[str]
+    ) -> dict[str, dict[str, dict]]:
+        """Fetch per-virtual-component config for ``ids`` via the v2 API.
+
+        POSTs to ``/v2/devices/api/get`` with a JSON body of
+        ``{"auth_key": …, "ids": [...], "select": ["settings"]}`` — the
+        auth_key rides in the BODY for this v2 endpoint, not as a Bearer
+        header or query param. The response is a JSON ARRAY of
+        ``{"id": <device_id>, "settings": {<component_key>: <config>, …}}``.
+
+        For virtual components the ``settings`` entries are keyed exactly
+        like the status keys (``number:200``, ``boolean:201``, …) and carry
+        the config the cloud status omits: the user-set ``name``, the number
+        ``meta.ui.unit``, and the enum ``options`` / ``meta.ui.titles``.
+
+        Only virtual-component keys are kept; every other settings key
+        (``switch:0``, ``script:1``, ``sys``, …) is dropped to keep the
+        cached config small. ids are batched into chunks of
+        ``_V2_CONFIG_BATCH`` with a pause between chunks to respect the
+        shared 1 req/s budget.
+
+        Args:
+            ids: Device ids to fetch config for.
+
+        Returns:
+            ``{device_id: {component_key: config_dict}}`` for every device
+            that returned at least one virtual-component config. Devices
+            with no virtual-component settings are omitted.
+
+        Raises:
+            ShellyCloudAuthError: auth_key rejected.
+            ShellyCloudError: transport / rate-limit / protocol failure.
+        """
+        result: dict[str, dict[str, dict]] = {}
+        if not ids:
+            return result
+
+        for offset in range(0, len(ids), _V2_CONFIG_BATCH):
+            chunk = ids[offset:offset + _V2_CONFIG_BATCH]
+            if offset:
+                # Space successive requests out under the 1 req/s limit.
+                await asyncio.sleep(_RATE_LIMIT_BACKOFF_S)
+            payload = {
+                "auth_key": self._auth_key,
+                "ids": chunk,
+                "select": ["settings"],
+            }
+            data = await self._post_json("/v2/devices/api/get", payload)
+            if not isinstance(data, list):
+                continue
+            for record in data:
+                if not isinstance(record, dict):
+                    continue
+                did = record.get("id")
+                if not isinstance(did, str):
+                    continue
+                settings = record.get("settings")
+                if not isinstance(settings, dict):
+                    continue
+                comp_configs: dict[str, dict] = {}
+                for key, cfg in settings.items():
+                    if (
+                        isinstance(key, str)
+                        and _VIRTUAL_COMPONENT_KEY_RE.match(key)
+                        and isinstance(cfg, dict)
+                    ):
+                        comp_configs[key] = cfg
+                if comp_configs:
+                    result[did] = comp_configs
+
+        return result
 
     # ── Command endpoints ──────────────────────────────────────────────
 

--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -204,9 +204,11 @@ def _create_rpc_sensors(
 class RpcVirtualBinarySensor(ShellyBaseEntity, BinarySensorEntity):
     """Read-only Gen2/Gen3 virtual boolean component (``boolean:<id>``).
 
-    Mirrors the live ``value`` as a plain binary sensor with a generic name
-    (e.g. "Boolean 200"). Read-only: the cloud status has no writable-view flag
-    and the Cloud Control API exposes no ``Boolean.Set``. (#9)
+    Mirrors the live ``value`` as a plain binary sensor. The user-set name is
+    fetched lazily via the v2 settings endpoint and cached on the coordinator;
+    until it arrives (or if it is absent) the entity falls back to a generic
+    name (e.g. "Boolean 200"). Read-only: the cloud status has no writable-view
+    flag and the Cloud Control API exposes no ``Boolean.Set``. (#9)
     """
 
     def __init__(
@@ -220,7 +222,19 @@ class RpcVirtualBinarySensor(ShellyBaseEntity, BinarySensorEntity):
         super().__init__(coordinator, device_id, 0)
         self._component_key = component_key
         self._attr_unique_id = f"{device_id}_{component_key}_value"
-        self._attr_name = f"Boolean {comp_id}"
+        # Generic fallback; the real name is a PROPERTY because the v2 config
+        # arrives via a background task after the entity is created. (#9)
+        self._generic_name = f"Boolean {comp_id}"
+
+    @property
+    def name(self) -> str:
+        """Return the user-set component name, or the generic fallback."""
+        config = self.virtual_component_config(self._component_key)
+        if isinstance(config, dict):
+            name = config.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+        return self._generic_name
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -182,7 +182,56 @@ def _create_rpc_sensors(
                     coordinator, device_id, desc, 0, "cloud", "connected"
                 ))
 
+    # Virtual boolean components (READ-ONLY) — Gen2/Gen3 ``boolean:<id>.value``.
+    # Exposed read-only for the same reason as the virtual sensors in sensor.py:
+    # the cloud status carries no component config (writable-view / name) and the
+    # Cloud Control API has no virtual-component write method. (#9)
+    for key in status:
+        if match := re.match(r"boolean:(\d+)", key):
+            idx = int(match.group(1))
+            data = status[key]
+            if isinstance(data, dict) and "value" in data:
+                uid = f"{device_id}_{key}_value"
+                if uid not in created:
+                    created.add(uid)
+                    entities.append(RpcVirtualBinarySensor(
+                        coordinator, device_id, idx, key
+                    ))
+
     return entities
+
+
+class RpcVirtualBinarySensor(ShellyBaseEntity, BinarySensorEntity):
+    """Read-only Gen2/Gen3 virtual boolean component (``boolean:<id>``).
+
+    Mirrors the live ``value`` as a plain binary sensor with a generic name
+    (e.g. "Boolean 200"). Read-only: the cloud status has no writable-view flag
+    and the Cloud Control API exposes no ``Boolean.Set``. (#9)
+    """
+
+    def __init__(
+        self,
+        coordinator: ShellyCloudCoordinator,
+        device_id: str,
+        comp_id: int,
+        component_key: str,
+    ) -> None:
+        """Initialize the virtual boolean binary sensor."""
+        super().__init__(coordinator, device_id, 0)
+        self._component_key = component_key
+        self._attr_unique_id = f"{device_id}_{component_key}_value"
+        self._attr_name = f"Boolean {comp_id}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the virtual boolean's current value."""
+        component = self.device_status.get(self._component_key)
+        if not isinstance(component, dict):
+            return None
+        value = component.get("value")
+        if value is None:
+            return None
+        return bool(value)
 
 
 def _create_ble_binary_sensors(

--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -103,7 +103,7 @@ PLATFORMS: list[Platform] = [
 # (checked first in ``device_gen`` before this structural fallback).
 _GEN2_PATTERN = re.compile(
     r"(switch|light|cover|input|cloud|sys|temperature|humidity"
-    r"|devicepower|voltmeter):\d+"
+    r"|devicepower|voltmeter|boolean|number|enum|text|button):\d+"
 )
 
 

--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -43,6 +44,11 @@ from .const import (
 # Gap between the v1 poll completing and the v2 name lookup firing, so we
 # stay under the 1 req/s per-account rate limit that both endpoints share.
 _V2_NAME_LOOKUP_GAP_S = 1.2
+
+# Status/config keys of Gen2/Gen3 virtual components (``number:200``, …). Used
+# to decide which online devices need a one-time v2 config fetch so their
+# read-only virtual entities can render real names/units/options. (#9)
+_VIRTUAL_COMPONENT_KEY_RE = re.compile(r"^(number|enum|text|boolean):\d+$")
 
 # Delay before the post-command status refresh (seconds). Long enough for the
 # Shelly Cloud to propagate the new state (so the poll confirms rather than
@@ -105,6 +111,13 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self.device_names: dict[str, str] = {}
         # Populated by ``_refresh_device_names`` when it schedules itself.
         self._name_lookup_in_flight = False
+        # Cache of device_id → {component_key → v2 config dict} for Gen2/Gen3
+        # virtual components. Fetched lazily once per device (config changes
+        # rarely) so the read-only virtual entities can show real names,
+        # units and enum options instead of generic labels. (#9)
+        self.virtual_configs: dict[str, dict[str, dict]] = {}
+        # Populated by ``_refresh_virtual_configs`` when it schedules itself.
+        self._vcomp_config_in_flight = False
 
     # ── Properties platform code may inspect ──────────────────────────
 
@@ -209,6 +222,9 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 # Seed with whatever we already resolved via the v2 name
                 # lookup; stays None until that lookup succeeds.
                 "name": self.device_names.get(device_id),
+                # Seed cached virtual-component config (real names/units/
+                # options); stays None until the v2 config fetch succeeds. (#9)
+                "virtual_config": self.virtual_configs.get(device_id),
             }
 
         # Fire SIGNAL_NEW_DEVICE only for devices the user has actually
@@ -235,6 +251,24 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         if unresolved and not self._name_lookup_in_flight:
             self._name_lookup_in_flight = True
             self.hass.async_create_task(self._refresh_device_names(unresolved))
+
+        # Schedule a one-time v2 config fetch for any ONLINE device whose
+        # status carries at least one virtual component we haven't resolved
+        # yet, so the read-only virtual entities can render real names, units
+        # and enum options. Config changes rarely, so once a device is in
+        # ``virtual_configs`` it is never re-fetched. (#9)
+        needs_config = [
+            did for did, info in new_devices.items()
+            if did not in self.virtual_configs
+            and info.get("online")
+            and any(
+                isinstance(k, str) and _VIRTUAL_COMPONENT_KEY_RE.match(k)
+                for k in info.get("status", {})
+            )
+        ]
+        if needs_config and not self._vcomp_config_in_flight:
+            self._vcomp_config_in_flight = True
+            self.hass.async_create_task(self._refresh_virtual_configs(needs_config))
 
         return new_devices
 
@@ -303,6 +337,62 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             )
 
         # Push updated device_info to platforms without waiting for next poll.
+        self.async_update_listeners()
+
+    async def _refresh_virtual_configs(self, ids: list[str]) -> None:
+        """Fetch virtual-component config for ``ids`` via the v2 API and cache it.
+
+        Mirrors :meth:`_refresh_device_names`: runs as a background task after
+        ``_async_update_data`` completes, then batches every requested id into
+        the v2 settings endpoint. The config carries the user-set name, the
+        number unit and the enum options that the cloud status omits, so the
+        read-only virtual entities can render them.
+
+        Waits ``2 * _V2_NAME_LOOKUP_GAP_S`` before firing — double the
+        name-lookup gap — so that on the first poll (when both this task and
+        :meth:`_refresh_device_names` are scheduled together) the two v2/v1
+        requests do not fire back-to-back and trip the shared 1 req/s budget
+        (``401 max_req``). Staggering keeps both under the rate limit instead
+        of relying on the request-retry backoff to mask the collision.
+
+        Failures are logged at debug level — a missing config just means the
+        entities keep their generic names, not worth an ``UpdateFailed``. Every
+        requested id is recorded (with an empty map when it returned no
+        virtual-component config) so a device is never re-fetched, exactly like
+        cached names. (#9)
+        """
+        try:
+            # Double the gap so this v2 lookup lands after the name lookup
+            # rather than alongside it — see the rate-limit note above.
+            await asyncio.sleep(2 * _V2_NAME_LOOKUP_GAP_S)
+            configs = await self._api.get_device_configs(ids)
+        except ShellyCloudAuthError:
+            _LOGGER.debug("v2 virtual-component config lookup rejected auth_key — skipping")
+            return
+        except ShellyCloudError as err:
+            _LOGGER.debug("v2 virtual-component config lookup failed: %s", err)
+            return
+        finally:
+            self._vcomp_config_in_flight = False
+
+        # Mark every requested id resolved so it is never re-fetched, seeding
+        # an empty map for devices that returned no virtual-component config.
+        for did in ids:
+            self.virtual_configs.setdefault(did, {})
+        if configs:
+            self.virtual_configs.update(configs)
+        for did in ids:
+            entry = self.devices.get(did)
+            if entry is not None:
+                entry["virtual_config"] = self.virtual_configs.get(did)
+
+        if configs:
+            _LOGGER.info(
+                "Resolved virtual-component config for %d device(s) via v2 API",
+                len(configs),
+            )
+
+        # Re-render entities with the real names/units/options straight away.
         self.async_update_listeners()
 
     # ── Command dispatch (compat shim for platform files) ─────────────

--- a/custom_components/shelly_cloud_diy/entities/base.py
+++ b/custom_components/shelly_cloud_diy/entities/base.py
@@ -101,6 +101,26 @@ class ShellyBaseEntity(CoordinatorEntity["ShellyCloudCoordinator"]):
         """Get device status from coordinator."""
         return self.device_data.get("status", {})
 
+    def virtual_component_config(self, component_key: str) -> dict[str, Any] | None:
+        """Return the cached v2 config for a virtual component, or None.
+
+        The coordinator fetches per-component config (name / unit / enum
+        options) lazily in the background via the v2 settings endpoint and
+        caches it under ``coordinator.virtual_configs[device_id][key]``. This
+        helper reads that cache with full None-safety: a missing cache
+        (e.g. before the background fetch completes, or a coordinator without
+        the attribute at all) returns ``None`` so callers fall back to their
+        generic behaviour. (#9)
+        """
+        configs = getattr(self.coordinator, "virtual_configs", None)
+        if not isinstance(configs, dict):
+            return None
+        device_configs = configs.get(self._device_id)
+        if not isinstance(device_configs, dict):
+            return None
+        config = device_configs.get(component_key)
+        return config if isinstance(config, dict) else None
+
     @property
     def is_gen2(self) -> bool:
         """Check if device is Gen2/Gen3."""

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.8"
+  "version": "0.6.9-beta1"
 }

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.9-beta1"
+  "version": "0.6.9-beta2"
 }

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.9-beta2"
+  "version": "0.6.9"
 }

--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -381,7 +381,69 @@ def _create_rpc_sensors(
                             coordinator, device_id, desc, idx, key, attr
                         ))
 
+    # Virtual components (READ-ONLY) — Gen2/Gen3 "virtual" number/enum/text
+    # components (e.g. created by a script or a Wall Display) surface their
+    # current value under ``<type>:<id>.value`` in the cloud status. We expose
+    # them read-only because the cloud status carries no component *config*
+    # (name / min / max / options / writable-view) and the Cloud Control API
+    # has no documented virtual-component write method — a controllable version
+    # needs both. Boolean is handled in binary_sensor.py; button carries no
+    # value (it is an action) and is skipped. (#9)
+    for key in status:
+        if match := re.match(r"(number|enum|text):(\d+)", key):
+            comp_type = match.group(1)
+            idx = int(match.group(2))
+            data = status[key]
+            if isinstance(data, dict) and "value" in data:
+                uid = f"{device_id}_{key}_value"
+                if uid not in created:
+                    created.add(uid)
+                    entities.append(RpcVirtualSensor(
+                        coordinator, device_id, comp_type, idx, key
+                    ))
+
     return entities
+
+
+class RpcVirtualSensor(ShellyBaseEntity, SensorEntity):
+    """Read-only Gen2/Gen3 virtual component (number / enum / text).
+
+    The cloud status exposes only the live ``value``; without the component
+    config (name / min / max / options / writable-view) we cannot build a
+    controllable entity, so this mirrors the value as a plain read-only sensor
+    with a generic name (e.g. "Number 200"). (#9)
+    """
+
+    _VIRTUAL_ICONS = {
+        "number": "mdi:numeric",
+        "enum": "mdi:format-list-bulleted",
+        "text": "mdi:text-short",
+    }
+
+    def __init__(
+        self,
+        coordinator: ShellyCloudCoordinator,
+        device_id: str,
+        comp_type: str,
+        comp_id: int,
+        component_key: str,
+    ) -> None:
+        """Initialize the virtual-component sensor."""
+        super().__init__(coordinator, device_id, 0)
+        self._component_key = component_key
+        self._attr_unique_id = f"{device_id}_{component_key}_value"
+        self._attr_name = f"{comp_type.capitalize()} {comp_id}"
+        icon = self._VIRTUAL_ICONS.get(comp_type)
+        if icon:
+            self._attr_icon = icon
+
+    @property
+    def native_value(self) -> float | int | str | None:
+        """Return the virtual component's current value."""
+        component = self.device_status.get(self._component_key)
+        if not isinstance(component, dict):
+            return None
+        return component.get("value")
 
 
 class BlockSensor(ShellyBaseEntity, SensorEntity):

--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -408,10 +408,14 @@ def _create_rpc_sensors(
 class RpcVirtualSensor(ShellyBaseEntity, SensorEntity):
     """Read-only Gen2/Gen3 virtual component (number / enum / text).
 
-    The cloud status exposes only the live ``value``; without the component
-    config (name / min / max / options / writable-view) we cannot build a
-    controllable entity, so this mirrors the value as a plain read-only sensor
-    with a generic name (e.g. "Number 200"). (#9)
+    The cloud status exposes only the live ``value``. The component *config*
+    (real name, number unit, enum options) is fetched lazily in the background
+    via the v2 settings endpoint and cached on the coordinator; this entity
+    enriches itself from that cache when it arrives. Until then — or if the
+    config is missing entirely — it falls back to a generic name (e.g.
+    "Number 200") with no unit, i.e. the original read-only behaviour. The
+    live value is always mirrored read-only (no controllable write path in the
+    Cloud Control API). (#9)
     """
 
     _VIRTUAL_ICONS = {
@@ -430,12 +434,72 @@ class RpcVirtualSensor(ShellyBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the virtual-component sensor."""
         super().__init__(coordinator, device_id, 0)
+        self._comp_type = comp_type
         self._component_key = component_key
         self._attr_unique_id = f"{device_id}_{component_key}_value"
-        self._attr_name = f"{comp_type.capitalize()} {comp_id}"
+        # Generic fallback used until (or unless) the v2 config resolves. The
+        # name is a PROPERTY, not baked into ``_attr_name``, because the config
+        # arrives via a background task after the entity is created.
+        self._generic_name = f"{comp_type.capitalize()} {comp_id}"
         icon = self._VIRTUAL_ICONS.get(comp_type)
         if icon:
             self._attr_icon = icon
+
+    @property
+    def name(self) -> str:
+        """Return the user-set component name, or the generic fallback."""
+        config = self.virtual_component_config(self._component_key)
+        if isinstance(config, dict):
+            name = config.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+        return self._generic_name
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the number component's unit from ``meta.ui.unit`` if present."""
+        if self._comp_type != "number":
+            return None
+        config = self.virtual_component_config(self._component_key)
+        if not isinstance(config, dict):
+            return None
+        meta = config.get("meta")
+        if not isinstance(meta, dict):
+            return None
+        ui = meta.get("ui")
+        if not isinstance(ui, dict):
+            return None
+        unit = ui.get("unit")
+        if isinstance(unit, str) and unit:
+            return unit
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose enum options / titles as attributes (safe, non-device-class).
+
+        We deliberately keep the sensor a plain string sensor rather than a
+        ``SensorDeviceClass.ENUM``: the live value might not be one of the
+        configured options, which would spam HA with warnings. Surfacing the
+        options as attributes gives dashboards the metadata without that risk.
+        """
+        if self._comp_type != "enum":
+            return None
+        config = self.virtual_component_config(self._component_key)
+        if not isinstance(config, dict):
+            return None
+        attrs: dict[str, Any] = {}
+        options = config.get("options")
+        if isinstance(options, list):
+            attrs["options"] = options
+        meta = config.get("meta")
+        if isinstance(meta, dict):
+            ui = meta.get("ui")
+            if isinstance(ui, dict):
+                titles = ui.get("titles")
+                if isinstance(titles, dict):
+                    attrs["titles"] = titles
+        return attrs or None
 
     @property
     def native_value(self) -> float | int | str | None:

--- a/tests/test_virtual_components.py
+++ b/tests/test_virtual_components.py
@@ -1,0 +1,121 @@
+"""Unit tests for read-only virtual components (issue #9, part 2).
+
+Confirmed cloud-status shapes (from @LEDuser's diagnostics): virtual components
+surface their live value under ``<type>:<id>.value`` — ``boolean:200 {"value":
+false}``, ``number:200 {"value": 24}``, ``enum:200 {"value": "cool"}``,
+``text:200 {"value": "SCRIPT READY"}``. ``button:200 {}`` has no value (it is an
+action) and must NOT create an entity. These tests drive the real RPC creation
+loops with a fake coordinator — no running HA required.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.shelly_cloud_diy.binary_sensor import (
+    RpcVirtualBinarySensor,
+    _create_rpc_sensors as create_rpc_binary_sensors,
+)
+from custom_components.shelly_cloud_diy.const import is_gen2_status
+from custom_components.shelly_cloud_diy.sensor import (
+    RpcVirtualSensor,
+    _create_rpc_sensors as create_rpc_sensors,
+)
+
+DEVICE_ID = "wall01display"
+
+
+class _FakeCoordinator:
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {device_id: {"status": status, "device_code": "SAWD-0A1XX10EU1", "online": True}}
+        self.data = self.devices
+        self.last_update_success = True
+
+
+# The exact status LEDuser reported (device 1), plus sys so it reads as Gen2.
+_VCOMP_STATUS: dict[str, Any] = {
+    "sys": {"mac": "AABBCC"},
+    "boolean:200": {"value": False},
+    "boolean:201": {"value": True},
+    "number:200": {"value": 24},
+    "number:201": {"value": 26.1},
+    "number:202": {"value": 52},
+    "enum:200": {"value": "cool"},
+    "enum:201": {"value": "auto"},
+    "enum:202": {"value": "middle"},
+    "text:200": {"value": "SCRIPT READY"},
+    "vcomps": [
+        "boolean:200", "boolean:201", "enum:200", "enum:201", "enum:202",
+        "number:200", "number:201", "number:202", "text:200",
+    ],
+}
+
+
+def _build(status: dict[str, Any]):
+    coord = _FakeCoordinator(DEVICE_ID, status)
+    sensors = create_rpc_sensors(DEVICE_ID, status, set(), coord)
+    binaries = create_rpc_binary_sensors(DEVICE_ID, status, set(), coord)
+    by_uid = {e.unique_id: e for e in [*sensors, *binaries]}
+    return sensors, binaries, by_uid
+
+
+def test_gen2_detection_includes_virtual_types():
+    assert is_gen2_status({"number:200": {"value": 1}}) is True
+    assert is_gen2_status({"boolean:200": {"value": True}}) is True
+    assert is_gen2_status({"text:200": {"value": "x"}}) is True
+
+
+def test_number_enum_text_become_readonly_sensors():
+    sensors, _b, by_uid = _build(_VCOMP_STATUS)
+    virtual = [e for e in sensors if isinstance(e, RpcVirtualSensor)]
+    assert len(virtual) == 7  # number(3) + enum(3) + text(1)
+
+    n = by_uid[f"{DEVICE_ID}_number:201_value"]
+    assert n._attr_name == "Number 201"
+    assert n.native_value == 26.1
+
+    e = by_uid[f"{DEVICE_ID}_enum:200_value"]
+    assert e._attr_name == "Enum 200"
+    assert e.native_value == "cool"
+
+    t = by_uid[f"{DEVICE_ID}_text:200_value"]
+    assert t._attr_name == "Text 200"
+    assert t.native_value == "SCRIPT READY"
+    # Read-only virtual sensors carry no wrong statistics metadata.
+    assert n.state_class is None and n.device_class is None
+
+
+def test_boolean_becomes_readonly_binary_sensor():
+    _s, binaries, by_uid = _build(_VCOMP_STATUS)
+    virtual = [e for e in binaries if isinstance(e, RpcVirtualBinarySensor)]
+    assert len(virtual) == 2
+    assert by_uid[f"{DEVICE_ID}_boolean:200_value"]._attr_name == "Boolean 200"
+    assert by_uid[f"{DEVICE_ID}_boolean:200_value"].is_on is False
+    assert by_uid[f"{DEVICE_ID}_boolean:201_value"].is_on is True
+
+
+def test_button_creates_no_entity():
+    """A virtual Button has no value (it is an action) — nothing to expose."""
+    status = {"sys": {"mac": "x"}, "button:200": {}, "v_eve:200": {"ev": "", "ttl": -1}}
+    sensors, binaries, _ = _build(status)
+    assert not any(isinstance(e, RpcVirtualSensor) for e in sensors)
+    assert not any(isinstance(e, RpcVirtualBinarySensor) for e in binaries)
+
+
+def test_presence_gated_missing_value_creates_nothing():
+    status = {"sys": {"mac": "x"}, "number:200": {}, "boolean:200": {}}
+    sensors, binaries, _ = _build(status)
+    assert not any(isinstance(e, RpcVirtualSensor) for e in sensors)
+    assert not any(isinstance(e, RpcVirtualBinarySensor) for e in binaries)
+
+
+def test_unique_ids_are_distinct():
+    _s, _b, by_uid = _build(_VCOMP_STATUS)
+    vuids = [u for u in by_uid if u.endswith("_value")]
+    assert len(vuids) == len(set(vuids)) == 9  # 7 sensors + 2 booleans
+
+
+def test_boolean_numeric_coercion():
+    status = {"sys": {"mac": "x"}, "boolean:200": {"value": 1}, "boolean:201": {"value": 0}}
+    _s, _b, by_uid = _build(status)
+    assert by_uid[f"{DEVICE_ID}_boolean:200_value"].is_on is True
+    assert by_uid[f"{DEVICE_ID}_boolean:201_value"].is_on is False

--- a/tests/test_virtual_components.py
+++ b/tests/test_virtual_components.py
@@ -25,10 +25,19 @@ DEVICE_ID = "wall01display"
 
 
 class _FakeCoordinator:
-    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        device_id: str,
+        status: dict[str, Any],
+        virtual_configs: dict[str, dict[str, dict]] | None = None,
+    ) -> None:
         self.devices = {device_id: {"status": status, "device_code": "SAWD-0A1XX10EU1", "online": True}}
         self.data = self.devices
         self.last_update_success = True
+        # Only set when a test wants to exercise config enrichment; leaving it
+        # unset also exercises the ``getattr(..., None)`` None-safety path.
+        if virtual_configs is not None:
+            self.virtual_configs = virtual_configs
 
 
 # The exact status LEDuser reported (device 1), plus sys so it reads as Gen2.
@@ -50,8 +59,8 @@ _VCOMP_STATUS: dict[str, Any] = {
 }
 
 
-def _build(status: dict[str, Any]):
-    coord = _FakeCoordinator(DEVICE_ID, status)
+def _build(status: dict[str, Any], virtual_configs=None):
+    coord = _FakeCoordinator(DEVICE_ID, status, virtual_configs)
     sensors = create_rpc_sensors(DEVICE_ID, status, set(), coord)
     binaries = create_rpc_binary_sensors(DEVICE_ID, status, set(), coord)
     by_uid = {e.unique_id: e for e in [*sensors, *binaries]}
@@ -70,15 +79,15 @@ def test_number_enum_text_become_readonly_sensors():
     assert len(virtual) == 7  # number(3) + enum(3) + text(1)
 
     n = by_uid[f"{DEVICE_ID}_number:201_value"]
-    assert n._attr_name == "Number 201"
+    assert n.name == "Number 201"
     assert n.native_value == 26.1
 
     e = by_uid[f"{DEVICE_ID}_enum:200_value"]
-    assert e._attr_name == "Enum 200"
+    assert e.name == "Enum 200"
     assert e.native_value == "cool"
 
     t = by_uid[f"{DEVICE_ID}_text:200_value"]
-    assert t._attr_name == "Text 200"
+    assert t.name == "Text 200"
     assert t.native_value == "SCRIPT READY"
     # Read-only virtual sensors carry no wrong statistics metadata.
     assert n.state_class is None and n.device_class is None
@@ -88,7 +97,7 @@ def test_boolean_becomes_readonly_binary_sensor():
     _s, binaries, by_uid = _build(_VCOMP_STATUS)
     virtual = [e for e in binaries if isinstance(e, RpcVirtualBinarySensor)]
     assert len(virtual) == 2
-    assert by_uid[f"{DEVICE_ID}_boolean:200_value"]._attr_name == "Boolean 200"
+    assert by_uid[f"{DEVICE_ID}_boolean:200_value"].name == "Boolean 200"
     assert by_uid[f"{DEVICE_ID}_boolean:200_value"].is_on is False
     assert by_uid[f"{DEVICE_ID}_boolean:201_value"].is_on is True
 
@@ -119,3 +128,80 @@ def test_boolean_numeric_coercion():
     _s, _b, by_uid = _build(status)
     assert by_uid[f"{DEVICE_ID}_boolean:200_value"].is_on is True
     assert by_uid[f"{DEVICE_ID}_boolean:201_value"].is_on is False
+
+
+# ── v2-config enrichment (issue #9, part 3) ─────────────────────────────────
+# The v2 settings endpoint returns per-virtual-component config keyed exactly
+# like the status keys. Config shape derived from the native HA Shelly
+# integration (utils.get_virtual_component_unit / get_rpc_custom_name,
+# entity.py enum options+titles), not live-confirmed on an account with
+# virtual comps.
+_VCOMP_CONFIG: dict[str, dict[str, dict]] = {
+    DEVICE_ID: {
+        "number:200": {"name": "Target Temp", "meta": {"ui": {"unit": "°C"}}},
+        "number:201": {"name": None, "meta": {"ui": {}}},  # null name → generic
+        "number:202": {"meta": {"ui": {"unit": ""}}},       # empty unit → None
+        "enum:200": {
+            "name": "HVAC Mode",
+            "options": ["cool", "heat", "auto"],
+            "meta": {"ui": {"titles": {"cool": "Cooling", "heat": "Heating"}}},
+        },
+        "text:200": {"name": "Script Status"},
+        "boolean:200": {"name": "Away Flag"},
+    }
+}
+
+
+def test_enriched_name_when_config_present():
+    _s, binaries, by_uid = _build(_VCOMP_STATUS, _VCOMP_CONFIG)
+    assert by_uid[f"{DEVICE_ID}_number:200_value"].name == "Target Temp"
+    assert by_uid[f"{DEVICE_ID}_enum:200_value"].name == "HVAC Mode"
+    assert by_uid[f"{DEVICE_ID}_text:200_value"].name == "Script Status"
+    assert by_uid[f"{DEVICE_ID}_boolean:200_value"].name == "Away Flag"
+
+
+def test_fallback_generic_name_when_config_absent():
+    # No virtual_configs on the coordinator at all → generic names, no crash.
+    _s, _b, by_uid = _build(_VCOMP_STATUS)
+    assert by_uid[f"{DEVICE_ID}_number:200_value"].name == "Number 200"
+    assert by_uid[f"{DEVICE_ID}_boolean:200_value"].name == "Boolean 200"
+    # Null / missing name in config also falls back to generic.
+    _s2, _b2, by_uid2 = _build(_VCOMP_STATUS, _VCOMP_CONFIG)
+    assert by_uid2[f"{DEVICE_ID}_number:201_value"].name == "Number 201"
+
+
+def test_number_unit_from_meta_ui_unit():
+    _s, _b, by_uid = _build(_VCOMP_STATUS, _VCOMP_CONFIG)
+    assert by_uid[f"{DEVICE_ID}_number:200_value"].native_unit_of_measurement == "°C"
+    # Empty-string unit → None (no bogus unit).
+    assert by_uid[f"{DEVICE_ID}_number:202_value"].native_unit_of_measurement is None
+    # Enum/text carry no unit even with config present.
+    assert by_uid[f"{DEVICE_ID}_enum:200_value"].native_unit_of_measurement is None
+
+
+def test_enum_options_attribute():
+    _s, _b, by_uid = _build(_VCOMP_STATUS, _VCOMP_CONFIG)
+    attrs = by_uid[f"{DEVICE_ID}_enum:200_value"].extra_state_attributes
+    assert attrs["options"] == ["cool", "heat", "auto"]
+    assert attrs["titles"] == {"cool": "Cooling", "heat": "Heating"}
+    # Enum with no config entry → no attributes, no crash.
+    assert by_uid[f"{DEVICE_ID}_enum:201_value"].extra_state_attributes is None
+    # A number is not an enum → never emits options attributes.
+    assert by_uid[f"{DEVICE_ID}_number:200_value"].extra_state_attributes is None
+
+
+def test_none_safety_partial_and_missing_config():
+    # Coordinator has virtual_configs but not for this device / component.
+    _s, _b, by_uid = _build(_VCOMP_STATUS, {"other-device": {"number:200": {"name": "X"}}})
+    n = by_uid[f"{DEVICE_ID}_number:200_value"]
+    assert n.name == "Number 200"
+    assert n.native_unit_of_measurement is None
+    # Malformed config sub-trees must not raise.
+    broken = {DEVICE_ID: {
+        "number:200": {"meta": "not-a-dict"},
+        "enum:200": {"options": "not-a-list", "meta": {"ui": "nope"}},
+    }}
+    _s2, _b2, by_uid2 = _build(_VCOMP_STATUS, broken)
+    assert by_uid2[f"{DEVICE_ID}_number:200_value"].native_unit_of_measurement is None
+    assert by_uid2[f"{DEVICE_ID}_number:200_value"].name == "Number 200"
+    assert by_uid2[f"{DEVICE_ID}_enum:200_value"].extra_state_attributes is None


### PR DESCRIPTION
Part 2 of #9 — **read-only** Virtual Components, built against @LEDuser's confirmed diagnostics.

## What
Gen2/Gen3 virtual components surface their live value under `<type>:<id>.value` in the cloud status. This maps them to read-only entities:
- `number`/`enum`/`text` → **RpcVirtualSensor** (plain read-only sensor, generic name e.g. "Number 200")
- `boolean` → **RpcVirtualBinarySensor** (read-only, "Boolean 200")
- `button` skipped (an action, no value; needs a write path we don't have)

## Why read-only (honest scope)
The cloud status carries the **value** but **not** the component config (name / min·max·step / unit / enum options / writable-view), and the Cloud Control API exposes **no** virtual-component write method. So controllable Switch/Number/Select/Text/Button + friendly names remain blocked on a Cloud-API config+write path — tracked in #9.

## Safety
- Presence-gated on `"value"` → empty `button:{}` / config-less device creates nothing.
- `_GEN2_PATTERN` gains the virtual prefixes; Gen1 Block devices never emit `<type>:<id>` keys → no misrouting (critic-verified).
- No `state_class`/`device_class` on the generic sensors (avoids wrong statistics on unknown-semantics values).
- Adversarial-critic: **SHIP**, no confirmed bugs. 7 new unit tests (18 total) pass against HA 2025.1.4 + latest.

Ships as prerelease **v0.6.9-beta1** for @LEDuser to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4dzfQjD5o7SyMex336GJE