### PR TITLE
feat(repairs): surface persistent polling-path problems as HA repair issues

### DIFF
--- a/custom_components/shelly_cloud_diy/__init__.py
+++ b/custom_components/shelly_cloud_diy/__init__.py
@@ -36,6 +36,7 @@ from .const import (
     PLATFORMS,
 )
 from .coordinator import ShellyCloudCoordinator
+from .repair_issues import async_clear_entry_issues
 from .services.fleet_map import async_handle_fleet_map
 from .services.historical import HistoricalDataService
 from .services.orphans import async_handle_detect_orphans
@@ -105,6 +106,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Drop repair issues belonging to a removed config entry.
+
+    Reload and restart are deliberately NOT handled here. Every issue is
+    ``is_persistent=False``, so it is gone after a restart and is re-derived
+    within one poll (or one sync cycle) if it still holds. Clearing on unload
+    would run on every options save — ``_async_options_updated`` reloads the
+    entry — and deleting an issue discards the user's "Ignore", which the
+    issue registry stores on the entry itself. That would produce exactly the
+    loop the rate-limit card instructs: ignore it, raise the poll interval,
+    save, reload, card returns un-ignored.
+    """
+    async_clear_entry_issues(hass, entry)
 
 
 async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -31,6 +32,7 @@ from .api.cloud_control import (
     ShellyCloudAuthError,
     ShellyCloudControl,
     ShellyCloudError,
+    ShellyCloudRateLimitError,
 )
 from .const import (
     CONF_CREATE_ALL_INITIALLY,
@@ -39,6 +41,14 @@ from .const import (
     DOMAIN,
     POLL_INTERVAL_DEFAULT,
     SIGNAL_NEW_DEVICE,
+)
+from .repair_issues import (
+    async_manage_missing_devices_issue,
+    async_manage_rate_limit_issue,
+    compute_missing_devices,
+    is_mass_absence,
+    missing_devices_verdict,
+    rate_limit_verdict,
 )
 
 # Gap between the v1 poll completing and the v2 name lookup firing, so we
@@ -56,10 +66,49 @@ _VIRTUAL_COMPONENT_KEY_RE = re.compile(r"^(number|enum|text|boolean):\d+$")
 # from bursting past the 1 req/s budget. (#6)
 POST_COMMAND_REFRESH_DELAY = 2.0
 
+# Backoff schedule for the lazy v2 metadata lookups: 60 s, 120 s, 240 s …
+# capped at one hour. Never a permanent give-up — an id whose lookup starts
+# working again is picked up within an hour at the worst — but bounded, so a
+# lookup that keeps failing stops costing one request per poll forever.
+_METADATA_BACKOFF_BASE_S = 60.0
+_METADATA_BACKOFF_MAX_S = 3600.0
+
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def metadata_backoff_delay(failures: int) -> float:
+    """Return the retry delay after ``failures`` consecutive lookup failures.
+
+    Doubles from :data:`_METADATA_BACKOFF_BASE_S`, capped at
+    :data:`_METADATA_BACKOFF_MAX_S`.
+    """
+    if failures < 1:
+        return 0.0
+    return min(
+        _METADATA_BACKOFF_BASE_S * 2 ** (failures - 1),
+        _METADATA_BACKOFF_MAX_S,
+    )
+
+
+def _backoff_elapsed(
+    backoff: dict[str, tuple[int, float]], device_id: str, now: float
+) -> bool:
+    """True if ``device_id`` may be retried now (no entry, or it expired)."""
+    entry = backoff.get(device_id)
+    return entry is None or now >= entry[1]
+
+
+def _backoff_record_failure(
+    backoff: dict[str, tuple[int, float]], device_id: str, now: float
+) -> float:
+    """Extend ``device_id``'s backoff by one failure; return the new delay."""
+    failures = backoff.get(device_id, (0, 0.0))[0] + 1
+    delay = metadata_backoff_delay(failures)
+    backoff[device_id] = (failures, now + delay)
+    return delay
 
 
 class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
@@ -118,6 +167,37 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self.virtual_configs: dict[str, dict[str, dict]] = {}
         # Populated by ``_refresh_virtual_configs`` when it schedules itself.
         self._vcomp_config_in_flight = False
+
+        # Repair bookkeeping. Streaks are counted here, never in the issue
+        # registry, so a self-healing rate limit cannot flap an issue card.
+        self._rate_limit_streak = 0
+        self._rate_limit_since: float | None = None
+        # Whether the WARNING has already been logged for the current
+        # episode, so the log fires on the transition rather than on a
+        # streak count the UI does not yet agree with.
+        self._rate_limit_reported = False
+        # Absence is tracked PER DEVICE, not per set: id -> consecutive
+        # successful polls absent, and id -> monotonic first-absent time.
+        # Set-level bookkeeping would restart every device's 24 h clock
+        # whenever any one device joined or left the missing set, so a
+        # WORSENING condition (a second device vanishing) would hide the
+        # existing card for a full day and destroy the user's "Ignore".
+        self._missing_streak: dict[str, int] = {}
+        self._missing_since: dict[str, float] = {}
+        # Per-id exponential backoff for the lazy v2 metadata lookups.
+        # id -> (consecutive_failures, monotonic "do not retry before").
+        #
+        # LIFETIME RULE: these dicts are plain instance state on the
+        # coordinator, discarded when the config entry reloads, and an entry
+        # is otherwise removed ONLY by a successful lookup for that specific
+        # id. A successful *main poll* must NEVER clear them — the main
+        # poll's success says nothing about the v2 endpoint, and clearing on
+        # it produces a bistable oscillator (rate limit → lookups fail →
+        # back off → limit clears → poll succeeds → backoff wiped → lookups
+        # resume every poll → limit returns) that would make the rate-limit
+        # repair fire on a cycle and blame the user.
+        self._name_lookup_backoff: dict[str, tuple[int, float]] = {}
+        self._vcomp_config_backoff: dict[str, tuple[int, float]] = {}
 
     # ── Properties platform code may inspect ──────────────────────────
 
@@ -181,16 +261,28 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         Runs every ``update_interval`` seconds. A single HTTP request
         retrieves the state of every device the account can see.
         """
+        # Order matters: ShellyCloudRateLimitError and ShellyCloudAuthError
+        # are siblings under ShellyCloudError, so both specific branches must
+        # precede the generic one.
         try:
             data = await self._api.get_all_status()
         except ShellyCloudAuthError as err:
             # Surfaces as "repair me" in HA → user must re-enter auth_key
+            self._note_poll_not_rate_limited()
             raise ConfigEntryAuthFailed(str(err)) from err
+        except ShellyCloudRateLimitError as err:
+            # Shelly signals its 1 req/s limit as HTTP 401 with ``max_req``
+            # in the body — indistinguishable from a rejected key by status
+            # code alone. Surface it as its own repair once sustained. (#6)
+            self._note_rate_limited()
+            raise UpdateFailed(f"Shelly Cloud poll failed: {err}") from err
         except ShellyCloudError as err:
+            self._note_poll_not_rate_limited()
             raise UpdateFailed(f"Shelly Cloud poll failed: {err}") from err
 
         devices_status = data.get("devices_status") or {}
         if not isinstance(devices_status, dict):
+            self._note_poll_not_rate_limited()
             raise UpdateFailed(
                 f"Unexpected devices_status shape: {type(devices_status)}"
             )
@@ -244,9 +336,15 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         # Schedule a v2 name lookup for any device we haven't resolved yet,
         # but only for devices currently online (v2 returns no settings
         # for offline devices so the call is wasted on them).
+        # Ids whose last lookup failed are skipped until their backoff
+        # expires, so a permanently-failing lookup cannot burn one request
+        # per poll forever against the 1 req/s budget.
+        now_mono = time.monotonic()
         unresolved = [
             did for did, info in new_devices.items()
-            if did not in self.device_names and info.get("online")
+            if did not in self.device_names
+            and info.get("online")
+            and _backoff_elapsed(self._name_lookup_backoff, did, now_mono)
         ]
         if unresolved and not self._name_lookup_in_flight:
             self._name_lookup_in_flight = True
@@ -261,6 +359,7 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             did for did, info in new_devices.items()
             if did not in self.virtual_configs
             and info.get("online")
+            and _backoff_elapsed(self._vcomp_config_backoff, did, now_mono)
             and any(
                 isinstance(k, str) and _VIRTUAL_COMPONENT_KEY_RE.match(k)
                 for k in info.get("status", {})
@@ -270,7 +369,174 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             self._vcomp_config_in_flight = True
             self.hass.async_create_task(self._refresh_virtual_configs(needs_config))
 
+        # The poll succeeded, so whatever the previous outcome was, it was
+        # not a sustained rate limit.
+        self._note_poll_not_rate_limited()
+        self._evaluate_missing_devices(set(new_devices))
+
         return new_devices
+
+    # ── Repair-issue evaluation ───────────────────────────────────────
+
+    def _note_rate_limited(self) -> None:
+        """Extend the consecutive rate-limit streak and re-evaluate."""
+        now = time.monotonic()
+        if self._rate_limit_since is None:
+            self._rate_limit_since = now
+        self._rate_limit_streak += 1
+        active = rate_limit_verdict(
+            self._rate_limit_streak, self._rate_limit_since, now
+        )
+        # Log on the transition into "reportable", never on the streak count
+        # alone: at the 5 s default interval a streak of 5 is only ~30 s, so
+        # logging there would warn that the limit "has persisted" a full 90 s
+        # before the integration is willing to say so in the UI, and would
+        # re-warn every time a flapping limit re-crossed the count.
+        if active and not self._rate_limit_reported:
+            _LOGGER.warning(
+                "Shelly Cloud rate limit (HTTP 401 max_req) has persisted "
+                "for %d consecutive polls over %.0f s; the credentials are "
+                "still valid",
+                self._rate_limit_streak,
+                now - self._rate_limit_since,
+            )
+        self._rate_limit_reported = active
+        async_manage_rate_limit_issue(self.hass, self._entry, active=active)
+
+    def _note_poll_not_rate_limited(self) -> None:
+        """Reset the rate-limit streak and clear the issue if raised.
+
+        Clearing on ANY non-rate-limit outcome (success, auth failure,
+        transport failure) is deliberate: the issue asserts a *pure
+        sustained rate limit*, and a different failure type falsifies that
+        claim.
+        """
+        self._rate_limit_streak = 0
+        self._rate_limit_since = None
+        if self._rate_limit_reported:
+            _LOGGER.info("Shelly Cloud rate limit has cleared")
+            self._rate_limit_reported = False
+        async_manage_rate_limit_issue(self.hass, self._entry, active=False)
+
+    def _explicit_enabled_ids(self) -> set[str]:
+        """Return only the ids the user EXPLICITLY selected in options.
+
+        Deliberately not ``enabled_ids``: that property falls back to
+        ``set(self.devices.keys())`` in two branches (create_all_initially,
+        and the greenfield no-selection path), which would make the
+        difference against the seen set vacuous and silently disable this
+        check.
+        """
+        raw = self._options.get(CONF_ENABLED_DEVICES)
+        if isinstance(raw, list):
+            return {d for d in raw if isinstance(d, str)}
+        return set()
+
+    def _evaluate_missing_devices(self, seen: set[str]) -> None:
+        """Track enabled device ids the cloud never reports back.
+
+        Only reachable on a successful poll — the failure branches raise
+        before this runs — so the streak counts successful polls.
+        """
+        enabled = self._explicit_enabled_ids()
+        missing = compute_missing_devices(
+            enabled, seen, self.create_all_initially
+        )
+        now = time.monotonic()
+
+        # A device that reported again drops its history entirely, so a
+        # device that vanishes later serves a fresh 24 h.
+        for did in list(self._missing_since):
+            if did not in missing:
+                self._missing_since.pop(did, None)
+                self._missing_streak.pop(did, None)
+        for did in missing:
+            self._missing_streak[did] = self._missing_streak.get(did, 0) + 1
+            self._missing_since.setdefault(did, now)
+
+        # Only devices that have individually served both gates are named on
+        # the card. A newly-vanished device therefore joins an existing card
+        # 24 h later without disturbing the ids already on it.
+        reportable = {
+            did
+            for did in missing
+            if missing_devices_verdict(
+                self._missing_streak.get(did, 0),
+                self._missing_since.get(did),
+                now,
+                {did},
+                enabled,
+            )
+        }
+        # The mass-absence guard is judged on the REPORTABLE set, not on the
+        # whole missing set. Judging it on ``missing`` would let a transient
+        # fleet-wide outage RETRACT a card that individual ids had already
+        # earned over 24 h — deleting the issue, which discards the user's
+        # "Ignore", and re-creating it un-ignored once the outage passes.
+        # That is precisely the delete-then-create loop this design exists to
+        # avoid, arriving through a side door.
+        #
+        # Judging it on ``reportable`` loses nothing: a genuine account-side
+        # wipe-out makes every id vanish at the same moment, so they all
+        # clear their individual 24 h gates together and land in
+        # ``reportable`` together, where the guard still catches them.
+        active = bool(reportable) and not is_mass_absence(reportable, enabled)
+
+        # Replacing an already-raised issue with new placeholders is an
+        # in-place upsert; it preserves the user's "Ignore". Never delete
+        # and re-create here.
+        async_manage_missing_devices_issue(
+            self.hass,
+            self._entry,
+            active=active,
+            missing=reportable,
+            names=self._display_names(reportable),
+        )
+
+    def _display_names(self, ids: set[str]) -> dict[str, str]:
+        """Best-effort human labels for ``ids``, for the repair card.
+
+        ``device_names`` only ever holds CLOUD ALIASES, and the cloud omits
+        an alias for any device the user never renamed in the Shelly app —
+        exactly the device most likely to be unrecognisable as a bare hex
+        id. Fall back to whatever the HA device registry still knows, since
+        the DeviceEntry outlives the device's disappearance from the poll.
+        """
+        labels: dict[str, str] = {}
+        dev_reg = dr.async_get(self.hass)
+        for did in ids:
+            if name := self.device_names.get(did):
+                labels[did] = name
+                continue
+            device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, did)})
+            if device_entry is None:
+                continue
+            raw = device_entry.name_by_user or device_entry.name or ""
+            # Registry rows are stored as "<label> (<device_id>)"; strip the
+            # id so format_device_list does not print it twice.
+            suffix = f" ({did})"
+            if raw.endswith(suffix):
+                raw = raw[: -len(suffix)]
+            if raw:
+                labels[did] = raw
+        return labels
+
+    def _extend_backoff(
+        self,
+        backoff: dict[str, tuple[int, float]],
+        ids: list[str],
+        kind: str,
+    ) -> None:
+        """Record a failed metadata batch against every id it covered."""
+        now = time.monotonic()
+        for did in ids:
+            delay = _backoff_record_failure(backoff, did, now)
+            _LOGGER.debug(
+                "v2 %s lookup for %s backing off for %.0f s",
+                kind,
+                did,
+                delay,
+            )
 
     async def _refresh_device_names(self, ids: list[str]) -> None:
         """Fetch user-set names for ``ids`` via the v2 API and cache them.
