### PR TITLE
fix(sensor): keep deep-sleep battery devices available while they check in (#13)

### DIFF
--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -50,6 +51,35 @@ _V2_NAME_LOOKUP_GAP_S = 1.2
 # read-only virtual entities can render real names/units/options. (#9)
 _VIRTUAL_COMPONENT_KEY_RE = re.compile(r"^(number|enum|text|boolean):\d+$")
 
+# ── Deep-sleep (battery) device freshness ─────────────────────────────
+#
+# Battery devices (H&T, Flood, Door/Window, …) are awake for a few seconds
+# every ``sys.wakeup_period`` and spend the rest in deep sleep. Shelly Cloud
+# keeps serving the last snapshot such a device pushed, and that snapshot is
+# typically captured seconds after boot — before the device's cloud session
+# is up. So ``cloud.connected`` is ``false`` in it and stays false forever,
+# even though the readings it carries are current. Availability therefore
+# cannot be derived from the transport flag for these devices; it has to come
+# from "is the device still checking in?". (#13)
+#
+# Multiplier applied to ``wakeup_period`` to get the staleness window. Matches
+# ``UPDATE_PERIOD_MULTIPLIER`` in HA core's native Shelly integration, so a
+# device that misses a single check-in is still considered alive but one that
+# stops reporting altogether goes unavailable.
+SLEEP_STALE_MULTIPLIER = 2.2
+
+# Period assumed for a device that reports itself sleeping but exposes no
+# usable ``wakeup_period`` (Gen1 battery devices publish no such field).
+SLEEP_ASSUMED_PERIOD_S = 2 * 3600
+
+# Lower bound on the staleness window. Deliberately generous — briefly showing
+# a dead device as available is far less harmful than flapping a working one.
+SLEEP_STALE_FLOOR_S = 4 * 3600
+
+# Hard ceiling on the staleness window, so a device configured with an absurd
+# wakeup period cannot stay "available" indefinitely after it dies.
+SLEEP_STALE_CAP_S = 24 * 3600
+
 # Delay before the post-command status refresh (seconds). Long enough for the
 # Shelly Cloud to propagate the new state (so the poll confirms rather than
 # reverts the optimistic entity state) and to keep the command + its refresh
@@ -62,6 +92,55 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def sleep_period_s(status: dict[str, Any]) -> int:
+    """Return the deep-sleep period of ``status`` in seconds, 0 if not sleeping.
+
+    A non-zero result marks the device as a battery/deep-sleep device, which
+    is what :attr:`ShellyBaseEntity.available` keys off. Gen2/Gen3 devices
+    publish ``sys.wakeup_period``; devices that only carry the cloud's
+    ``_sleeping`` marker fall back to :data:`SLEEP_ASSUMED_PERIOD_S`.
+
+    A device running off external power is never treated as sleeping, even
+    when it still carries a ``wakeup_period`` from its battery days — it is
+    permanently connected, so the transport flag is meaningful again and an
+    offline reading means the device really is gone. (#13)
+    """
+    if not isinstance(status, dict):
+        return 0
+
+    power = status.get("devicepower:0")
+    external = power.get("external") if isinstance(power, dict) else None
+    if isinstance(external, dict) and external.get("present") is True:
+        return 0
+
+    sys_block = status.get("sys")
+    period = sys_block.get("wakeup_period") if isinstance(sys_block, dict) else None
+    if isinstance(period, (int, float)) and not isinstance(period, bool) and period > 0:
+        return int(period)
+    return SLEEP_ASSUMED_PERIOD_S if status.get("_sleeping") is True else 0
+
+
+def checkin_marker(status: dict[str, Any]) -> tuple[Any, ...]:
+    """Return the fields that change whenever the device pushes a new snapshot.
+
+    Used as a change-detection fingerprint rather than reading any of these
+    as a clock: ``ts`` can lag the rest of the payload by hours, ``_updated``
+    carries no timezone, and device clocks drift. Comparing the fingerprint
+    against the previous poll and stamping *our own* monotonic time when it
+    changes sidesteps all three. (#13)
+    """
+    if not isinstance(status, dict):
+        return ()
+    sys_block = status.get("sys") if isinstance(status.get("sys"), dict) else {}
+    return (
+        status.get("_updated"),
+        status.get("serial"),
+        sys_block.get("unixtime"),
+        sys_block.get("uptime"),
+        status.get("ts"),
+    )
+
+
 class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
     """Poll the Shelly Cloud Control API and publish device state to HA.
 
@@ -71,6 +150,8 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         {
             "status": <full status dict, including _dev_info>,
             "online": bool,
+            "sleeping": bool,
+            "sleep_stale_at": float | None,
             "device_code": str,
             "name": str | None,
         }
@@ -109,6 +190,10 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         # new devices appear; we never re-fetch already-known names (they
         # change rarely and cost rate-limit budget).
         self.device_names: dict[str, str] = {}
+        # Ids covered by a completed name lookup, including those the account
+        # has no alias for — keeps a never-renamed device from re-triggering
+        # the lookup on every poll. (#13)
+        self._names_attempted: set[str] = set()
         # Populated by ``_refresh_device_names`` when it schedules itself.
         self._name_lookup_in_flight = False
         # Cache of device_id → {component_key → v2 config dict} for Gen2/Gen3
@@ -118,6 +203,59 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self.virtual_configs: dict[str, dict[str, dict]] = {}
         # Populated by ``_refresh_virtual_configs`` when it schedules itself.
         self._vcomp_config_in_flight = False
+        # device_id → (checkin fingerprint, monotonic timestamp of the poll
+        # where that fingerprint first appeared). Drives the staleness window
+        # for deep-sleep battery devices. (#13)
+        self._sleep_seen: dict[str, tuple[tuple, float]] = {}
+
+    # ── Deep-sleep freshness bookkeeping (#13) ────────────────────────
+
+    def _evaluate_sleep_state(
+        self, device_id: str, status: dict[str, Any], now: float
+    ) -> tuple[bool, float | None]:
+        """Return ``(sleeping, stale_at)`` for one device's status snapshot.
+
+        ``sleeping`` marks a deep-sleep battery device — for those the cloud's
+        transport flag is meaningless and availability is decided by whether
+        the device is still checking in. ``stale_at`` is the monotonic
+        deadline at which the last check-in stops counting; ``None`` for
+        devices this does not apply to.
+
+        Returning a deadline rather than a boolean matters when polling breaks:
+        the entity keeps re-evaluating against its own clock, so a sleeping
+        device eventually goes unavailable during a prolonged cloud outage
+        instead of freezing on the last verdict. It also avoids tying
+        availability to ``last_update_success``, which a single transient
+        ``401 max_req`` would flip for the whole fleet at once.
+
+        ``now`` is a monotonic timestamp supplied by the caller so the whole
+        decision stays deterministic and testable.
+        """
+        period = sleep_period_s(status)
+        if not period:
+            # Mains device (or a battery device now on external power) — drop
+            # any history so it cannot leak into a later evaluation, and leave
+            # availability to ``online``.
+            self._sleep_seen.pop(device_id, None)
+            return False, None
+
+        marker = checkin_marker(status)
+        previous = self._sleep_seen.get(device_id)
+        if previous is None or previous[0] != marker:
+            # First sight, or the device pushed a new snapshot: (re)start the
+            # window. First sight counts as a check-in — we have no evidence
+            # the device is gone, and the alternative would make every battery
+            # device unavailable for one window after every HA restart.
+            self._sleep_seen[device_id] = (marker, now)
+            last_seen = now
+        else:
+            last_seen = previous[1]
+
+        window = min(
+            max(period * SLEEP_STALE_MULTIPLIER, SLEEP_STALE_FLOOR_S),
+            SLEEP_STALE_CAP_S,
+        )
+        return True, last_seen + window
 
     # ── Properties platform code may inspect ──────────────────────────
 
@@ -196,6 +334,7 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             )
 
         new_devices: dict[str, dict[str, Any]] = {}
+        now = time.monotonic()
         for device_id, status in devices_status.items():
             if not isinstance(status, dict):
                 continue
@@ -215,9 +354,18 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 cloud = status.get("cloud")
                 online = bool(cloud.get("connected")) if isinstance(cloud, dict) else False
 
+            # A deep-sleep battery device is "not connected" by construction
+            # between wakes, so its availability comes from whether it is
+            # still checking in rather than from ``online``. (#13)
+            sleeping, sleep_stale_at = self._evaluate_sleep_state(
+                device_id, status, now
+            )
+
             new_devices[device_id] = {
                 "status": status,
                 "online": online,
+                "sleeping": sleeping,
+                "sleep_stale_at": sleep_stale_at,
                 "device_code": code,
                 # Seed with whatever we already resolved via the v2 name
                 # lookup; stays None until that lookup succeeds.
@@ -239,14 +387,32 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 async_dispatcher_send(self.hass, SIGNAL_NEW_DEVICE, device_id)
         self._known_device_ids = set(new_devices)
 
+        # Forget check-in history for devices that have been absent from the
+        # poll for longer than the longest window we would ever apply, so
+        # ``_sleep_seen`` cannot grow without bound. Absence alone is not
+        # enough: ``/device/all_status`` intermittently omits devices, and
+        # dropping the history on every omission would restart the window on
+        # each reappearance — a device that flaps in and out would then never
+        # be able to go stale.
+        for gone in set(self._sleep_seen) - set(new_devices):
+            if now - self._sleep_seen[gone][1] > SLEEP_STALE_CAP_S:
+                self._sleep_seen.pop(gone, None)
+
         self.devices = new_devices
 
-        # Schedule a v2 name lookup for any device we haven't resolved yet,
-        # but only for devices currently online (v2 returns no settings
-        # for offline devices so the call is wasted on them).
+        # Schedule a name lookup for any device we haven't resolved yet.
+        # Sleeping devices are included: the lookup hits the account-wide v1
+        # alias listing, which returns aliases regardless of whether a device
+        # is currently connected — gating them out only meant battery sensors
+        # never got their Shelly-app name. Devices already covered by a
+        # completed lookup are excluded even when they came back nameless,
+        # otherwise a device the user never renamed would re-trigger the
+        # lookup on every single poll and burn the shared 1 req/s budget. (#13)
         unresolved = [
             did for did, info in new_devices.items()
-            if did not in self.device_names and info.get("online")
+            if did not in self.device_names
+            and did not in self._names_attempted
+            and (info.get("online") or info.get("sleeping"))
         ]
         if unresolved and not self._name_lookup_in_flight:
             self._name_lookup_in_flight = True
@@ -273,26 +439,33 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         return new_devices
 
     async def _refresh_device_names(self, ids: list[str]) -> None:
-        """Fetch user-set names for ``ids`` via the v2 API and cache them.
+        """Fetch the Shelly-App aliases for ``ids`` and cache them.
 
         Runs as a background task after ``_async_update_data`` completes so
         it does not delay the coordinator's next tick. Waits
         ``_V2_NAME_LOOKUP_GAP_S`` to stay under the shared 1 req/s rate
-        limit, then batches every missing id into a single v2 request.
-        Failures are logged at debug level — a missing name is not worth
-        bubbling up as an UpdateFailed.
+        limit, then covers every missing id with a single request to the
+        account-wide v1 alias listing. Failures are logged at debug level —
+        a missing name is not worth bubbling up as an UpdateFailed.
+
+        Every requested id is recorded in ``_names_attempted`` once the call
+        comes back, including the ones the account has no alias for, so a
+        never-renamed device is not looked up again on the next poll. A failed
+        call records nothing and is therefore retried. (#13)
         """
         try:
             await asyncio.sleep(_V2_NAME_LOOKUP_GAP_S)
             names = await self._api.get_device_names(ids)
         except ShellyCloudAuthError:
-            _LOGGER.debug("v2 name lookup rejected auth_key — skipping")
+            _LOGGER.debug("Device name lookup rejected auth_key — skipping")
             return
         except ShellyCloudError as err:
-            _LOGGER.debug("v2 name lookup failed: %s", err)
+            _LOGGER.debug("Device name lookup failed: %s", err)
             return
         finally:
             self._name_lookup_in_flight = False
+
+        self._names_attempted.update(ids)
 
         if not names:
             return
@@ -302,7 +475,7 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             entry = self.devices.get(did)
             if entry is not None:
                 entry["name"] = name
-        _LOGGER.info("Resolved %d device name(s) via v2 API", len(names))
+        _LOGGER.info("Resolved %d device name(s) from the cloud alias list", len(names))
 
         # Push the resolved names into the HA device registry so existing
         # DeviceEntry rows (created at integration setup with a fallback

--- a/custom_components/shelly_cloud_diy/diagnostics.py
+++ b/custom_components/shelly_cloud_diy/diagnostics.py
@@ -9,6 +9,7 @@ account's naming.
 """
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -16,6 +17,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from .const import DOMAIN
+from .coordinator import sleep_period_s
 from .services.fleet_map import compute_fleet, gather_cloud_devices, to_diagnostics
 
 if TYPE_CHECKING:
@@ -101,5 +103,28 @@ async def async_get_device_diagnostics(
         # Transparency: exactly which keys are stripped from `record` below,
         # so anyone attaching this to a bug report knows what was withheld.
         "redacted_keys": sorted(DEVICE_TO_REDACT),
+        "sleep": _sleep_diagnostics(record),
         "record": async_redact_data(record, DEVICE_TO_REDACT),
+    }
+
+
+def _sleep_diagnostics(record: dict[str, Any]) -> dict[str, Any] | None:
+    """Explain the availability verdict for a deep-sleep battery device.
+
+    The record carries ``sleep_stale_at`` as a raw monotonic timestamp, which
+    means nothing in a dump. Resolving it to "seconds left before this device
+    is considered gone" makes an availability report self-diagnosing. Returns
+    ``None`` for mains devices, where the cloud's ``online`` flag decides. (#13)
+    """
+    if not record.get("sleeping"):
+        return None
+
+    stale_at = record.get("sleep_stale_at")
+    return {
+        "wakeup_period_s": sleep_period_s(record.get("status") or {}),
+        "seconds_until_considered_gone": (
+            round(stale_at - time.monotonic(), 1)
+            if isinstance(stale_at, (int, float))
+            else None
+        ),
     }

--- a/custom_components/shelly_cloud_diy/entities/base.py
+++ b/custom_components/shelly_cloud_diy/entities/base.py
@@ -199,5 +199,24 @@ class ShellyBaseEntity(CoordinatorEntity["ShellyCloudCoordinator"]):
 
     @property
     def available(self) -> bool:
-        """Return if entity is available."""
-        return self.device_data.get("online", False)
+        """Return if entity is available.
+
+        Normally this is the cloud's transport flag. Deep-sleep battery
+        devices are the exception: they are awake only a few seconds per
+        wakeup period, and the snapshot Shelly Cloud caches for them is
+        captured seconds after boot — before the cloud session is up — so
+        their ``cloud.connected`` reads ``false`` permanently while the
+        readings in that very snapshot are current. For those devices the
+        coordinator stamps a deadline for the last check-in, and staying
+        available means still being inside it. Same contract as the native
+        Shelly integration in HA core. (#13)
+        """
+        device_data = self.device_data
+        if device_data.get("online", False):
+            return True
+        if not device_data.get("sleeping"):
+            return False
+        stale_at = device_data.get("sleep_stale_at")
+        if not isinstance(stale_at, (int, float)):
+            return True
+        return time.monotonic() < stale_at

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.9"
+  "version": "0.6.10-beta1"
 }

--- a/tests/test_sleeping_availability.py
+++ b/tests/test_sleeping_availability.py
@@ -1,0 +1,432 @@
+"""Unit tests for deep-sleep device availability (issue #13).
+
+A battery device (Shelly H&T Gen3 and friends) is awake for a few seconds per
+``sys.wakeup_period`` and asleep the rest of the time. Shelly Cloud keeps
+serving the last snapshot such a device pushed, and that snapshot is captured
+seconds after boot — before the device's cloud session is established — so it
+carries ``cloud.connected: false`` permanently while the readings inside it
+are current. Deriving availability from that flag made every H&T unavailable
+forever after an OTA update changed the firmware's boot timing.
+
+These tests pin the replacement contract: sleeping devices stay available
+while they keep checking in, and go unavailable once they stop. They exercise
+the real production code — ``sleep_period_s``, ``checkin_marker``,
+``ShellyCloudCoordinator._evaluate_sleep_state``, the record written by
+``_async_update_data`` and ``ShellyBaseEntity.available`` — with a lightweight
+fake coordinator and a fake API, so no running Home Assistant instance is
+required and they behave identically against any HA version.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.shelly_cloud_diy.coordinator import (
+    SLEEP_ASSUMED_PERIOD_S,
+    SLEEP_STALE_CAP_S,
+    SLEEP_STALE_FLOOR_S,
+    SLEEP_STALE_MULTIPLIER,
+    ShellyCloudCoordinator,
+    checkin_marker,
+    sleep_period_s,
+)
+from custom_components.shelly_cloud_diy.entities.base import ShellyBaseEntity
+
+DEVICE_ID = "907069591dc4"
+MAINS_ID = "aabbccddeeff"
+
+# Window the H&T's 7200 s wakeup period produces: 15840 s, above the 4 h floor.
+HT_WINDOW = 7200 * SLEEP_STALE_MULTIPLIER
+
+# Redacted status of the H&T Gen3 from issue #13, trimmed to the fields the
+# availability path reads. Note the combination that caused the bug: every
+# transport flag false, ``uptime: 4`` right after a deep-sleep wake, and
+# perfectly current readings in the same payload.
+HT_GEN3_STATUS: dict[str, Any] = {
+    "id": DEVICE_ID,
+    "code": "S3SN-0U12A",
+    "cloud": {"connected": False},
+    "ws": {"connected": False},
+    "mqtt": {"connected": False},
+    "wifi": {"status": "got ip", "rssi": -33},
+    "temperature:0": {"id": 0, "tC": 24.6, "tF": 76.4},
+    "humidity:0": {"id": 0, "rh": 43},
+    "devicepower:0": {"battery": {"V": 6.12, "percent": 100}, "external": {"present": False}},
+    "sys": {
+        "unixtime": 1785659343,
+        "uptime": 4,
+        "wakeup_period": 7200,
+        "wakeup_reason": {"boot": "deepsleep_wake", "cause": "periodic"},
+    },
+    "ts": 1785589264.33,
+    "serial": 1785659343,
+    "_updated": "2026-08-02 08:29:04",
+    "_sleeping": True,
+}
+
+# What a mains-powered device looks like while genuinely disconnected: no
+# wakeup period, no sleeping marker. Must stay unavailable.
+MAINS_OFFLINE_STATUS: dict[str, Any] = {
+    "id": MAINS_ID,
+    "code": "SNSW-001X16EU",
+    "cloud": {"connected": False},
+    "switch:0": {"id": 0, "output": False},
+    "sys": {"unixtime": 1785659343, "uptime": 98123},
+    "_updated": "2026-08-02 08:29:04",
+}
+
+
+def _pushed(status: dict[str, Any], unixtime: int = 1785666543) -> dict[str, Any]:
+    """Return ``status`` as it looks after the device pushed a new snapshot."""
+    return {
+        **status,
+        "sys": {**status["sys"], "unixtime": unixtime, "uptime": 3},
+        "serial": unixtime,
+        "_updated": "2026-08-02 10:29:03",
+    }
+
+
+def _coordinator() -> ShellyCloudCoordinator:
+    """A coordinator with only the sleep bookkeeping wired up.
+
+    ``__init__`` needs a HomeAssistant instance and a config entry; the sleep
+    evaluation needs neither, so bypass it rather than mock all of HA.
+    """
+    coord = object.__new__(ShellyCloudCoordinator)
+    coord._sleep_seen = {}
+    return coord
+
+
+class _FakeCoordinator:
+    """Minimal coordinator: the base entity only reads ``.devices[id]``."""
+
+    def __init__(self, device_id: str, entry: dict[str, Any]) -> None:
+        self.devices = {device_id: entry}
+        self.data = self.devices
+        self.last_update_success = True
+
+
+def _entity(**entry: Any) -> ShellyBaseEntity:
+    """Build a real base entity over a device record with the given keys."""
+    record: dict[str, Any] = {
+        "status": HT_GEN3_STATUS,
+        "device_code": "S3SN-0U12A",
+        "name": None,
+        **entry,
+    }
+    return ShellyBaseEntity(_FakeCoordinator(DEVICE_ID, record), DEVICE_ID)
+
+
+# ── sleep_period_s ────────────────────────────────────────────────────
+
+
+def test_sleep_period_reads_wakeup_period() -> None:
+    assert sleep_period_s(HT_GEN3_STATUS) == 7200
+
+
+def test_sleep_period_zero_for_mains_device() -> None:
+    assert sleep_period_s(MAINS_OFFLINE_STATUS) == 0
+
+
+def test_sleep_period_falls_back_for_sleeping_marker_only() -> None:
+    """Gen1 battery devices carry no wakeup_period, only the cloud marker."""
+    status = {"cloud": {"connected": False}, "_sleeping": True}
+    assert sleep_period_s(status) == SLEEP_ASSUMED_PERIOD_S
+
+
+def test_externally_powered_device_is_not_sleeping() -> None:
+    """A battery device on USB power stays connected — the flag is honest again."""
+    status = {
+        **HT_GEN3_STATUS,
+        "devicepower:0": {"battery": {"percent": 100}, "external": {"present": True}},
+    }
+    assert sleep_period_s(status) == 0
+
+
+@pytest.mark.parametrize(
+    "period",
+    [0, -1, None, "7200", True, False, {"secs": 7200}],
+)
+def test_sleep_period_rejects_unusable_wakeup_values(period: Any) -> None:
+    """A bogus wakeup_period must not be mistaken for a sleeping device.
+
+    ``True`` is the interesting one: it is an ``int`` subclass in Python and
+    would otherwise pass as a 1-second period.
+    """
+    status = {"sys": {"wakeup_period": period}}
+    assert sleep_period_s(status) == 0
+
+
+def test_sleep_period_survives_garbage_status() -> None:
+    assert sleep_period_s({}) == 0
+    assert sleep_period_s({"sys": "not-a-dict"}) == 0
+    assert sleep_period_s({"devicepower:0": "not-a-dict", "_sleeping": True}) == (
+        SLEEP_ASSUMED_PERIOD_S
+    )
+    assert sleep_period_s(None) == 0  # type: ignore[arg-type]
+
+
+# ── checkin_marker ────────────────────────────────────────────────────
+
+
+def test_checkin_marker_ignores_fields_that_are_not_check_ins() -> None:
+    """Only a real push must move the fingerprint — not a changed reading.
+
+    Shelly Cloud re-serves the cached snapshot verbatim between wakes, so a
+    marker that keyed off measurement values would never settle.
+    """
+    same_device_new_reading = {**HT_GEN3_STATUS, "temperature:0": {"id": 0, "tC": 25.9}}
+    assert checkin_marker(same_device_new_reading) == checkin_marker(HT_GEN3_STATUS)
+
+
+def test_checkin_marker_changes_when_the_device_pushes_again() -> None:
+    assert checkin_marker(_pushed(HT_GEN3_STATUS)) != checkin_marker(HT_GEN3_STATUS)
+
+
+def test_checkin_marker_survives_garbage_status() -> None:
+    assert checkin_marker({"sys": "not-a-dict"}) == (None, None, None, None, None)
+    assert checkin_marker(None) == ()  # type: ignore[arg-type]
+
+
+# ── _evaluate_sleep_state ─────────────────────────────────────────────
+
+
+def test_first_sight_of_a_sleeping_device_starts_the_window() -> None:
+    """No history is not evidence of death — and an HA restart clears it."""
+    coord = _coordinator()
+    sleeping, stale_at = coord._evaluate_sleep_state(DEVICE_ID, HT_GEN3_STATUS, 1000.0)
+    assert sleeping is True
+    assert stale_at == pytest.approx(1000.0 + HT_WINDOW)
+
+
+def test_deadline_does_not_move_while_the_device_stays_silent() -> None:
+    """Re-polling the same cached snapshot must not extend the window."""
+    coord = _coordinator()
+    _, first = coord._evaluate_sleep_state(DEVICE_ID, HT_GEN3_STATUS, 1000.0)
+
+    for offset in (5.0, 3600.0, HT_WINDOW - 1.0, HT_WINDOW + 1.0):
+        sleeping, stale_at = coord._evaluate_sleep_state(
+            DEVICE_ID, HT_GEN3_STATUS, 1000.0 + offset
+        )
+        assert sleeping is True
+        assert stale_at == first, offset
+
+
+def test_a_new_check_in_resets_the_window() -> None:
+    coord = _coordinator()
+    coord._evaluate_sleep_state(DEVICE_ID, HT_GEN3_STATUS, 1000.0)
+
+    # Device checks in just before it would have expired…
+    checkin_at = 1000.0 + HT_WINDOW - 10.0
+    _, stale_at = coord._evaluate_sleep_state(
+        DEVICE_ID, _pushed(HT_GEN3_STATUS), checkin_at
+    )
+    # …so the window now runs from there, not from the original sighting.
+    assert stale_at == pytest.approx(checkin_at + HT_WINDOW)
+
+
+def test_window_is_never_shorter_than_the_floor() -> None:
+    """A 10-minute wakeup period must not produce a 22-minute window."""
+    coord = _coordinator()
+    status = {**HT_GEN3_STATUS, "sys": {**HT_GEN3_STATUS["sys"], "wakeup_period": 600}}
+
+    _, stale_at = coord._evaluate_sleep_state(DEVICE_ID, status, 0.0)
+    assert stale_at == pytest.approx(SLEEP_STALE_FLOOR_S)
+
+
+def test_window_is_capped() -> None:
+    """An absurd wakeup period must not keep a dead device alive forever."""
+    coord = _coordinator()
+    status = {
+        **HT_GEN3_STATUS,
+        "sys": {**HT_GEN3_STATUS["sys"], "wakeup_period": 30 * 24 * 3600},
+    }
+
+    _, stale_at = coord._evaluate_sleep_state(DEVICE_ID, status, 0.0)
+    assert stale_at == pytest.approx(SLEEP_STALE_CAP_S)
+
+
+def test_mains_device_is_never_treated_as_sleeping() -> None:
+    coord = _coordinator()
+    assert coord._evaluate_sleep_state(MAINS_ID, MAINS_OFFLINE_STATUS, 0.0) == (
+        False,
+        None,
+    )
+    assert MAINS_ID not in coord._sleep_seen
+
+
+def test_history_is_dropped_when_a_device_stops_sleeping() -> None:
+    """A battery device switched to external power must not keep stale history."""
+    coord = _coordinator()
+    coord._evaluate_sleep_state(DEVICE_ID, HT_GEN3_STATUS, 0.0)
+    assert DEVICE_ID in coord._sleep_seen
+
+    powered = {
+        **HT_GEN3_STATUS,
+        "devicepower:0": {"battery": {"percent": 100}, "external": {"present": True}},
+    }
+    assert coord._evaluate_sleep_state(DEVICE_ID, powered, 1.0) == (False, None)
+    assert DEVICE_ID not in coord._sleep_seen
+
+
+# ── _async_update_data: the record the entities actually read ─────────
+
+
+class _FakeApi:
+    """Stands in for ShellyCloudControl: serves a canned all-status payload."""
+
+    def __init__(self, devices_status: dict[str, Any]) -> None:
+        self._devices_status = devices_status
+        self.name_lookups: list[list[str]] = []
+
+    async def get_all_status(self) -> dict[str, Any]:
+        return {"devices_status": self._devices_status}
+
+
+class _StubHass:
+    """Captures background tasks instead of running them."""
+
+    def __init__(self) -> None:
+        self.tasks: list[Any] = []
+
+    def async_create_task(self, coro: Any) -> None:
+        self.tasks.append(coro)
+        coro.close()  # never awaited — keep asyncio from warning about it
+
+
+def _live_coordinator(devices_status: dict[str, Any]) -> ShellyCloudCoordinator:
+    """A coordinator whose real ``_async_update_data`` can be driven."""
+    coord = object.__new__(ShellyCloudCoordinator)
+    coord._api = _FakeApi(devices_status)
+    coord.hass = _StubHass()
+    # No device is opted in, so the poll never dispatches SIGNAL_NEW_DEVICE
+    # (which would need a real HA dispatcher).
+    coord._entry = SimpleNamespace(options={"enabled_devices": []})
+    coord.devices = {}
+    coord._known_device_ids = set()
+    coord.device_names = {}
+    coord._names_attempted = set()
+    coord._name_lookup_in_flight = False
+    coord.virtual_configs = {}
+    coord._vcomp_config_in_flight = False
+    coord._sleep_seen = {}
+    return coord
+
+
+def test_poll_writes_the_sleep_keys_into_the_device_record() -> None:
+    """The seam the fix hangs on: without these keys the bug is back."""
+    coord = _live_coordinator(
+        {DEVICE_ID: HT_GEN3_STATUS, MAINS_ID: MAINS_OFFLINE_STATUS}
+    )
+    before = time.monotonic()
+    devices = asyncio.run(coord._async_update_data())
+
+    ht = devices[DEVICE_ID]
+    assert ht["online"] is False, "the cloud really does report it as offline"
+    assert ht["sleeping"] is True
+    assert ht["sleep_stale_at"] >= before + HT_WINDOW
+
+    mains = devices[MAINS_ID]
+    assert mains["online"] is False
+    assert mains["sleeping"] is False
+    assert mains["sleep_stale_at"] is None
+
+
+def test_poll_result_makes_a_sleeping_entity_available() -> None:
+    """End to end: cloud payload → record → entity availability."""
+    coord = _live_coordinator({DEVICE_ID: HT_GEN3_STATUS})
+    devices = asyncio.run(coord._async_update_data())
+
+    entity = ShellyBaseEntity(_FakeCoordinator(DEVICE_ID, devices[DEVICE_ID]), DEVICE_ID)
+    assert entity.available is True
+
+
+def test_name_lookup_covers_sleeping_devices_but_only_once() -> None:
+    """Sleeping devices need the alias lookup — and must not re-fire per poll.
+
+    The lookup shares the account's 1 req/s budget, so a device the user never
+    renamed would otherwise burn one request on every single poll.
+    """
+    coord = _live_coordinator({DEVICE_ID: HT_GEN3_STATUS})
+
+    asyncio.run(coord._async_update_data())
+    assert len(coord.hass.tasks) == 1, "sleeping device must be looked up"
+
+    # Simulate the lookup completing without finding an alias for it.
+    coord._name_lookup_in_flight = False
+    coord._names_attempted.add(DEVICE_ID)
+
+    asyncio.run(coord._async_update_data())
+    assert len(coord.hass.tasks) == 1, "nameless device must not be re-fetched"
+
+
+def test_check_in_history_survives_a_device_missing_from_one_poll() -> None:
+    """/device/all_status intermittently omits devices; that must not reset
+    the window, or a flapping device could never go stale."""
+    coord = _live_coordinator({DEVICE_ID: HT_GEN3_STATUS})
+    devices = asyncio.run(coord._async_update_data())
+    first_deadline = devices[DEVICE_ID]["sleep_stale_at"]
+
+    coord._api._devices_status = {}  # device omitted from this poll
+    asyncio.run(coord._async_update_data())
+    assert DEVICE_ID in coord._sleep_seen
+
+    coord._api._devices_status = {DEVICE_ID: HT_GEN3_STATUS}  # …and back
+    devices = asyncio.run(coord._async_update_data())
+    assert devices[DEVICE_ID]["sleep_stale_at"] == first_deadline
+
+
+# ── ShellyBaseEntity.available ────────────────────────────────────────
+
+
+def _future() -> float:
+    return time.monotonic() + 3600.0
+
+
+def _past() -> float:
+    return time.monotonic() - 1.0
+
+
+def test_available_when_cloud_reports_online() -> None:
+    assert _entity(online=True, sleeping=False, sleep_stale_at=None).available is True
+
+
+def test_online_short_circuits_regardless_of_sleep_state() -> None:
+    """An awake battery device is available even past its staleness window."""
+    assert _entity(online=True, sleeping=True, sleep_stale_at=_past()).available is True
+
+
+def test_sleeping_and_fresh_is_available_despite_offline_cloud_flag() -> None:
+    """The regression from #13: this used to report unavailable."""
+    assert _entity(online=False, sleeping=True, sleep_stale_at=_future()).available is True
+
+
+def test_sleeping_but_stale_is_unavailable() -> None:
+    assert _entity(online=False, sleeping=True, sleep_stale_at=_past()).available is False
+
+
+def test_offline_mains_device_stays_unavailable() -> None:
+    assert _entity(online=False, sleeping=False, sleep_stale_at=None).available is False
+
+
+def test_record_without_sleep_keys_behaves_as_before() -> None:
+    """Records written before this change (or by other code paths) must not
+    accidentally become available."""
+    assert _entity(online=False).available is False
+    assert _entity(online=True).available is True
+
+
+def test_sleeping_without_a_deadline_is_available() -> None:
+    """Defensive: a malformed deadline must fail open, not hide a live sensor."""
+    assert _entity(online=False, sleeping=True).available is True
+    assert _entity(online=False, sleeping=True, sleep_stale_at=None).available is True
+
+
+def test_unknown_device_is_unavailable() -> None:
+    """``device_data`` returns {} for a device that vanished from the poll."""
+    entity = ShellyBaseEntity(_FakeCoordinator("someone-else", {}), DEVICE_ID)
+    assert entity.available is False


### PR DESCRIPTION
Fixes #13 — a Shelly H&T Gen3 that went permanently unavailable after an OTA update, while the Shelly app still showed it alive and the cloud snapshot carried current readings.

## Root cause

Entity availability came straight from the cloud's transport flag: the coordinator derives `online` from `status.cloud.connected`, and `ShellyBaseEntity.available` returned it verbatim.

For a deep-sleep battery device that flag is meaningless. The device is awake for a few seconds every `wakeup_period`, and Shelly Cloud re-serves the last snapshot it pushed. That snapshot is captured seconds after boot — the reporter's shows `sys.uptime: 4` and `wakeup_reason: {boot: deepsleep_wake}`, with WiFi already up at -33 dBm but `cloud`, `ws` and `mqtt` all disconnected. So `cloud.connected` reads false and stays false forever, while the very same record carries 24.6 °C, 43 % RH and battery 100 %.

The OTA changed only *when* in the boot sequence the firmware pushes its status. Nothing changed in the integration — `git log -S` shows no availability change between v0.6.0 and v0.6.9.

## Fix

Deep-sleep devices are identified by `sys.wakeup_period` (or the cloud's `_sleeping` marker) and stay available while they keep checking in.

* **Check-in detection** fingerprints the fields that move on a push (`_updated`, `serial`, `sys.unixtime`, `sys.uptime`, `ts`) and stamps our own monotonic clock when the fingerprint changes. None of those fields is usable as a clock on its own — the reporter's `ts` lags the rest of his payload by 19.5 h, `_updated` carries no timezone, device clocks drift.
* **Window** is `2.2 × wakeup_period`, clamped to 4–24 h. The multiplier matches `UPDATE_PERIOD_MULTIPLIER` in HA core's native Shelly integration, so a device that misses one check-in survives and one that dies goes unavailable.
* **A deadline, not a boolean**, is published to the entities, so they re-evaluate against their own clock and a sleeping device still goes unavailable during a prolonged cloud outage instead of freezing on the last verdict. Availability is deliberately *not* tied to `last_update_success` — one transient `401 max_req` would otherwise flip the whole fleet at once.

## Blast radius

Mains devices are untouched: with no wakeup period and no sleeping marker, the old `online` path decides, unchanged. A battery device on external power counts as mains — it stays connected, so its transport flag is honest again. `entities/base.py` is the single choke point; no entity class overrides `available` or sets `_attr_available`.

## Fixed alongside (same wrong assumption)

* The Shelly-app alias lookup was gated on `online`, so a battery device never got its name and fell back to the model label (visible in the report as `"name": null`). It hits the account-wide v1 alias listing, which does not care whether a device is connected. Requested ids are now recorded once the call returns — including ones with no alias — so a never-renamed device cannot re-trigger the lookup on every poll and burn the shared 1 req/s budget. That was a latent bug for online devices too.
* Device diagnostics resolve the staleness deadline to `seconds_until_considered_gone`, so a future availability report explains itself.

## Verification

* 57 tests green in both dev environments (py3.12 / HA 2025.1.4 and py3.14 / HA latest).
* New `tests/test_sleeping_availability.py` uses the reporter's redacted payload as its fixture and covers the classifier, the fingerprint, the window (floor, cap, reset-on-check-in), the record `_async_update_data` actually writes, the end-to-end entity verdict, and the regression guards — offline mains device stays unavailable, externally powered device is not sleeping, a device omitted from one poll keeps its window, nameless lookup fires once.
* Not yet confirmed on hardware — shipping as `v0.6.10-beta1` for the reporter to verify.