### PR TITLE
fix(binary_sensor): disable the Cloud diagnostic sensor by default (#13)

### DIFF
--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -427,6 +427,9 @@ class RpcBinarySensor(ShellyBaseEntity, BinarySensorEntity):
             self._attr_device_class = description.device_class
         if description.entity_category:
             self._attr_entity_category = description.entity_category
+        self._attr_entity_registry_enabled_default = (
+            description.entity_registry_enabled_default
+        )
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/shelly_cloud_diy/entities/descriptions.py
+++ b/custom_components/shelly_cloud_diy/entities/descriptions.py
@@ -808,6 +808,7 @@ class RpcBinarySensorDescription:
     name: str | None = None
     device_class: BinarySensorDeviceClass | None = None
     entity_category: EntityCategory | None = None
+    entity_registry_enabled_default: bool = True
 
 
 RPC_BINARY_SENSORS: Final[dict[str, RpcBinarySensorDescription]] = {
@@ -817,12 +818,18 @@ RPC_BINARY_SENSORS: Final[dict[str, RpcBinarySensorDescription]] = {
         name="Input",
         device_class=BinarySensorDeviceClass.POWER,
     ),
+    # Disabled by default, matching HA core's native Shelly integration. On a
+    # deep-sleep device this flag is a boot-timing artifact rather than a state:
+    # the cached snapshot is captured seconds after wake, before the cloud
+    # session is established, so it reads false forever while the device is
+    # demonstrably reaching the cloud. (#13)
     "cloud": RpcBinarySensorDescription(
         key="cloud",
         sub_key="connected",
         name="Cloud",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
 }
 

--- a/tests/test_cloud_sensor_default.py
+++ b/tests/test_cloud_sensor_default.py
@@ -1,0 +1,91 @@
+"""The Cloud diagnostic binary sensor is disabled by default (issue #13 follow-up).
+
+``cloud.connected`` is served from the cached cloud snapshot. On a deep-sleep
+device that snapshot is captured seconds after wake, before the cloud session is
+established, so the flag reads false permanently while the device is
+demonstrably reaching the cloud — the reporter on #13 saw exactly that after the
+sensors themselves were fixed. HA core's native Shelly integration ships the
+same sensor with ``entity_registry_enabled_default=False``; these tests pin that
+we match it, and that no other binary sensor was swept up in the change.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.shelly_cloud_diy.binary_sensor import (
+    _create_rpc_sensors as create_rpc_binary_sensors,
+)
+from custom_components.shelly_cloud_diy.entities.descriptions import (
+    RPC_BINARY_SENSORS,
+)
+
+DEVICE_ID = "aabbccddeeff"
+
+
+class _FakeCoordinator:
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {
+            device_id: {
+                "status": status,
+                "device_code": "S3SN-0U12A",
+                "online": True,
+            }
+        }
+        self.data = self.devices
+        self.last_update_success = True
+
+
+# A deep-sleep H&T as it actually arrives: cloud reports disconnected in the
+# same record that carries current readings.
+_SLEEPING_STATUS: dict[str, Any] = {
+    "sys": {"mac": "AABBCCDDEEFF", "wakeup_period": 7200},
+    "cloud": {"connected": False},
+    "input:0": {"state": True},
+}
+
+
+def _build() -> dict[str, Any]:
+    coordinator = _FakeCoordinator(DEVICE_ID, _SLEEPING_STATUS)
+    entities = create_rpc_binary_sensors(
+        DEVICE_ID, _SLEEPING_STATUS, set(), coordinator
+    )
+    return {entity.unique_id: entity for entity in entities}
+
+
+def test_cloud_sensor_is_still_created() -> None:
+    """The entity must keep existing — disabled, not removed.
+
+    Dropping it would strand the registry entries of every existing install.
+    """
+    assert f"{DEVICE_ID}_cloud_connected" in _build()
+
+
+def test_cloud_sensor_disabled_by_default() -> None:
+    """It must not be enabled on a fresh install."""
+    entity = _build()[f"{DEVICE_ID}_cloud_connected"]
+    assert entity.entity_registry_enabled_default is False
+
+
+def test_cloud_sensor_still_reports_the_raw_flag() -> None:
+    """Disabling the default must not change what the sensor says when enabled.
+
+    The value is honest; it is only a poor signal for a sleeping device.
+    """
+    entity = _build()[f"{DEVICE_ID}_cloud_connected"]
+    assert entity.is_on is False
+
+
+def test_other_binary_sensors_stay_enabled() -> None:
+    """Only the cloud sensor changed — the input sensor is user-facing."""
+    entity = _build()[f"{DEVICE_ID}_input:0_state"]
+    assert entity.entity_registry_enabled_default is True
+
+
+def test_descriptions_default_to_enabled() -> None:
+    """The new dataclass field must not silently disable anything else."""
+    disabled = {
+        key
+        for key, desc in RPC_BINARY_SENSORS.items()
+        if not desc.entity_registry_enabled_default
+    }
+    assert disabled == {"cloud"}


### PR DESCRIPTION
Follow-up to #13. After the deep-sleep availability fix shipped in v0.6.10, the reporter confirmed his sensors were back but noted that `cloud` still reads offline.

That value is honest — it is what the cached snapshot contains — but it is a boot-timing artifact rather than a state. A deep-sleep device pushes its status seconds after wake, before the cloud session is established, so `cloud.connected` is false in the very record that carries its current temperature, humidity and battery. As an enabled-by-default diagnostic it reads as a fault on a perfectly healthy device.

HA core's native Shelly integration ships the same sensor with `entity_registry_enabled_default=False` (`binary_sensor.py:213`). This matches it.

## Scope

- New field `entity_registry_enabled_default` on `RpcBinarySensorDescription`, defaulting to `True` so no other sensor changes.
- `RpcBinarySensor` applies it via `_attr_entity_registry_enabled_default`.
- Only the `cloud` descriptor opts out.

The entity is **kept, not removed** — dropping it would strand the registry entries of every existing install. Existing installs are unaffected either way, since the flag only applies at first registration; the reporter still disables his manually, which he was told.

## Verification

62 tests green in both dev environments (py3.12 / HA 2025.1.4 and py3.14 / HA 2026.7.2), up from 57. New `tests/test_cloud_sensor_default.py` pins that the entity is still created, that it is disabled by default, that its reported value is unchanged, that the input sensor stays enabled, and that `cloud` is the *only* descriptor opting out.