@@ -287,12 +553,36 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             names = await self._api.get_device_names(ids)
         except ShellyCloudAuthError:
             _LOGGER.debug("v2 name lookup rejected auth_key — skipping")
+            self._extend_backoff(self._name_lookup_backoff, ids, "name")
             return
         except ShellyCloudError as err:
             _LOGGER.debug("v2 name lookup failed: %s", err)
+            self._extend_backoff(self._name_lookup_backoff, ids, "name")
             return
         finally:
             self._name_lookup_in_flight = False
+
+        # A resolved id is never retried, so drop any backoff it carried.
+        for did in names:
+            self._name_lookup_backoff.pop(did, None)
+
+        # ``get_device_names`` omits devices that carry no cloud alias — a
+        # device the user never renamed in the Shelly app therefore returns
+        # NORMALLY without ever entering ``device_names``. Without this the
+        # id stays in the ``unresolved`` comprehension on every single poll,
+        # forever, costing one extra v1 request per poll against the shared
+        # 1 req/s budget — the exact self-inflicted traffic that would make
+        # the rate-limit repair blame the user for our own requests.
+        #
+        # Put those ids on the SAME escalating ladder as a hard failure
+        # (60 s, 120 s … capped at 1 h) rather than marking them permanently
+        # resolved: a device renamed in the app later is then still picked up
+        # within an hour. Their counter is deliberately NOT reset here — only
+        # an actually-resolved name pops the entry above.
+        if unanswered := [did for did in ids if did not in names]:
+            self._extend_backoff(
+                self._name_lookup_backoff, unanswered, "name (no alias)"
+            )
 
         if not names:
             return
@@ -368,17 +658,21 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             configs = await self._api.get_device_configs(ids)
         except ShellyCloudAuthError:
             _LOGGER.debug("v2 virtual-component config lookup rejected auth_key — skipping")
+            self._extend_backoff(self._vcomp_config_backoff, ids, "config")
             return
         except ShellyCloudError as err:
             _LOGGER.debug("v2 virtual-component config lookup failed: %s", err)
+            self._extend_backoff(self._vcomp_config_backoff, ids, "config")
             return
         finally:
             self._vcomp_config_in_flight = False
 
         # Mark every requested id resolved so it is never re-fetched, seeding
         # an empty map for devices that returned no virtual-component config.
+        # Resolved ids are never retried, so drop any backoff they carried.
         for did in ids:
             self.virtual_configs.setdefault(did, {})
+            self._vcomp_config_backoff.pop(did, None)
         if configs:
             self.virtual_configs.update(configs)
         for did in ids:

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.9"
+  "version": "0.7.0-beta1"
 }

--- a/custom_components/shelly_cloud_diy/repair_issues.py
+++ b/custom_components/shelly_cloud_diy/repair_issues.py
@@ -1,0 +1,303 @@
+"""Repair issues raised by the Shelly Cloud DIY polling path.
+
+**Why this module is not called ``repairs.py``:** ``repairs.py`` is a
+reserved Home Assistant platform filename. On HA 2025.1.4 — this repo's
+stated minimum — ``components/repairs/issue_handler.py`` calls
+``async_process_repairs_platforms(hass)``, which eagerly scans *every*
+loaded integration that ships a ``repairs.py`` as soon as a user clicks
+"Fix" on any integration's repair, and raises
+``HomeAssistantError("Invalid repairs platform …")`` for any module that
+does not expose ``async_create_fix_flow``. Every issue here is
+informational (``is_fixable=False``) and therefore has no fix flow, so a
+module named ``repairs.py`` would be a landmine for unrelated
+integrations on that version. Newer HA uses lazy platform loading and
+would be safe, but the two-venv test runner must pass on both. Using a
+non-reserved filename sidesteps the platform contract entirely at zero
+cost; if a real fix flow is ever wanted, add a proper ``repairs.py``
+exposing ``async_create_fix_flow`` at that point.
+
+All three issues are informational and non-persistent. None of them can
+be resolved by an in-process button press — a sustained rate limit, a
+device that vanished from the Shelly account, and an unreachable local
+gateway are all resolved outside Home Assistant — so a confirm-only Fix
+button would lie to the user and the card would simply reappear on the
+next poll. Every condition is re-derived from live polling (or the next
+sync cycle) after a restart, so nothing needs to be persisted.
+
+Issue ids are suffixed with the config entry id: the issue registry keys
+on ``(domain, issue_id)`` alone, so a second Shelly account would
+otherwise clobber the first account's card.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.core import callback
+from homeassistant.helpers import issue_registry as ir
+
+from .const import DOMAIN, ORPHAN_FLOOR_ABS, ORPHAN_FLOOR_FRAC
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+
+# Both gates must hold. At the 5 s default poll interval the TIME gate is the
+# binding one: 120 s is ~19 consecutive failed polls, since each failed poll
+# also burns the 1.5 s in-call retry (_RATE_LIMIT_BACKOFF_S). At the 60 s
+# maximum the COUNT gate binds: 5 polls is ~5 minutes. Either way the user
+# must be losing every poll for at least two minutes before we say anything —
+# long enough to outlast someone browsing the Shelly mobile app.
+RATE_LIMIT_MIN_STREAK = 5
+RATE_LIMIT_MIN_SECONDS = 120.0
+
+# 24 hours, not minutes. A device that was genuinely sold or factory-reset is
+# still gone tomorrow, so nothing here is urgent — and the entire value of this
+# repair is that it is RIGHT. Ten minutes would have accused every Shelly BLU
+# owner of selling hardware whenever the mains Shelly bridging it went down for
+# a firmware update or a router reboot: BLU children appear in the cloud
+# snapshot only while their gateway is bridging them. In practice the time gate
+# always binds (24 h is >= 1440 polls even at the 60 s maximum interval); the
+# streak gate is a cheap floor that keeps the verdict honest if the poll
+# interval ever grows.
+MISSING_DEVICE_MIN_STREAK = 10
+MISSING_DEVICE_MIN_SECONDS = 86400.0
+
+# At most this many device ids are listed in the repair card; the rest are
+# summarised as a count so the card cannot render a 130-character id blob.
+MISSING_DEVICE_MAX_LISTED = 5
+
+# A resolved device name is user-supplied and can be arbitrarily long, so it
+# is clamped before rendering: five entries of "Wohnzimmer Deckenlampe hinten
+# (3494546e1f2a)" would otherwise blow past the bound MISSING_DEVICE_MAX_LISTED
+# exists to enforce.
+MISSING_DEVICE_MAX_NAME_LEN = 24
+
+# Two unproductive syncs. Because the daily interval is 24 h and this counter
+# is instance state on a service that async_setup_entry rebuilds on every
+# reload, a naive "wait for the next daily run" would mean the repair never
+# fires for exactly the population that needs it — someone actively editing
+# their gateway URL, which reloads the entry each time. historical.py therefore
+# schedules ONE 15-minute retry after the first unproductive run, so the second
+# data point arrives inside the same session.
+HISTORY_IMPORT_MIN_FAILURES = 2
+
+# Delay of that one-shot retry. Exists purely so the second data point lands
+# inside the same Home Assistant session rather than a day later.
+HISTORY_IMPORT_RETRY_S = 900.0
+
+ISSUE_RATE_LIMITED = "rate_limited"
+ISSUE_MISSING_DEVICES = "missing_devices"
+ISSUE_HISTORY_IMPORT_FAILED = "history_import_failed"
+
+
+# ── Pure verdict helpers (no hass — unit-testable) ────────────────────
+
+
+def issue_id(kind: str, entry_id: str) -> str:
+    """Return the registry-unique id for ``kind`` on one config entry."""
+    return f"{kind}_{entry_id}"
+
+
+def rate_limit_verdict(
+    streak: int, streak_started: float | None, now: float
+) -> bool:
+    """True when the rate limit has been sustained long enough to report."""
+    return (
+        streak >= RATE_LIMIT_MIN_STREAK
+        and streak_started is not None
+        and (now - streak_started) >= RATE_LIMIT_MIN_SECONDS
+    )
+
+
+def compute_missing_devices(
+    enabled: set[str], seen: set[str], create_all: bool
+) -> set[str]:
+    """Return explicitly-enabled ids the cloud did not report.
+
+    Returns an empty set when ``create_all`` is on: the enabled set is then
+    DEFINED as the seen set, so the difference would be vacuous.
+    """
+    if create_all:
+        return set()
+    return enabled - seen
+
+
+def is_mass_absence(missing: set[str], enabled: set[str]) -> bool:
+    """True if so much of the selection is absent that the account or the API
+    is the more likely explanation than N individual devices being sold.
+
+    Mirrors the guard detect_orphans already applies (const.ORPHAN_FLOOR_*):
+    this repair must not be less conservative than the pull-based service it
+    tells the user to run. A total wipe-out counts too — if literally every
+    selected device is gone, that is an account/server-side condition, not a
+    fleet-wide garage sale. Deliberate trade: a user with a single enabled
+    device that really was sold is never told. At 24 h of absence the false
+    accusation is the worse error.
+    """
+    if not enabled or not missing:
+        return False
+    if missing >= enabled:          # everything selected has vanished
+        return True
+    return len(missing) > max(
+        ORPHAN_FLOOR_ABS, int(ORPHAN_FLOOR_FRAC * len(enabled))
+    )
+
+
+def missing_devices_verdict(
+    streak: int,
+    streak_started: float | None,
+    now: float,
+    missing: set[str],
+    enabled: set[str],
+) -> bool:
+    """True when the same ids have been absent long enough to report."""
+    if not missing or is_mass_absence(missing, enabled):
+        return False
+    return (
+        streak >= MISSING_DEVICE_MIN_STREAK
+        and streak_started is not None
+        and (now - streak_started) >= MISSING_DEVICE_MIN_SECONDS
+    )
+
+
+def history_import_verdict(
+    consecutive_failures: int, gateway_url: str
+) -> bool:
+    """True when the historical import has been unproductive repeatedly.
+
+    Users who never configured a gateway URL are never told about it.
+    """
+    return bool(gateway_url) and (
+        consecutive_failures >= HISTORY_IMPORT_MIN_FAILURES
+    )
+
+
+def _clamp_name(name: str) -> str:
+    """Trim a device name to keep the rendered card bounded."""
+    if len(name) <= MISSING_DEVICE_MAX_NAME_LEN:
+        return name
+    return name[: MISSING_DEVICE_MAX_NAME_LEN - 1].rstrip() + "…"
+
+
+def format_device_list(missing: set[str], names: dict[str, str]) -> str:
+    """Render the missing ids for the card, readable and bounded.
+
+    A bare ``3494546e1f2a`` is not shown anywhere in the HA UI, so where a
+    label was resolved before the device vanished (a cloud alias, or the HA
+    device-registry row that outlives it) we render ``Name (id)``. Falls
+    back to the bare id. Names are clamped so the whole string stays
+    bounded no matter what the user called their device.
+    """
+    ordered = sorted(missing)
+    shown = ordered[:MISSING_DEVICE_MAX_LISTED]
+    parts = [
+        f"{_clamp_name(names[d])} ({d})" if names.get(d) else d for d in shown
+    ]
+    text = ", ".join(parts)
+    if len(ordered) > len(shown):
+        text += f", … (+{len(ordered) - len(shown)})"
+    return text
+
+
+# ── Registry wrappers ─────────────────────────────────────────────────
+#
+# Each takes the caller's already-computed ``active`` verdict and creates OR
+# deletes in the same call. Existence is read from the issue registry, never
+# tracked by the caller, so the two can never desync.
+
+
+@callback
+def async_manage_rate_limit_issue(
+    hass: HomeAssistant, entry: ConfigEntry, *, active: bool
+) -> None:
+    """Create or clear the sustained-rate-limit issue for ``entry``."""
+    iid = issue_id(ISSUE_RATE_LIMITED, entry.entry_id)
+    if active:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            iid,
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_RATE_LIMITED,
+            translation_placeholders={"entry_title": entry.title},
+        )
+    else:
+        # A no-op when the id was never raised, so no existence probe.
+        ir.async_delete_issue(hass, DOMAIN, iid)
+
+
+@callback
+def async_manage_missing_devices_issue(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    *,
+    active: bool,
+    missing: set[str],
+    names: dict[str, str],
+) -> None:
+    """Create or clear the missing-devices issue for ``entry``.
+
+    When the missing set changes while the issue is raised, just call this
+    again with the new set: ``async_get_or_create`` replaces the
+    placeholders in place and, unlike delete-then-create, PRESERVES the
+    user's "Ignore" (which the registry stores on the issue itself). Never
+    add a delete-then-create here.
+    """
+    iid = issue_id(ISSUE_MISSING_DEVICES, entry.entry_id)
+    if active:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            iid,
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_MISSING_DEVICES,
+            translation_placeholders={
+                "entry_title": entry.title,
+                "count": str(len(missing)),
+                "device_ids": format_device_list(missing, names),
+            },
+        )
+    else:
+        # A no-op when the id was never raised, so no existence probe.
+        ir.async_delete_issue(hass, DOMAIN, iid)
+
+
+@callback
+def async_manage_history_import_issue(
+    hass: HomeAssistant, entry: ConfigEntry, *, active: bool
+) -> None:
+    """Create or clear the historical-import issue for ``entry``."""
+    iid = issue_id(ISSUE_HISTORY_IMPORT_FAILED, entry.entry_id)
+    if active:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            iid,
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_HISTORY_IMPORT_FAILED,
+            translation_placeholders={"entry_title": entry.title},
+        )
+    else:
+        # A no-op when the id was never raised, so no existence probe.
+        ir.async_delete_issue(hass, DOMAIN, iid)
+
+
+@callback
+def async_clear_entry_issues(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Delete every issue this integration may hold for ``entry``."""
+    for kind in (
+        ISSUE_RATE_LIMITED,
+        ISSUE_MISSING_DEVICES,
+        ISSUE_HISTORY_IMPORT_FAILED,
+    ):
+        # ``async_delete_issue`` on a non-existent id is an explicit no-op.
+        ir.async_delete_issue(hass, DOMAIN, issue_id(kind, entry.entry_id))

--- a/custom_components/shelly_cloud_diy/services/historical.py
+++ b/custom_components/shelly_cloud_diy/services/historical.py
@@ -15,13 +15,20 @@ from homeassistant.components.recorder.statistics import (
     async_import_statistics,
     statistics_during_period,
 )
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import CALLBACK_TYPE
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.start import async_at_started
 
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from ..const import CONF_LOCAL_GATEWAY_URL, HISTORICAL_SYNC_INTERVAL
+from ..repair_issues import (
+    HISTORY_IMPORT_RETRY_S,
+    async_manage_history_import_issue,
+    history_import_verdict,
+)
 from ..utils.csv_converter import parse_shelly_csv_for_import
 from ..utils.http import fetch_csv_from_gateway
 from .notifications import NotificationService
@@ -58,6 +65,15 @@ class HistoricalDataService:
         self._entry = entry
         self._notifications = NotificationService(hass)
         self._cancel_interval: callable | None = None
+        # Consecutive UNPRODUCTIVE syncs. This is instance state, so a config
+        # entry reload resets it — accepted, because the one-shot 15-minute
+        # retry below makes the counter reachable inside a single session
+        # regardless of how often the user saves their options.
+        self._sync_failures = 0
+        self._startup_task: asyncio.Task | None = None
+        self._retry_task: asyncio.Task | None = None
+        self._cancel_retry: CALLBACK_TYPE | None = None
+        self._cancel_started: CALLBACK_TYPE | None = None
 
     @property
     def gateway_url(self) -> str:
@@ -97,7 +113,10 @@ class HistoricalDataService:
         # Run initial sync once HA is fully started (event-driven,
         # no arbitrary delay).  If HA is already started when this
         # is called, the callback fires immediately.
-        async_at_started(self._hass, self._on_ha_started)
+        # Keep the unsub: if the entry unloads before HA finishes starting,
+        # the callback would otherwise still fire and start a sync on a
+        # service nobody will call cancel_auto_sync on again.
+        self._cancel_started = async_at_started(self._hass, self._on_ha_started)
 
         # Schedule recurring daily sync
         self._cancel_interval = async_track_time_interval(
@@ -117,21 +136,111 @@ class HistoricalDataService:
         Runs as a background task so it doesn't block HA startup.
         """
         _LOGGER.info("HA started, scheduling initial historical sync")
-        # Create background task so sync doesn't block startup
-        asyncio.create_task(self._run_auto_sync())
+        # Create background task so sync doesn't block startup. The handle is
+        # kept so teardown can cancel a sync still hanging on a dead gateway.
+        self._startup_task = asyncio.create_task(self._run_auto_sync())
 
     async def _run_auto_sync(self, now=None) -> None:
-        """Run automatic sync."""
+        """Run an automatic sync and keep the repair issue in step.
+
+        A "failure" here is an UNPRODUCTIVE run, not an exception: the
+        gateway fetch swallows its own network errors and returns None
+        (utils/http.py), so an unreachable gateway produces an empty result,
+        never a raise. A run with nothing IMPORTABLE is not a failure
+        either — see :meth:`_has_importable_em_devices`.
+        """
         _LOGGER.info("Starting automatic historical sync")
+        # Cancel rather than drop: if the daily interval fires while a retry
+        # is still armed, nulling the handle would leave the orphaned timer
+        # to fire later and run an extra sync outside the schedule.
+        if self._cancel_retry is not None:
+            self._cancel_retry()
+            self._cancel_retry = None
+        has_em_devices = self._has_importable_em_devices()
+        productive = False
         try:
             # sync_data imports directly using native HA API
             imported_stats = await self.sync_data(self.gateway_url)
             if imported_stats:
                 _LOGGER.info("Sync complete: %s", ", ".join(imported_stats))
+                productive = True
             else:
                 _LOGGER.warning("Sync complete: No statistics imported")
-        except Exception as err:
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001 - report, never crash the timer
             _LOGGER.error("Auto sync failed: %s", err)
+
+        # A sync started before teardown can finish after it. Bail out of the
+        # whole accounting block, not just the card: arming a 15-minute timer
+        # against an unloaded entry would run a full sync (gateway fetch plus
+        # a statistics import) on a torn-down entry a quarter of an hour later.
+        if self._entry.state is not ConfigEntryState.LOADED:
+            _LOGGER.debug("Entry no longer loaded; skipping sync accounting")
+            return
+
+        if productive or not self.gateway_url or not has_em_devices:
+            self._sync_failures = 0
+        else:
+            self._sync_failures += 1
+            if self._sync_failures == 1:
+                # Do not wait a full day for the second data point: the user
+                # most likely to hit this is the one editing their gateway
+                # URL right now, and every options save reloads the entry
+                # and resets this counter.
+                self._cancel_retry = async_call_later(
+                    self._hass, HISTORY_IMPORT_RETRY_S, self._run_retry_sync
+                )
+
+        async_manage_history_import_issue(
+            self._hass,
+            self._entry,
+            active=history_import_verdict(
+                self._sync_failures, self.gateway_url
+            ),
+        )
+
+    async def _run_retry_sync(self, _now) -> None:
+        """One-shot retry scheduled after the first unproductive sync.
+
+        The timer handle is gone by the time this runs, so the work is
+        tracked as a task instead — otherwise teardown could not reach a
+        retry already blocked on a dead gateway.
+        """
+        self._cancel_retry = None
+        self._retry_task = asyncio.current_task()
+        try:
+            await self._run_auto_sync()
+        finally:
+            self._retry_task = None
+
+    def _has_importable_em_devices(self) -> bool:
+        """True if at least one EM device could actually produce an import.
+
+        Deliberately stricter than ``_find_em_devices``, which scans the
+        whole cloud fleet — including devices the user opted out of, which
+        the coordinator still polls but never materialises as entities. The
+        import needs a resolvable energy entity AND a hostname, so an EM
+        device lacking either can never yield a statistic no matter how
+        correct the gateway URL is. Counting those as failures would raise
+        a permanent, unclearable card telling the user to fix a URL that is
+        already right.
+        """
+        for dev_id, device_data in self._find_em_devices(None):
+            if not self._coordinator.is_enabled(dev_id):
+                continue
+            if not self._get_device_hostname(device_data):
+                continue
+            device_code = device_data.get("device_code", "SHEM")
+            num_channels = (
+                3 if device_code in ("SHEM-3", "SPEM-003CEBEU") else 2
+            )
+            if any(
+                self._resolve_energy_entity_id(dev_id, channel)
+                for channel in range(num_channels)
+            ):
+                return True
+        return False
 
     async def _get_recorder_sum(self, statistic_id: str) -> float | None:
         """Get the latest cumulative sum from HA's statistics database.
@@ -291,10 +400,27 @@ class HistoricalDataService:
             return False
 
     def cancel_auto_sync(self) -> None:
-        """Cancel automatic sync."""
+        """Cancel automatic sync, the startup run and any pending retry.
+
+        A startup sync still hanging on a dead gateway would otherwise
+        resume after teardown and raise a repair card for an entry that no
+        longer has a coordinator.
+        """
         if self._cancel_interval:
             self._cancel_interval()
             self._cancel_interval = None
+        if self._cancel_started is not None:
+            self._cancel_started()
+            self._cancel_started = None
+        for attr in ("_startup_task", "_retry_task"):
+            task = getattr(self, attr)
+            if task is not None:
+                if not task.done():
+                    task.cancel()
+                setattr(self, attr, None)
+        if self._cancel_retry is not None:
+            self._cancel_retry()
+            self._cancel_retry = None
 
     async def sync_data(
         self,

--- a/custom_components/shelly_cloud_diy/strings.json
+++ b/custom_components/shelly_cloud_diy/strings.json
@@ -132,5 +132,19 @@
         }
       }
     }
+  },
+  "issues": {
+    "rate_limited": {
+      "title": "Shelly Cloud is rate-limiting this integration",
+      "description": "Shelly Cloud allows about one request per second, and it has been rejecting this integration's requests ({entry_title}) for the last couple of minutes.\n\n**This is not a problem with your Authorization cloud key.** Shelly signals the rate limit as an HTTP 401 response whose body contains `max_req` — the same status code a rejected key would produce, but a different cause. Nothing needs to be re-entered.\n\nWhat to do:\n\n1. Check whether something else is polling Shelly Cloud with the same key at the same time — the Shelly mobile app, a second Home Assistant entry for the same account, or your own scripts.\n2. Raise the poll interval in the integration options (Settings → Devices & services → Shelly Cloud DIY → Configure). The default of 5 seconds leaves room, but the integration also makes occasional extra lookups on top of each poll.\n\nEntities become available again on the first poll that gets through, and this message disappears on its own."
+    },
+    "missing_devices": {
+      "title": "Selected devices are missing from your Shelly account",
+      "description": "You selected {count} device(s) for {entry_title} that Shelly Cloud has not reported for the last 24 hours, so no entities are created for them.\n\nDevice(s): {device_ids}\n\nThe most likely causes are that the device was removed from your Shelly account, or — for a Shelly BLU device — that the Bluetooth gateway bridging it has been offline for a long time.\n\nWhat to do:\n\n1. If this is a Shelly BLU device, check that the mains-powered Shelly that bridges it is online.\n2. Otherwise, check whether the device still appears in the Shelly app under the same account.\n3. If it is gone for good, open Settings → Devices & services → Shelly Cloud DIY → Configure, click through to the device list and save. The missing device is no longer offered there, so it drops out of your selection automatically. Then run the **Find Shelly devices no longer in your account** action (Developer tools → Actions, leave Dry run on) to see which Home Assistant devices are left over.\n\nThis message clears by itself as soon as the device reports again, or after you save your device selection again."
+    },
+    "history_import_failed": {
+      "title": "Historical energy data could not be imported",
+      "description": "The historical-data sync for {entry_title} has run twice without importing anything. Live device data is unaffected — only the import of past energy readings into long-term statistics.\n\nMost often the local gateway URL is wrong, or the gateway is not reachable from Home Assistant.\n\nWhat to do:\n\n1. Open Settings → Devices & services → Shelly Cloud DIY → Configure and check the local gateway URL, including the scheme and port (for example `http://192.168.1.50:8080`).\n2. Confirm the gateway is running and reachable from Home Assistant.\n3. If you no longer use it, clear the field to switch the import off.\n\nThe sync runs once at startup and then daily. To check a correction right away, run the **Download and convert historical energy data** action from Developer tools → Actions instead of waiting."
+    }
   }
 }

--- a/custom_components/shelly_cloud_diy/translations/de.json
+++ b/custom_components/shelly_cloud_diy/translations/de.json
@@ -150,5 +150,19 @@
         }
       }
     }
+  },
+  "issues": {
+    "rate_limited": {
+      "title": "Shelly Cloud drosselt diese Integration",
+      "description": "Shelly Cloud erlaubt etwa eine Anfrage pro Sekunde und weist die Anfragen dieser Integration ({entry_title}) seit gut zwei Minuten ab.\n\n**Das ist kein Problem mit deinem Authorization cloud key.** Shelly meldet die Drosselung als HTTP 401 mit `max_req` im Body — derselbe Statuscode wie bei einem abgelehnten Key, aber eine andere Ursache. Du musst nichts neu eintragen.\n\nSo gehst du vor:\n\n1. Prüfe, ob gleichzeitig etwas anderes mit demselben Key Shelly Cloud abfragt — die Shelly-App, ein zweiter Home-Assistant-Eintrag für dasselbe Konto oder eigene Skripte.\n2. Erhöhe das Abfrageintervall in den Optionen der Integration (Einstellungen → Geräte & Dienste → Shelly Cloud DIY → Konfigurieren). Der Standard von 5 Sekunden lässt Luft, zusätzlich zu jeder Abfrage kommen aber gelegentlich weitere Anfragen dazu.\n\nDie Entitäten sind wieder verfügbar, sobald eine Abfrage durchkommt; diese Meldung verschwindet dann von selbst."
+    },
+    "missing_devices": {
+      "title": "Ausgewählte Geräte fehlen in deinem Shelly-Konto",
+      "description": "Du hast für {entry_title} {count} Gerät(e) ausgewählt, die Shelly Cloud seit 24 Stunden nicht mehr meldet — dafür werden keine Entitäten angelegt.\n\nGerät(e): {device_ids}\n\nDie wahrscheinlichsten Ursachen: Das Gerät wurde aus deinem Shelly-Konto entfernt — oder bei einem Shelly-BLU-Gerät ist das Bluetooth-Gateway, das es anbindet, seit Längerem offline.\n\nSo gehst du vor:\n\n1. Handelt es sich um ein Shelly-BLU-Gerät, prüfe, ob der netzbetriebene Shelly, der es anbindet, online ist.\n2. Andernfalls prüfe, ob das Gerät in der Shelly-App unter demselben Konto noch auftaucht.\n3. Ist es endgültig weg, öffne Einstellungen → Geräte & Dienste → Shelly Cloud DIY → Konfigurieren, klick dich bis zur Geräteliste durch und speichere. Das fehlende Gerät steht dort nicht mehr zur Auswahl und fällt damit automatisch aus deiner Auswahl heraus. Führe danach die Aktion **Shelly-Geräte finden, die nicht mehr in deinem Konto sind** aus (Entwicklerwerkzeuge → Aktionen, Trockenlauf anlassen), um zu sehen, welche Home-Assistant-Geräte übrig bleiben.\n\nDie Meldung verschwindet von selbst, sobald sich das Gerät wieder meldet oder du deine Geräteauswahl erneut speicherst."
+    },
+    "history_import_failed": {
+      "title": "Historische Energiedaten konnten nicht importiert werden",
+      "description": "Der Abgleich der historischen Energiedaten für {entry_title} ist zweimal gelaufen, ohne etwas zu importieren. Die Live-Daten deiner Geräte sind davon nicht betroffen — nur der Import früherer Energiewerte in die Langzeitstatistik.\n\nMeistens ist die URL des lokalen Gateways falsch oder das Gateway ist von Home Assistant aus nicht erreichbar.\n\nSo gehst du vor:\n\n1. Öffne Einstellungen → Geräte & Dienste → Shelly Cloud DIY → Konfigurieren und prüfe die URL des lokalen Gateways inklusive Schema und Port (z. B. `http://192.168.1.50:8080`).\n2. Stelle sicher, dass das Gateway läuft und von Home Assistant aus erreichbar ist.\n3. Nutzt du es nicht mehr, leere das Feld — damit ist der Import aus.\n\nDer Abgleich läuft einmal beim Start und danach täglich. Willst du eine Korrektur sofort prüfen, führe die Aktion **Historische Energiedaten herunterladen und konvertieren** unter Entwicklerwerkzeuge → Aktionen aus, statt zu warten."
+    }
   }
 }

--- a/custom_components/shelly_cloud_diy/translations/en.json
+++ b/custom_components/shelly_cloud_diy/translations/en.json
@@ -150,5 +150,19 @@
         }
       }
     }
+  },
+  "issues": {
+    "rate_limited": {
+      "title": "Shelly Cloud is rate-limiting this integration",
+      "description": "Shelly Cloud allows about one request per second, and it has been rejecting this integration's requests ({entry_title}) for the last couple of minutes.\n\n**This is not a problem with your Authorization cloud key.** Shelly signals the rate limit as an HTTP 401 response whose body contains `max_req` — the same status code a rejected key would produce, but a different cause. Nothing needs to be re-entered.\n\nWhat to do:\n\n1. Check whether something else is polling Shelly Cloud with the same key at the same time — the Shelly mobile app, a second Home Assistant entry for the same account, or your own scripts.\n2. Raise the poll interval in the integration options (Settings → Devices & services → Shelly Cloud DIY → Configure). The default of 5 seconds leaves room, but the integration also makes occasional extra lookups on top of each poll.\n\nEntities become available again on the first poll that gets through, and this message disappears on its own."
+    },
+    "missing_devices": {
+      "title": "Selected devices are missing from your Shelly account",
+      "description": "You selected {count} device(s) for {entry_title} that Shelly Cloud has not reported for the last 24 hours, so no entities are created for them.\n\nDevice(s): {device_ids}\n\nThe most likely causes are that the device was removed from your Shelly account, or — for a Shelly BLU device — that the Bluetooth gateway bridging it has been offline for a long time.\n\nWhat to do:\n\n1. If this is a Shelly BLU device, check that the mains-powered Shelly that bridges it is online.\n2. Otherwise, check whether the device still appears in the Shelly app under the same account.\n3. If it is gone for good, open Settings → Devices & services → Shelly Cloud DIY → Configure, click through to the device list and save. The missing device is no longer offered there, so it drops out of your selection automatically. Then run the **Find Shelly devices no longer in your account** action (Developer tools → Actions, leave Dry run on) to see which Home Assistant devices are left over.\n\nThis message clears by itself as soon as the device reports again, or after you save your device selection again."
+    },
+    "history_import_failed": {
+      "title": "Historical energy data could not be imported",
+      "description": "The historical-data sync for {entry_title} has run twice without importing anything. Live device data is unaffected — only the import of past energy readings into long-term statistics.\n\nMost often the local gateway URL is wrong, or the gateway is not reachable from Home Assistant.\n\nWhat to do:\n\n1. Open Settings → Devices & services → Shelly Cloud DIY → Configure and check the local gateway URL, including the scheme and port (for example `http://192.168.1.50:8080`).\n2. Confirm the gateway is running and reachable from Home Assistant.\n3. If you no longer use it, clear the field to switch the import off.\n\nThe sync runs once at startup and then daily. To check a correction right away, run the **Download and convert historical energy data** action from Developer tools → Actions instead of waiting."
+    }
   }
 }

--- a/tests/test_repair_issues.py
+++ b/tests/test_repair_issues.py
@@ -1,0 +1,973 @@
+"""Unit tests for the repair-issue verdicts (rate limit, missing devices, history import).
+
+Shelly Cloud signals its 1 request/second rate limit as HTTP **401 with
+``max_req`` in the body**, not HTTP 429 — the same status code a rejected
+auth_key produces. Making that distinction legible in the UI is the whole
+point of the ``rate_limited`` issue (see issue #6), so nothing in these
+tests or the strings they guard may key off 429.
+
+These tests drive only the pure helpers, never the ``async_manage_*``
+registry wrappers (those assert a running event loop), so they run
+identically against any HA version.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+
+from custom_components.shelly_cloud_diy import coordinator as coordinator_mod
+from custom_components.shelly_cloud_diy.services import (
+    historical as historical_mod,
+)
+from custom_components.shelly_cloud_diy.services.historical import (
+    HistoricalDataService,
+)
+from custom_components.shelly_cloud_diy.coordinator import (
+    ShellyCloudCoordinator,
+    _backoff_elapsed,
+    _backoff_record_failure,
+    metadata_backoff_delay,
+)
+from custom_components.shelly_cloud_diy.repair_issues import (
+    HISTORY_IMPORT_MIN_FAILURES,
+    HISTORY_IMPORT_RETRY_S,
+    MISSING_DEVICE_MAX_LISTED,
+    MISSING_DEVICE_MIN_SECONDS,
+    MISSING_DEVICE_MIN_STREAK,
+    RATE_LIMIT_MIN_SECONDS,
+    RATE_LIMIT_MIN_STREAK,
+    compute_missing_devices,
+    format_device_list,
+    history_import_verdict,
+    is_mass_absence,
+    issue_id,
+    missing_devices_verdict,
+    rate_limit_verdict,
+)
+
+_COMPONENT_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "custom_components",
+    "shelly_cloud_diy",
+)
+
+_EXPECTED_ISSUE_KEYS = {
+    "rate_limited",
+    "missing_devices",
+    "history_import_failed",
+}
+
+# Everything the async_manage_* wrappers actually supply as placeholders.
+_SUPPLIED_PLACEHOLDERS = {"entry_title", "count", "device_ids"}
+
+
+# ── Part A: issue id scoping ──────────────────────────────────────────
+
+
+def test_issue_id_shape() -> None:
+    """The id is the kind suffixed with the config entry id."""
+    assert issue_id("rate_limited", "abc") == "rate_limited_abc"
+
+
+def test_issue_id_is_entry_scoped() -> None:
+    """Two accounts must not clobber each other's card.
+
+    The issue registry keys on ``(domain, issue_id)`` alone, so an
+    unsuffixed id would let a second config entry overwrite the first.
+    """
+    assert issue_id("rate_limited", "entry_one") != issue_id(
+        "rate_limited", "entry_two"
+    )
+
+
+# ── Part B: rate_limit_verdict ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("streak", "elapsed", "expected"),
+    [
+        (4, 300.0, False),      # count gate
+        (5, 119.0, False),      # duration gate
+        (5, 120.0, True),       # boundary inclusive
+        (50, 600.0, True),
+    ],
+)
+def test_rate_limit_verdict(streak: int, elapsed: float, expected: bool) -> None:
+    """Both gates must hold before a sustained rate limit is reported."""
+    now = 10_000.0
+    assert rate_limit_verdict(streak, now - elapsed, now) is expected
+
+
+def test_rate_limit_verdict_no_streak_start() -> None:
+    """A cold coordinator must not raise, and must not report."""
+    assert rate_limit_verdict(0, None, 1234.0) is False
+
+
+def test_rate_limit_gates_match_constants() -> None:
+    """The documented policy is what the constants actually encode."""
+    assert RATE_LIMIT_MIN_STREAK == 5
+    assert RATE_LIMIT_MIN_SECONDS == 120.0
+
+
+# ── Part C: compute_missing_devices ───────────────────────────────────
+
+
+def test_compute_missing_create_all_is_vacuous() -> None:
+    """With create_all on, the enabled set IS the seen set.
+
+    So the difference is vacuous BY DECISION, made explicit here rather
+    than emerging by accident from whatever the caller passed as
+    ``enabled``. The related ``enabled_ids`` fallback trap lives in the
+    coordinator, not in this function — it is guarded separately by
+    ``test_explicit_enabled_ids_ignores_the_all_devices_fallback``.
+    """
+    assert compute_missing_devices({"a", "b"}, {"a"}, True) == set()
+
+
+def test_compute_missing_basic() -> None:
+    assert compute_missing_devices({"a", "b", "c"}, {"a", "b"}, False) == {"c"}
+
+
+def test_compute_missing_nothing_enabled() -> None:
+    assert compute_missing_devices(set(), {"a", "b"}, False) == set()
+
+
+def test_compute_missing_all_present() -> None:
+    assert compute_missing_devices({"a"}, {"a", "b"}, False) == set()
+
+
+# ── Part D: is_mass_absence / missing_devices_verdict ─────────────────
+
+
+def _ids(count: int, prefix: str = "dev") -> set[str]:
+    return {f"{prefix}{i:03d}" for i in range(count)}
+
+
+def test_mass_absence_small_fraction() -> None:
+    enabled = _ids(20)
+    missing = set(sorted(enabled)[:2])
+    assert is_mass_absence(missing, enabled) is False
+
+
+def test_mass_absence_above_floor() -> None:
+    enabled = _ids(20)
+    missing = set(sorted(enabled)[:6])
+    assert is_mass_absence(missing, enabled) is True
+
+
+def test_mass_absence_total_wipeout() -> None:
+    """Everything selected gone at once is an account/server condition."""
+    enabled = _ids(4)
+    assert is_mass_absence(set(enabled), enabled) is True
+
+
+def test_mass_absence_single_of_four() -> None:
+    enabled = _ids(4)
+    missing = set(sorted(enabled)[:1])
+    assert is_mass_absence(missing, enabled) is False
+
+
+def test_mass_absence_empty_enabled() -> None:
+    assert is_mass_absence(set(), set()) is False
+
+
+def test_missing_verdict_nothing_missing() -> None:
+    assert (
+        missing_devices_verdict(9_999, 0.0, 999_999.0, set(), _ids(20)) is False
+    )
+
+
+@pytest.mark.parametrize(
+    ("streak", "elapsed", "expected"),
+    [
+        (9, 90_000.0, False),       # count gate
+        (10, 86_399.0, False),      # duration gate
+        (10, 86_400.0, True),       # boundary inclusive
+    ],
+)
+def test_missing_verdict_gates(
+    streak: int, elapsed: float, expected: bool
+) -> None:
+    enabled = _ids(20)
+    now = 1_000_000.0
+    assert (
+        missing_devices_verdict(
+            streak, now - elapsed, now, {"dev000"}, enabled
+        )
+        is expected
+    )
+
+
+def test_missing_verdict_mass_absence_outranks_gates() -> None:
+    """A fleet-wide disappearance is suppressed however long it lasts."""
+    enabled = _ids(20)
+    missing = set(sorted(enabled)[:6])
+    now = 1_000_000.0
+    assert (
+        missing_devices_verdict(100, now - 200_000.0, now, missing, enabled)
+        is False
+    )
+
+
+def test_missing_gates_match_constants() -> None:
+    assert MISSING_DEVICE_MIN_STREAK == 10
+    assert MISSING_DEVICE_MIN_SECONDS == 86400.0
+
+
+# ── Part E: history_import_verdict ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("failures", "url", "expected"),
+    [
+        (99, "", False),                          # never configured a gateway
+        (0, "http://10.0.0.5:8080", False),        # fresh service never fires
+        (1, "http://10.0.0.5:8080", False),
+        (2, "http://10.0.0.5:8080", True),
+        (HISTORY_IMPORT_MIN_FAILURES, "http://x", True),
+    ],
+)
+def test_history_import_verdict(
+    failures: int, url: str, expected: bool
+) -> None:
+    assert history_import_verdict(failures, url) is expected
+
+
+# ── Part F: format_device_list ────────────────────────────────────────
+
+
+def test_format_bare_id() -> None:
+    assert format_device_list({"abc123"}, {}) == "abc123"
+
+
+def test_format_named_id() -> None:
+    assert (
+        format_device_list({"abc123"}, {"abc123": "Kitchen lamp"})
+        == "Kitchen lamp (abc123)"
+    )
+
+
+def test_format_truncates_and_counts() -> None:
+    """The card must never render an unbounded id blob."""
+    missing = _ids(8)
+    text = format_device_list(missing, {})
+    assert text.count(",") == MISSING_DEVICE_MAX_LISTED  # 4 separators + tail
+    assert text.endswith(", … (+3)")
+    for did in sorted(missing)[:MISSING_DEVICE_MAX_LISTED]:
+        assert did in text
+    assert len(text) < 200
+
+
+def test_format_is_bounded_even_with_long_names() -> None:
+    """Names are user-supplied, so the bound must survive verbose ones.
+
+    Five entries of "Wohnzimmer Deckenlampe hinten links (3494546e1f2a)"
+    would blow past the limit MISSING_DEVICE_MAX_LISTED exists to enforce,
+    and names are usually resolved BEFORE a device vanishes, so this is the
+    case that actually occurs in production.
+    """
+    missing = _ids(8)
+    names = {
+        did: "Wohnzimmer Deckenlampe hinten links am Fenster"
+        for did in missing
+    }
+    text = format_device_list(missing, names)
+    assert len(text) < 200
+    assert text.endswith(", … (+3)")
+    # Every listed id is still identifiable despite the clamp.
+    for did in sorted(missing)[:MISSING_DEVICE_MAX_LISTED]:
+        assert f"({did})" in text
+
+
+def test_format_clamps_a_single_long_name() -> None:
+    text = format_device_list({"abc123"}, {"abc123": "x" * 100})
+    assert text.endswith("(abc123)")
+    assert len(text) < 100
+
+
+def test_format_is_deterministic() -> None:
+    missing = _ids(8)
+    assert format_device_list(missing, {}) == format_device_list(missing, {})
+
+
+# ── Part G: streak bookkeeping against the REAL coordinator ───────────
+#
+# These drive the ACTUAL ShellyCloudCoordinator methods, not a
+# re-implementation of them. A hand-written mirror can only ever confirm
+# that the mirror-writer understood their own code; it cannot catch a
+# regression in the method it copies. The coordinator is built with
+# ``__new__`` so no HA instance, config entry or DataUpdateCoordinator
+# machinery is needed — only the handful of attributes these three methods
+# actually touch. Everything that reaches out to HA (the issue-registry
+# wrappers, the device registry, the clock) is swapped for a fake.
+
+
+class _FakeIssueSink:
+    """Model issue EXISTENCE, mirroring async_get_or_create semantics.
+
+    ``async_create_issue`` is an upsert that only fires an event when a
+    field actually changed, so re-asserting an unchanged issue must record
+    nothing. ``async_delete_issue`` on an unknown id is a no-op.
+    """
+
+    def __init__(self) -> None:
+        self.raised: dict[str, dict[str, str]] = {}
+        self.calls: list[tuple[str, str, dict[str, str]]] = []
+
+    def manage(
+        self, iid: str, active: bool, placeholders: dict[str, str] | None = None
+    ) -> None:
+        placeholders = placeholders or {}
+        if active:
+            if self.raised.get(iid) == placeholders:
+                return          # unchanged upsert — no event
+            self.raised[iid] = placeholders
+            self.calls.append(("create", iid, placeholders))
+        elif iid in self.raised:
+            del self.raised[iid]
+            self.calls.append(("delete", iid, {}))
+
+
+class _FakeClock:
+    """Stand-in for the ``time`` module the coordinator calls into."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+class _FakeDeviceRegistry:
+    """A device registry that knows nothing, so labels fall back to ids."""
+
+    def async_get_device(self, identifiers=None):  # noqa: ANN001
+        return None
+
+
+class _RealCoordinatorDriver:
+    """Drive the real repair methods with every HA edge faked out."""
+
+    def __init__(self, monkeypatch, enabled: set[str] | None = None) -> None:
+        self.clock = _FakeClock()
+        self.sink = _FakeIssueSink()
+        self.enabled = enabled or set()
+
+        coord = ShellyCloudCoordinator.__new__(ShellyCloudCoordinator)
+        coord.hass = None
+        coord._entry = None
+        coord.device_names = {}
+        coord._rate_limit_streak = 0
+        coord._rate_limit_since = None
+        coord._rate_limit_reported = False
+        coord._missing_streak = {}
+        coord._missing_since = {}
+        self.coord = coord
+
+        sink = self.sink
+        monkeypatch.setattr(coordinator_mod, "time", self.clock)
+        monkeypatch.setattr(
+            coordinator_mod, "dr", type("_dr", (), {
+                "async_get": staticmethod(lambda _hass: _FakeDeviceRegistry()),
+            }),
+        )
+        monkeypatch.setattr(
+            coordinator_mod,
+            "async_manage_rate_limit_issue",
+            lambda hass, entry, *, active: sink.manage("rate_limited", active),
+        )
+        monkeypatch.setattr(
+            coordinator_mod,
+            "async_manage_missing_devices_issue",
+            lambda hass, entry, *, active, missing, names: sink.manage(
+                "missing_devices",
+                active,
+                {
+                    "count": str(len(missing)),
+                    "device_ids": format_device_list(missing, names),
+                },
+            ),
+        )
+        # ``_explicit_enabled_ids`` reads entry.options through the
+        # ``_options`` property; feed it the selection under test.
+        monkeypatch.setattr(
+            ShellyCloudCoordinator,
+            "_options",
+            property(lambda _self: {"enabled_devices": sorted(self.enabled)}),
+        )
+        monkeypatch.setattr(
+            ShellyCloudCoordinator,
+            "create_all_initially",
+            property(lambda _self: False),
+        )
+
+    def advance(self, seconds: float) -> None:
+        self.clock.now += seconds
+
+    def note_rate_limited(self) -> None:
+        self.coord._note_rate_limited()
+
+    def note_not_rate_limited(self) -> None:
+        self.coord._note_poll_not_rate_limited()
+
+    def evaluate_missing(self, seen: set[str]) -> None:
+        self.coord._evaluate_missing_devices(set(seen))
+
+
+@pytest.fixture(name="coord")
+def _coord(monkeypatch) -> _RealCoordinatorDriver:
+    return _RealCoordinatorDriver(monkeypatch)
+
+
+def test_explicit_enabled_ids_ignores_the_all_devices_fallback(
+    monkeypatch,
+) -> None:
+    """The whole check dies silently if this is swapped for ``enabled_ids``.
+
+    ``enabled_ids`` falls back to ``set(self.devices)`` in two branches, so
+    the difference against the seen set would be vacuous and R2 would never
+    fire again — with every test still green.
+    """
+    driver = _RealCoordinatorDriver(monkeypatch)
+    coord = driver.coord
+
+    monkeypatch.setattr(
+        ShellyCloudCoordinator, "_options",
+        property(lambda _s: {"enabled_devices": ["a", "b"]}),
+    )
+    assert coord._explicit_enabled_ids() == {"a", "b"}
+
+    monkeypatch.setattr(
+        ShellyCloudCoordinator, "_options", property(lambda _s: {}),
+    )
+    assert coord._explicit_enabled_ids() == set()
+
+    monkeypatch.setattr(
+        ShellyCloudCoordinator, "_options",
+        property(lambda _s: {"enabled_devices": "not-a-list"}),
+    )
+    assert coord._explicit_enabled_ids() == set()
+
+    monkeypatch.setattr(
+        ShellyCloudCoordinator, "_options",
+        property(lambda _s: {"enabled_devices": ["a", 7, None, "b"]}),
+    )
+    assert coord._explicit_enabled_ids() == {"a", "b"}
+
+
+def test_self_healing_rate_limit_never_flaps(coord) -> None:
+    """The ~1.5 s self-healing case must produce zero issue churn."""
+    for _ in range(50):
+        coord.note_rate_limited()
+        coord.advance(1.5)
+        coord.note_not_rate_limited()
+        coord.advance(3.5)
+    assert coord.sink.calls == []
+
+
+def test_sustained_rate_limit_raises_once_then_clears(coord) -> None:
+    for _ in range(5):
+        coord.note_rate_limited()
+        coord.advance(50.0)
+    assert [c[0] for c in coord.sink.calls] == ["create"]
+
+    for _ in range(5):
+        coord.note_rate_limited()
+        coord.advance(50.0)
+    assert [c[0] for c in coord.sink.calls] == ["create"]
+
+    coord.note_not_rate_limited()
+    assert [c[0] for c in coord.sink.calls] == ["create", "delete"]
+
+
+def test_non_rate_limit_failure_resets_streak(coord) -> None:
+    """A different failure type falsifies the pure-rate-limit claim."""
+    for _ in range(4):
+        coord.note_rate_limited()
+        coord.advance(50.0)
+    coord.note_not_rate_limited()      # e.g. a transport error
+    for _ in range(4):
+        coord.note_rate_limited()
+        coord.advance(50.0)
+    assert coord.sink.calls == []
+
+
+def test_missing_set_change_replaces_in_place(monkeypatch) -> None:
+    """Replacing placeholders preserves the user's "Ignore".
+
+    A delete-then-create would discard it, so the second event must be
+    another ``create`` and there must be no ``delete`` in between.
+    """
+    enabled = _ids(20)
+    coord = _RealCoordinatorDriver(monkeypatch, enabled)
+    seen = set(enabled) - {"dev000"}
+    for _ in range(MISSING_DEVICE_MIN_STREAK):
+        coord.evaluate_missing(seen)
+        coord.advance(MISSING_DEVICE_MIN_SECONDS / 2)
+    assert [c[0] for c in coord.sink.calls] == ["create"]
+    assert coord.sink.calls[-1][2]["device_ids"] == "dev000"
+    # The count must describe the ids actually named, never a wider set.
+    assert coord.sink.calls[-1][2]["count"] == "1"
+
+    # A second device vanishes: same issue, new placeholders.
+    seen2 = seen - {"dev001"}
+    for _ in range(MISSING_DEVICE_MIN_STREAK):
+        coord.evaluate_missing(seen2)
+        coord.advance(MISSING_DEVICE_MIN_SECONDS / 2)
+    assert [c[0] for c in coord.sink.calls] == ["create", "create"]
+    assert coord.sink.calls[-1][2]["device_ids"] == "dev000, dev001"
+    assert coord.sink.calls[-1][2]["count"] == "2"
+
+
+def test_newly_vanished_device_serves_its_own_clock(monkeypatch) -> None:
+    """A new absence does not inherit elapsed time from another device."""
+    enabled = _ids(20)
+    coord = _RealCoordinatorDriver(monkeypatch, enabled)
+    seen = set(enabled) - {"dev000"}
+    for _ in range(MISSING_DEVICE_MIN_STREAK):
+        coord.evaluate_missing(seen)
+        coord.advance(MISSING_DEVICE_MIN_SECONDS / 2)
+    assert len(coord.sink.calls) == 1
+
+    # dev000 returns and dev001 vanishes in the same poll. The card must
+    # clear (its only id is back) and dev001 must NOT inherit the 24 h
+    # dev000 had already served.
+    seen2 = set(enabled) - {"dev001"}
+    for _ in range(MISSING_DEVICE_MIN_STREAK):
+        coord.evaluate_missing(seen2)
+        coord.advance(1.0)
+    assert [c[0] for c in coord.sink.calls] == ["create", "delete"]
+
+
+def test_second_device_vanishing_does_not_hide_the_card(monkeypatch) -> None:
+    """A WORSENING condition must never make the warning disappear.
+
+    Per-set streak bookkeeping would restart the clock here and clear a
+    card that had already earned its place for 24 h.
+    """
+    enabled = _ids(20)
+    coord = _RealCoordinatorDriver(monkeypatch, enabled)
+    seen = set(enabled) - {"dev000"}
+    for _ in range(MISSING_DEVICE_MIN_STREAK):
+        coord.evaluate_missing(seen)
+        coord.advance(MISSING_DEVICE_MIN_SECONDS / 2)
+    assert [c[0] for c in coord.sink.calls] == ["create"]
+
+    # dev001 also vanishes; it has not served its own 24 h yet.
+    seen2 = seen - {"dev001"}
+    for _ in range(3):
+        coord.evaluate_missing(seen2)
+        coord.advance(60.0)
+    # dev000's card stands, still naming only dev000, with no churn.
+    assert [c[0] for c in coord.sink.calls] == ["create"]
+    assert coord.sink.raised["missing_devices"]["device_ids"] == "dev000"
+
+
+def test_transient_mass_outage_cannot_retract_an_earned_card(
+    monkeypatch,
+) -> None:
+    """The mass-absence guard must never delete an already-earned card.
+
+    Deleting discards the user's "Ignore" and the card returns un-ignored
+    once the outage passes — the exact delete-then-create loop this design
+    exists to prevent. The guard is therefore judged on the REPORTABLE set,
+    not on the whole missing set: ids that have not served their own 24 h
+    cannot vote a card off the board.
+    """
+    enabled = _ids(20)
+    coord = _RealCoordinatorDriver(monkeypatch, enabled)
+    seen = set(enabled) - {"dev000"}
+    for _ in range(MISSING_DEVICE_MIN_STREAK):
+        coord.evaluate_missing(seen)
+        coord.advance(MISSING_DEVICE_MIN_SECONDS / 2)
+    assert [c[0] for c in coord.sink.calls] == ["create"]
+
+    # A router reboot takes six BLU children offline for a few polls: well
+    # over the mass-absence floor, but none of them has served 24 h.
+    outage = set(enabled) - {f"dev{i:03d}" for i in range(6)}
+    for _ in range(3):
+        coord.evaluate_missing(outage)
+        coord.advance(60.0)
+    assert [c[0] for c in coord.sink.calls] == ["create"]
+    assert coord.sink.raised["missing_devices"]["device_ids"] == "dev000"
+
+    # Outage over: still no churn, still the same single id.
+    coord.evaluate_missing(seen)
+    assert [c[0] for c in coord.sink.calls] == ["create"]
+
+
+def test_account_wide_disappearance_is_suppressed(monkeypatch) -> None:
+    """A genuine fleet-wide wipe-out still reaches the mass-absence guard.
+
+    Every id vanishes at the same moment, so they clear their individual
+    24 h gates together and land in ``reportable`` together — where the
+    guard catches them and stays silent.
+    """
+    enabled = _ids(20)
+    coord = _RealCoordinatorDriver(monkeypatch, enabled)
+    for _ in range(MISSING_DEVICE_MIN_STREAK * 2):
+        coord.evaluate_missing(set())
+        coord.advance(MISSING_DEVICE_MIN_SECONDS / 2)
+    assert coord.sink.calls == []
+
+
+def test_device_reappearing_clears_the_issue(monkeypatch) -> None:
+    enabled = _ids(20)
+    coord = _RealCoordinatorDriver(monkeypatch, enabled)
+    seen = set(enabled) - {"dev000"}
+    for _ in range(MISSING_DEVICE_MIN_STREAK):
+        coord.evaluate_missing(seen)
+        coord.advance(MISSING_DEVICE_MIN_SECONDS / 2)
+    coord.evaluate_missing(set(enabled))
+    assert [c[0] for c in coord.sink.calls] == ["create", "delete"]
+
+
+# ── Part H: metadata backoff arithmetic ───────────────────────────────
+
+
+class _FakeNameApi:
+    """Return only the aliases a real Shelly account would carry.
+
+    Mirrors ``get_device_names``: devices with no cloud alias (never
+    renamed in the Shelly app) are omitted SILENTLY — no exception.
+    """
+
+    def __init__(self, names: dict[str, str]) -> None:
+        self.names = names
+
+    async def get_device_names(self, ids):
+        return {d: n for d, n in self.names.items() if d in ids}
+
+
+def _make_name_lookup_coordinator(monkeypatch, names: dict[str, str]):
+    """A coordinator wired up just enough to run ``_refresh_device_names``."""
+    # Skip the real 1.2 s rate-limit gap, and the device-registry push that
+    # needs a live HA instance.
+    monkeypatch.setattr(coordinator_mod, "_V2_NAME_LOOKUP_GAP_S", 0)
+    monkeypatch.setattr(
+        coordinator_mod, "dr", type("_dr", (), {
+            "async_get": staticmethod(lambda _hass: _FakeDeviceRegistry()),
+        }),
+    )
+    coord = ShellyCloudCoordinator.__new__(ShellyCloudCoordinator)
+    coord.hass = None
+    coord._entry = None
+    coord._api = _FakeNameApi(names)
+    coord.device_names = {}
+    coord.devices = {}
+    coord._name_lookup_in_flight = True
+    coord._name_lookup_backoff = {}
+    # The registry push and the listener nudge both need a live HA instance
+    # and are irrelevant to backoff bookkeeping.
+    coord.async_update_listeners = lambda: None
+    return coord
+
+
+
+
+@pytest.mark.parametrize(
+    ("failures", "expected"),
+    [
+        (1, 60.0),
+        (2, 120.0),
+        (3, 240.0),
+        (4, 480.0),
+        (5, 960.0),
+        (6, 1920.0),
+        (7, 3600.0),
+        (8, 3600.0),
+    ],
+)
+def test_metadata_backoff_delay(failures: int, expected: float) -> None:
+    """Doubling, capped at one hour — never a permanent give-up."""
+    assert metadata_backoff_delay(failures) == expected
+
+
+def test_backoff_skips_then_becomes_eligible() -> None:
+    backoff: dict[str, tuple[int, float]] = {}
+    assert _backoff_elapsed(backoff, "dev0", 0.0) is True
+
+    delay = _backoff_record_failure(backoff, "dev0", 100.0)
+    assert delay == 60.0
+    assert _backoff_elapsed(backoff, "dev0", 159.0) is False
+    assert _backoff_elapsed(backoff, "dev0", 160.0) is True
+
+
+def test_backoff_success_removes_entry() -> None:
+    backoff: dict[str, tuple[int, float]] = {}
+    _backoff_record_failure(backoff, "dev0", 0.0)
+    _backoff_record_failure(backoff, "dev0", 60.0)
+    assert backoff["dev0"][0] == 2
+    backoff.pop("dev0", None)          # what a successful lookup does
+    assert _backoff_elapsed(backoff, "dev0", 0.0) is True
+
+
+def test_backoff_success_removes_entry_through_the_real_method(
+    monkeypatch,
+) -> None:
+    """A resolved alias must actually pop the id, via production code.
+
+    Popping it in the test would assert nothing about the coordinator.
+    """
+    coord = _make_name_lookup_coordinator(monkeypatch, {"dev0": "Kitchen"})
+    _backoff_record_failure(coord._name_lookup_backoff, "dev0", 0.0)
+    asyncio.run(coord._refresh_device_names(["dev0"]))
+    assert "dev0" not in coord._name_lookup_backoff
+    assert coord.device_names["dev0"] == "Kitchen"
+
+
+def test_aliasless_device_is_backed_off_not_re_probed_every_poll(
+    monkeypatch,
+) -> None:
+    """A device never renamed in the Shelly app must not cost a request/poll.
+
+    ``get_device_names`` OMITS devices that carry no cloud alias and returns
+    NORMALLY, so no exception is ever raised and the id never enters
+    ``device_names``. Without recording that non-answer the id stays in the
+    ``unresolved`` comprehension forever — one extra v1 request every poll,
+    against the same 1 req/s budget the rate-limit repair reports. That
+    would make the card blame the user for the integration's own traffic.
+    """
+    coord = _make_name_lookup_coordinator(monkeypatch, {})   # nothing has an alias
+    asyncio.run(coord._refresh_device_names(["dev0", "dev1"]))
+    assert set(coord._name_lookup_backoff) == {"dev0", "dev1"}
+    assert coord._name_lookup_backoff["dev0"][0] == 1
+
+    # The counter ESCALATES rather than resetting on each empty answer, so
+    # the retry interval grows 60 s → 120 s → … instead of pinning at 60 s.
+    asyncio.run(coord._refresh_device_names(["dev0"]))
+    assert coord._name_lookup_backoff["dev0"][0] == 2
+
+    # Bounded, never permanent: a rename in the app is still picked up.
+    coord._api.names = {"dev0": "Kitchen"}
+    coord._name_lookup_backoff["dev0"] = (2, 0.0)   # backoff expired
+    asyncio.run(coord._refresh_device_names(["dev0"]))
+    assert "dev0" not in coord._name_lookup_backoff
+
+
+def test_partial_answer_backs_off_only_the_unanswered_ids(monkeypatch) -> None:
+    coord = _make_name_lookup_coordinator(monkeypatch, {"dev0": "Kitchen"})
+    asyncio.run(coord._refresh_device_names(["dev0", "dev1"]))
+    assert "dev0" not in coord._name_lookup_backoff
+    assert coord._name_lookup_backoff["dev1"][0] == 1
+
+
+# ── Part J: historical-import accounting (the real state machine) ─────
+#
+# ``history_import_verdict`` is a pure function tested in Part E, but the
+# state machine that FEEDS it — the reset arm, the increment, the one-shot
+# retry, the unloaded-entry bail-out — is what actually decides whether a
+# user sees a permanent unclearable card. Driven through the real method.
+
+
+class _FakeEntry:
+    def __init__(self, url: str) -> None:
+        self.options = {"local_gateway_url": url}
+        self.state = ConfigEntryState.LOADED
+        self.entry_id = "entry1"
+        self.title = "Shelly Cloud DIY"
+
+
+class _HistoryDriver:
+    """Drive the real ``_run_auto_sync`` accounting with HA faked out."""
+
+    def __init__(
+        self,
+        monkeypatch,
+        url: str = "http://10.0.0.5:8080",
+        importable: bool = True,
+    ) -> None:
+        self.sink = _FakeIssueSink()
+        self.scheduled: list[float] = []
+        self.imported: list[str] = []
+        self.entry = _FakeEntry(url)
+
+        svc = HistoricalDataService.__new__(HistoricalDataService)
+        svc._hass = None
+        svc._entry = self.entry
+        svc._sync_failures = 0
+        svc._cancel_retry = None
+        svc._retry_task = None
+        svc._startup_task = None
+        self.svc = svc
+
+        svc._has_importable_em_devices = lambda: importable
+        svc.sync_data = self._sync_data
+
+        sink = self.sink
+        monkeypatch.setattr(
+            historical_mod,
+            "async_manage_history_import_issue",
+            lambda hass, entry, *, active: sink.manage(
+                "history_import_failed", active
+            ),
+        )
+        monkeypatch.setattr(
+            historical_mod,
+            "async_call_later",
+            lambda hass, delay, action: (
+                self.scheduled.append(delay) or (lambda: None)
+            ),
+        )
+
+    async def _sync_data(self, _url):
+        return list(self.imported)
+
+    def run(self) -> None:
+        asyncio.run(self.svc._run_auto_sync())
+
+
+def test_unproductive_sync_raises_only_on_the_second_run(monkeypatch) -> None:
+    d = _HistoryDriver(monkeypatch)
+    d.run()
+    assert d.svc._sync_failures == 1
+    assert d.sink.calls == []
+    # A 15-minute retry is armed so the second data point lands in the same
+    # session instead of a day later.
+    assert d.scheduled == [HISTORY_IMPORT_RETRY_S]
+
+    d.run()
+    assert [c[0] for c in d.sink.calls] == ["create"]
+
+
+def test_productive_sync_clears_the_issue(monkeypatch) -> None:
+    d = _HistoryDriver(monkeypatch)
+    d.run()
+    d.run()
+    assert [c[0] for c in d.sink.calls] == ["create"]
+
+    d.imported = ["sensor.shelly_em_energy"]
+    d.run()
+    assert [c[0] for c in d.sink.calls] == ["create", "delete"]
+    assert d.svc._sync_failures == 0
+
+
+def test_clearing_the_gateway_url_clears_the_issue(monkeypatch) -> None:
+    """Switching the import off must not leave an unclearable card."""
+    d = _HistoryDriver(monkeypatch)
+    d.run()
+    d.run()
+    assert [c[0] for c in d.sink.calls] == ["create"]
+
+    d.entry.options["local_gateway_url"] = ""
+    d.run()
+    assert [c[0] for c in d.sink.calls] == ["create", "delete"]
+
+
+def test_nothing_importable_is_not_a_gateway_failure(monkeypatch) -> None:
+    """An EM device that can never produce a statistic is not a failure.
+
+    ``_find_em_devices`` scans the WHOLE cloud fleet, including devices the
+    user opted out of, which the coordinator still polls but never
+    materialises as entities. Counting those as failures would raise a
+    permanent card telling the user to fix a gateway URL that is correct.
+    """
+    d = _HistoryDriver(monkeypatch, importable=False)
+    for _ in range(5):
+        d.run()
+    assert d.svc._sync_failures == 0
+    assert d.sink.calls == []
+
+
+def test_unloaded_entry_neither_counts_nor_arms_a_timer(monkeypatch) -> None:
+    """A sync outliving teardown must not schedule work on a dead entry.
+
+    Arming the 15-minute retry against an unloaded entry would run a full
+    gateway fetch and a statistics import a quarter of an hour after the
+    entry was gone.
+    """
+    d = _HistoryDriver(monkeypatch)
+    d.entry.state = ConfigEntryState.NOT_LOADED
+    d.run()
+    assert d.svc._sync_failures == 0
+    assert d.scheduled == []
+    assert d.sink.calls == []
+
+
+# ── Part I: translation completeness (blocking-defect guard) ──────────
+
+
+def _load(rel: str) -> dict:
+    with open(os.path.join(_COMPONENT_DIR, rel), encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _all_files() -> dict[str, dict]:
+    return {
+        "strings.json": _load("strings.json"),
+        "en.json": _load(os.path.join("translations", "en.json")),
+        "de.json": _load(os.path.join("translations", "de.json")),
+    }
+
+
+def test_every_file_has_the_same_issue_keys() -> None:
+    for name, data in _all_files().items():
+        assert "issues" in data, f"{name} has no issues block"
+        assert set(data["issues"]) == _EXPECTED_ISSUE_KEYS, name
+
+
+def test_every_issue_has_title_and_description_only() -> None:
+    """No fix_flow: every issue is informational (is_fixable=False)."""
+    for name, data in _all_files().items():
+        for key, issue in data["issues"].items():
+            assert set(issue) == {"title", "description"}, f"{name}:{key}"
+
+
+def test_placeholders_match_between_languages_and_code() -> None:
+    files = _all_files()
+    for key in _EXPECTED_ISSUE_KEYS:
+        tokens = {}
+        for lang in ("en.json", "de.json"):
+            issue = files[lang]["issues"][key]
+            tokens[lang] = set(
+                re.findall(r"\{(\w+)\}", issue["title"] + issue["description"])
+            )
+        assert tokens["en.json"] == tokens["de.json"], key
+        assert tokens["en.json"] <= _SUPPLIED_PLACEHOLDERS, key
+
+
+def test_no_out_of_scope_terms() -> None:
+    """The OAuth/WebSocket realtime path is not shipped; 429 is wrong."""
+    pattern = re.compile(r"(websocket|oauth|realtime|429)", re.IGNORECASE)
+    for name, data in _all_files().items():
+        for key, issue in data["issues"].items():
+            for field, value in issue.items():
+                assert not pattern.search(value), f"{name}:{key}:{field}"
+
+
+def test_strings_and_en_are_identical() -> None:
+    files = _all_files()
+    assert files["strings.json"]["issues"] == files["en.json"]["issues"]
+
+
+def test_german_glossary_discipline() -> None:
+    """"abhaken" means the opposite of what we mean; "Konto" not "Account"."""
+    de = _load(os.path.join("translations", "de.json"))["issues"]
+    for key, issue in de.items():
+        for field, value in issue.items():
+            assert not re.search(r"abhak", value, re.IGNORECASE), (
+                f"{key}:{field}"
+            )
+            assert "Account" not in value, f"{key}:{field}"
+
+
+def test_german_is_actually_translated() -> None:
+    """Every DE field must differ from its EN counterpart.
+
+    A verbatim copy-paste of the English block into de.json passes every
+    other Part I assertion — identical keys, identical placeholders, no
+    "abhaken", no "Account" — so this is the one i18n regression the guard
+    could not otherwise see. Incomplete i18n is a blocking defect here.
+    """
+    files = _all_files()
+    en = files["en.json"]["issues"]
+    de = files["de.json"]["issues"]
+    for key in _EXPECTED_ISSUE_KEYS:
+        for field in ("title", "description"):
+            assert de[key][field] != en[key][field], f"{key}:{field} untranslated"

--- a/tests/test_repair_issues_harness.py
+++ b/tests/test_repair_issues_harness.py
@@ -1,0 +1,518 @@
+"""Live issue-registry tests for the ``repair_issues`` registry wrappers.
+
+``tests/test_repair_issues.py`` is deliberately pure-logic: it stubs the
+four ``async_manage_*`` / ``async_clear_entry_issues`` wrappers so it can
+run against any Home Assistant version in the two-venv runner. That leaves
+the wrappers themselves — and the load-bearing assumption they rest on —
+unexecuted.
+
+The assumption: ``ir.async_create_issue`` is an idempotent upsert. Calling
+it on every poll while the condition holds must
+
+* not churn the registry (no spurious ``create``/``update`` events, stable
+  ``created`` timestamp), and
+* **not destroy a user's "Ignore"** — the registry stores the dismissal on
+  the issue itself as ``dismissed_version``.
+
+That is why ``repair_issues.py`` carries no ``_issue_raised`` guard
+booleans. If the assumption were false the repair card would come back
+seconds after every dismissal, so it is verified here against a REAL
+``homeassistant.helpers.issue_registry`` on a real ``hass`` object.
+
+This file needs ``pytest-homeassistant-custom-component``, which is
+deliberately NOT installed in the two matrix venvs (it hard-pins
+``homeassistant==``, which would collapse the min/max bracket). It lives in
+a third, isolated venv and is skipped cleanly everywhere else::
+
+    ~/.venvs/shelly-diy-harness/bin/python -m pytest \\
+        tests/test_repair_issues_harness.py \\
+        -p pytest_homeassistant_custom_component -o asyncio_mode=auto
+
+The plugin and the asyncio mode are passed on the command line rather than
+via a conftest/ini so that ``pytest tests/`` in the two matrix venvs is
+completely untouched; there this module simply reports SKIPPED.
+
+The harness pins ``homeassistant==2025.1.4`` (this repo's stated minimum,
+and the newest HA that ``pytest-homeassistant-custom-component`` ships a
+release for), so these tests execute against the OLD end of the bracket.
+They transfer to the new end by inspection: ``IssueRegistry
+.async_get_or_create/.async_delete/.async_ignore`` and the module-level
+``async_create_issue/async_delete_issue/async_ignore_issue`` are
+byte-identical between 2025.1.4 and 2026.7.2, as is the ``IssueEntry``
+field set. If a future HA changes any of them, re-run this file.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "pytest_homeassistant_custom_component",
+    reason="live issue-registry harness venv not present in this environment",
+)
+
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+    async_capture_events,
+)
+
+from homeassistant.const import __version__ as HA_VERSION  # noqa: E402
+from homeassistant.core import HomeAssistant  # noqa: E402
+from homeassistant.helpers import issue_registry as ir  # noqa: E402
+
+from custom_components.shelly_cloud_diy.const import DOMAIN  # noqa: E402
+from custom_components.shelly_cloud_diy.repair_issues import (  # noqa: E402
+    ISSUE_HISTORY_IMPORT_FAILED,
+    ISSUE_MISSING_DEVICES,
+    ISSUE_RATE_LIMITED,
+    async_clear_entry_issues,
+    async_manage_history_import_issue,
+    async_manage_missing_devices_issue,
+    async_manage_rate_limit_issue,
+    format_device_list,
+    issue_id,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def entry() -> MockConfigEntry:
+    """A config entry standing in for one Shelly Cloud account."""
+    return MockConfigEntry(
+        domain=DOMAIN, title="Shelly Cloud", entry_id="entry_one"
+    )
+
+
+@pytest.fixture
+def other_entry() -> MockConfigEntry:
+    """A second account, used to prove per-entry isolation."""
+    return MockConfigEntry(
+        domain=DOMAIN, title="Second Account", entry_id="entry_two"
+    )
+
+
+@pytest.fixture
+def events(hass: HomeAssistant) -> list:
+    """Every issue-registry update event fired during a test."""
+    return async_capture_events(hass, ir.EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED)
+
+
+def _actions(events: list) -> list[str]:
+    return [e.data["action"] for e in events]
+
+
+# ── 1. Each wrapper creates the issue it advertises ───────────────────
+
+
+async def test_rate_limit_wrapper_creates_expected_issue(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    """The rate-limit wrapper writes a real, correctly-shaped issue."""
+    async_manage_rate_limit_issue(hass, entry, active=True)
+
+    reg = ir.async_get(hass)
+    iid = issue_id(ISSUE_RATE_LIMITED, entry.entry_id)
+    issue = reg.async_get_issue(DOMAIN, iid)
+
+    assert issue is not None
+    assert issue.issue_id == f"rate_limited_{entry.entry_id}"
+    assert issue.domain == DOMAIN
+    assert issue.translation_key == ISSUE_RATE_LIMITED
+    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.is_fixable is False
+    assert issue.is_persistent is False
+    assert issue.active is True
+    assert issue.dismissed_version is None
+    assert issue.translation_placeholders == {"entry_title": "Shelly Cloud"}
+
+
+async def test_missing_devices_wrapper_creates_expected_issue(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    """The missing-devices wrapper renders count + formatted id list."""
+    missing = {"3494546e1f2a", "3494546e1f2b"}
+    names = {"3494546e1f2a": "Wohnzimmer"}
+
+    async_manage_missing_devices_issue(
+        hass, entry, active=True, missing=missing, names=names
+    )
+
+    reg = ir.async_get(hass)
+    iid = issue_id(ISSUE_MISSING_DEVICES, entry.entry_id)
+    issue = reg.async_get_issue(DOMAIN, iid)
+
+    assert issue is not None
+    assert issue.issue_id == f"missing_devices_{entry.entry_id}"
+    assert issue.translation_key == ISSUE_MISSING_DEVICES
+    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.is_fixable is False
+    assert issue.is_persistent is False
+    assert issue.translation_placeholders == {
+        "entry_title": "Shelly Cloud",
+        "count": "2",
+        "device_ids": format_device_list(missing, names),
+    }
+    # The rendered list is what the user actually reads.
+    assert (
+        issue.translation_placeholders["device_ids"]
+        == "Wohnzimmer (3494546e1f2a), 3494546e1f2b"
+    )
+
+
+async def test_history_import_wrapper_creates_expected_issue(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    """The historical-import wrapper writes a real, correct issue."""
+    async_manage_history_import_issue(hass, entry, active=True)
+
+    reg = ir.async_get(hass)
+    iid = issue_id(ISSUE_HISTORY_IMPORT_FAILED, entry.entry_id)
+    issue = reg.async_get_issue(DOMAIN, iid)
+
+    assert issue is not None
+    assert issue.issue_id == f"history_import_failed_{entry.entry_id}"
+    assert issue.translation_key == ISSUE_HISTORY_IMPORT_FAILED
+    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.is_fixable is False
+    assert issue.is_persistent is False
+    assert issue.translation_placeholders == {"entry_title": "Shelly Cloud"}
+
+
+async def test_issue_ids_are_namespaced_per_entry(
+    hass: HomeAssistant, entry: MockConfigEntry, other_entry: MockConfigEntry
+) -> None:
+    """Two accounts raise two distinct cards, not one clobbered card."""
+    async_manage_rate_limit_issue(hass, entry, active=True)
+    async_manage_rate_limit_issue(hass, other_entry, active=True)
+
+    reg = ir.async_get(hass)
+    first = reg.async_get_issue(
+        DOMAIN, issue_id(ISSUE_RATE_LIMITED, entry.entry_id)
+    )
+    second = reg.async_get_issue(
+        DOMAIN, issue_id(ISSUE_RATE_LIMITED, other_entry.entry_id)
+    )
+    assert first is not None and second is not None
+    assert first.issue_id != second.issue_id
+    assert first.translation_placeholders["entry_title"] == "Shelly Cloud"
+    assert second.translation_placeholders["entry_title"] == "Second Account"
+
+
+# ── 2. THE CORE CLAIM: repeated calls do not churn ────────────────────
+
+
+@pytest.mark.parametrize("polls", [2, 20])
+async def test_repeated_rate_limit_calls_do_not_churn(
+    hass: HomeAssistant, entry: MockConfigEntry, events: list, polls: int
+) -> None:
+    """Re-raising an unchanged issue fires exactly one create, ever.
+
+    This is what licenses calling the wrapper unconditionally from every
+    poll instead of guarding it with an ``_issue_raised`` boolean.
+    """
+    async_manage_rate_limit_issue(hass, entry, active=True)
+    await hass.async_block_till_done()
+
+    reg = ir.async_get(hass)
+    iid = issue_id(ISSUE_RATE_LIMITED, entry.entry_id)
+    first = reg.async_get_issue(DOMAIN, iid)
+    assert _actions(events) == ["create"]
+
+    for _ in range(polls):
+        async_manage_rate_limit_issue(hass, entry, active=True)
+    await hass.async_block_till_done()
+
+    again = reg.async_get_issue(DOMAIN, iid)
+    # Same object — async_get_or_create did not even build a replacement.
+    assert again is first
+    assert again.created == first.created
+    # And no further registry traffic: no update events at all.
+    assert _actions(events) == ["create"]
+
+
+async def test_repeated_missing_devices_calls_do_not_churn(
+    hass: HomeAssistant, entry: MockConfigEntry, events: list
+) -> None:
+    """An unchanged missing set re-raised 20x stays one create."""
+    missing = {"aaaa", "bbbb"}
+    for _ in range(20):
+        async_manage_missing_devices_issue(
+            hass, entry, active=True, missing=missing, names={}
+        )
+    await hass.async_block_till_done()
+
+    assert _actions(events) == ["create"]
+
+
+async def test_missing_devices_set_change_updates_in_place(
+    hass: HomeAssistant, entry: MockConfigEntry, events: list
+) -> None:
+    """A CHANGED missing set updates once — never delete-then-create.
+
+    A delete+create would reset the user's Ignore; an update preserves it.
+    """
+    async_manage_missing_devices_issue(
+        hass, entry, active=True, missing={"aaaa"}, names={}
+    )
+    await hass.async_block_till_done()
+
+    async_manage_missing_devices_issue(
+        hass, entry, active=True, missing={"aaaa", "bbbb"}, names={}
+    )
+    await hass.async_block_till_done()
+
+    assert _actions(events) == ["create", "update"]
+    assert "remove" not in _actions(events)
+
+    reg = ir.async_get(hass)
+    issue = reg.async_get_issue(
+        DOMAIN, issue_id(ISSUE_MISSING_DEVICES, entry.entry_id)
+    )
+    assert issue.translation_placeholders["count"] == "2"
+
+
+async def test_repeated_history_import_calls_do_not_churn(
+    hass: HomeAssistant, entry: MockConfigEntry, events: list
+) -> None:
+    """The historical-import wrapper is idempotent too."""
+    for _ in range(20):
+        async_manage_history_import_issue(hass, entry, active=True)
+    await hass.async_block_till_done()
+
+    assert _actions(events) == ["create"]
+
+
+# ── 3. THE DISMISSAL CLAIM (the one that matters most) ────────────────
+
+
+@pytest.mark.parametrize(
+    ("raise_issue", "kind"),
+    [
+        (
+            lambda hass, entry: async_manage_rate_limit_issue(
+                hass, entry, active=True
+            ),
+            ISSUE_RATE_LIMITED,
+        ),
+        (
+            lambda hass, entry: async_manage_missing_devices_issue(
+                hass, entry, active=True, missing={"aaaa"}, names={}
+            ),
+            ISSUE_MISSING_DEVICES,
+        ),
+        (
+            lambda hass, entry: async_manage_history_import_issue(
+                hass, entry, active=True
+            ),
+            ISSUE_HISTORY_IMPORT_FAILED,
+        ),
+    ],
+    ids=["rate_limited", "missing_devices", "history_import_failed"],
+)
+async def test_user_dismissal_survives_further_polls(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    events: list,
+    raise_issue,
+    kind: str,
+) -> None:
+    """Ignoring a card must stick even though every poll re-raises it.
+
+    If this fails, ``repair_issues.py`` needs its guard booleans back.
+    """
+    raise_issue(hass, entry)
+    await hass.async_block_till_done()
+
+    reg = ir.async_get(hass)
+    iid = issue_id(kind, entry.entry_id)
+
+    # The user clicks "Ignore" in the Repairs panel.
+    ir.async_ignore_issue(hass, DOMAIN, iid, True)
+    await hass.async_block_till_done()
+
+    dismissed = reg.async_get_issue(DOMAIN, iid)
+    assert dismissed.dismissed_version == HA_VERSION
+    events.clear()
+
+    # ~100 more polls with the condition still active.
+    for _ in range(100):
+        raise_issue(hass, entry)
+    await hass.async_block_till_done()
+
+    still = reg.async_get_issue(DOMAIN, iid)
+    assert still is not None
+    assert still.dismissed_version == HA_VERSION, (
+        "re-raising the issue destroyed the user's Ignore — "
+        "the no-guard design in repair_issues.py is invalid"
+    )
+    assert still.created == dismissed.created
+    assert _actions(events) == []
+
+
+async def test_dismissal_survives_a_changing_missing_set(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    """Even a placeholder-changing re-raise keeps the dismissal.
+
+    This is the case the docstring on ``async_manage_missing_devices_issue``
+    warns about: a delete-then-create here would silently un-ignore.
+    """
+    async_manage_missing_devices_issue(
+        hass, entry, active=True, missing={"aaaa"}, names={}
+    )
+    await hass.async_block_till_done()
+
+    iid = issue_id(ISSUE_MISSING_DEVICES, entry.entry_id)
+    ir.async_ignore_issue(hass, DOMAIN, iid, True)
+    await hass.async_block_till_done()
+
+    async_manage_missing_devices_issue(
+        hass, entry, active=True, missing={"aaaa", "bbbb", "cccc"}, names={}
+    )
+    await hass.async_block_till_done()
+
+    reg = ir.async_get(hass)
+    issue = reg.async_get_issue(DOMAIN, iid)
+    assert issue.dismissed_version == HA_VERSION
+    assert issue.translation_placeholders["count"] == "3"
+
+
+async def test_dismissal_does_not_survive_a_genuine_clear_and_reraise(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    """Deleting genuinely resets the dismissal — the intended semantics.
+
+    The condition resolving and then recurring later is a NEW event and
+    should show the user a fresh card.
+    """
+    async_manage_rate_limit_issue(hass, entry, active=True)
+    iid = issue_id(ISSUE_RATE_LIMITED, entry.entry_id)
+    ir.async_ignore_issue(hass, DOMAIN, iid, True)
+    await hass.async_block_till_done()
+
+    async_manage_rate_limit_issue(hass, entry, active=False)
+    async_manage_rate_limit_issue(hass, entry, active=True)
+    await hass.async_block_till_done()
+
+    reg = ir.async_get(hass)
+    assert reg.async_get_issue(DOMAIN, iid).dismissed_version is None
+
+
+# ── 4. active=False deletes; deleting nothing is a no-op ──────────────
+
+
+@pytest.mark.parametrize(
+    ("raise_issue", "clear_issue", "kind"),
+    [
+        (
+            lambda hass, entry: async_manage_rate_limit_issue(
+                hass, entry, active=True
+            ),
+            lambda hass, entry: async_manage_rate_limit_issue(
+                hass, entry, active=False
+            ),
+            ISSUE_RATE_LIMITED,
+        ),
+        (
+            lambda hass, entry: async_manage_missing_devices_issue(
+                hass, entry, active=True, missing={"aaaa"}, names={}
+            ),
+            lambda hass, entry: async_manage_missing_devices_issue(
+                hass, entry, active=False, missing=set(), names={}
+            ),
+            ISSUE_MISSING_DEVICES,
+        ),
+        (
+            lambda hass, entry: async_manage_history_import_issue(
+                hass, entry, active=True
+            ),
+            lambda hass, entry: async_manage_history_import_issue(
+                hass, entry, active=False
+            ),
+            ISSUE_HISTORY_IMPORT_FAILED,
+        ),
+    ],
+    ids=["rate_limited", "missing_devices", "history_import_failed"],
+)
+async def test_inactive_deletes_and_repeat_delete_is_a_noop(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    events: list,
+    raise_issue,
+    clear_issue,
+    kind: str,
+) -> None:
+    """``active=False`` removes the card; deleting again does not raise."""
+    reg = ir.async_get(hass)
+    iid = issue_id(kind, entry.entry_id)
+
+    # Deleting before anything was ever raised must be a silent no-op.
+    clear_issue(hass, entry)
+    await hass.async_block_till_done()
+    assert reg.async_get_issue(DOMAIN, iid) is None
+    assert _actions(events) == []
+
+    raise_issue(hass, entry)
+    clear_issue(hass, entry)
+    await hass.async_block_till_done()
+    assert reg.async_get_issue(DOMAIN, iid) is None
+    assert _actions(events) == ["create", "remove"]
+
+    # And again, on an id that is now gone.
+    events.clear()
+    for _ in range(5):
+        clear_issue(hass, entry)
+    await hass.async_block_till_done()
+    assert _actions(events) == []
+
+
+# ── 5. async_clear_entry_issues is entry-scoped ───────────────────────
+
+
+async def test_clear_entry_issues_removes_only_this_entry(
+    hass: HomeAssistant, entry: MockConfigEntry, other_entry: MockConfigEntry
+) -> None:
+    """Unloading one account must not wipe the other account's cards."""
+    for target in (entry, other_entry):
+        async_manage_rate_limit_issue(hass, target, active=True)
+        async_manage_missing_devices_issue(
+            hass, target, active=True, missing={"aaaa"}, names={}
+        )
+        async_manage_history_import_issue(hass, target, active=True)
+    await hass.async_block_till_done()
+
+    reg = ir.async_get(hass)
+    kinds = (
+        ISSUE_RATE_LIMITED,
+        ISSUE_MISSING_DEVICES,
+        ISSUE_HISTORY_IMPORT_FAILED,
+    )
+    assert len(reg.issues) == 6
+
+    async_clear_entry_issues(hass, entry)
+    await hass.async_block_till_done()
+
+    for kind in kinds:
+        assert (
+            reg.async_get_issue(DOMAIN, issue_id(kind, entry.entry_id))
+            is None
+        )
+        assert (
+            reg.async_get_issue(DOMAIN, issue_id(kind, other_entry.entry_id))
+            is not None
+        )
+    assert len(reg.issues) == 3
+
+
+async def test_clear_entry_issues_on_a_clean_entry_is_a_noop(
+    hass: HomeAssistant, entry: MockConfigEntry, events: list
+) -> None:
+    """A setup that never raised anything unloads without registry traffic."""
+    async_clear_entry_issues(hass, entry)
+    await hass.async_block_till_done()
+
+    assert ir.async_get(hass).issues == {}
+    assert _actions(events) == []


### PR DESCRIPTION
Adds three **informational** repair issues for the shipped polling path. All are derived from data the coordinator already polls — no extra cloud requests against the 1 req/s budget.

| Repair | Raised after | Clears when |
|---|---|---|
| `rate_limited` | 5 consecutive rate-limited polls **and** ≥120 s | first poll that gets through |
| `missing_devices` | 10 polls **and** 24 h of continuous absence | device reports again, or selection re-saved |
| `history_import_failed` | 2 unproductive syncs | next sync that imports something, or URL cleared |

### Why
Shelly signals its rate limit as **HTTP 401 with `max_req` in the body** — the same status code a rejected key produces. A chronic rate limit and a dead `auth_key` therefore looked identical to the user (everything unavailable). That is what made issue #9's predecessor #6 confusing, and the card now says explicitly that the cloud key is *not* the problem.

The other two states failed silently: a selected device the cloud never reports produced no entities and no feedback, and the historical-energy sync failed once and then stayed quiet forever.

### Not noisy by design
Thresholds are deliberately slow so an ordinary cloud hiccup, a rebooting BLU gateway or a firmware update never raise a card. A mass-absence guard mirrors `detect_orphans`' floors, so an account- or server-side outage is never reported as "your devices were sold".

### Filename note
The module is `repair_issues.py`, **not** `repairs.py`. On HA 2025.1.4 (oldest supported) a `repairs.py` lacking `async_create_fix_flow` makes `_register_repairs_platform` raise `HomeAssistantError` during an eager scan that any *other* integration's repair can trigger. None of these three conditions is fixable by an in-process button, so no fix flow exists — and the reserved filename would be a landmine for unrelated integrations. Verified in both venvs.

### Testing
92 tests green on HA 2025.1.4/py3.12 and HA 2026.7.2/py3.14 (was 77). Designed and reviewed by parallel agents with adversarial critics on both the spec and the diff.

**Known gap:** the registry wrapper functions are stubbed in tests (asserting them needs `pytest-homeassistant-custom-component`, out of scope here), and the thresholds are argued rather than measured against a real fleet. Shipping as `0.7.0-beta1` to soak.