### PR TITLE
fix(sensor): energy and power meters — em1/em1data, pm1, and Gen2 detection for relay-less meters

### DIFF
--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -101,9 +101,26 @@ PLATFORMS: list[Platform] = [
 # reported through Shelly BLU Gateway use the same ``humidity:0`` /
 # ``temperature:0`` shape but are distinguished by ``_dev_info.gen == "GBLE"``
 # (checked first in ``device_gen`` before this structural fallback).
+#
+# This inference is not a nicety: Shelly Cloud sends ``_dev_info`` only for
+# BLE-bridged devices, so for every real Gen2/Gen3 Shelly this pattern is the
+# *only* thing that routes the device to the RPC entity builders instead of
+# the Gen1 block ones — and the block builders find nothing in an RPC status.
+#
+# The energy-meter components are therefore listed explicitly. A relay-less
+# meter (Shelly Pro 3EM) carries nothing but ``em:0`` / ``emdata:0`` and its
+# device temperature, so it used to be recognised purely by the incidental
+# ``temperature:0``; the 2-channel Pro EM-50 got by on its ``switch:0``.
+# Neither is something to rely on.
+#
+# ``cloud`` and ``sys`` were listed here but are *not* components: they carry
+# no ``:<id>`` suffix, so those alternatives could never match and are gone.
+# They must not be re-added with an optional index either — a Gen1 status has
+# a bare ``cloud`` key too, which would classify every Gen1 device as Gen2.
 _GEN2_PATTERN = re.compile(
-    r"(switch|light|cover|input|cloud|sys|temperature|humidity"
-    r"|devicepower|voltmeter|boolean|number|enum|text|button):\d+"
+    r"(switch|light|cover|input|temperature|humidity"
+    r"|devicepower|voltmeter|em1data|em1|emdata|em"
+    r"|boolean|number|enum|text|button):\d+"
 )
 
 

--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -107,11 +107,12 @@ PLATFORMS: list[Platform] = [
 # *only* thing that routes the device to the RPC entity builders instead of
 # the Gen1 block ones — and the block builders find nothing in an RPC status.
 #
-# The energy-meter components are therefore listed explicitly. A relay-less
+# The metering components are therefore listed explicitly. A relay-less
 # meter (Shelly Pro 3EM) carries nothing but ``em:0`` / ``emdata:0`` and its
 # device temperature, so it used to be recognised purely by the incidental
 # ``temperature:0``; the 2-channel Pro EM-50 got by on its ``switch:0``.
-# Neither is something to rely on.
+# Neither is something to rely on, and a pure ``pm1`` meter (PM Mini Gen3)
+# has neither to fall back on.
 #
 # ``cloud`` and ``sys`` were listed here but are *not* components: they carry
 # no ``:<id>`` suffix, so those alternatives could never match and are gone.
@@ -119,7 +120,7 @@ PLATFORMS: list[Platform] = [
 # a bare ``cloud`` key too, which would classify every Gen1 device as Gen2.
 _GEN2_PATTERN = re.compile(
     r"(switch|light|cover|input|temperature|humidity"
-    r"|devicepower|voltmeter|em1data|em1|emdata|em"
+    r"|devicepower|voltmeter|em1data|em1|emdata|em|pm1"
     r"|boolean|number|enum|text|button):\d+"
 )
 

--- a/custom_components/shelly_cloud_diy/entities/descriptions.py
+++ b/custom_components/shelly_cloud_diy/entities/descriptions.py
@@ -718,6 +718,85 @@ RPC_SENSORS: Final[dict[str, RpcSensorDescription]] = {
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
     ),
+    # ------------------------------------------------------------------
+    # Energy Meter — single-phase channels (``em1:<id>`` measurement,
+    # ``em1data:<id>`` counters). Used by the 2-channel meters such as the
+    # Shelly Pro EM-50, which report per-channel values instead of the
+    # phase-prefixed fields of the 3-phase ``em`` component. Each channel is
+    # its own component index, so one description per field suffices —
+    # ``RpcSensor`` appends the channel number to the name for index > 0.
+    # ------------------------------------------------------------------
+    "em1_act_power": RpcSensorDescription(
+        key="em1",
+        sub_key="act_power",
+        name="Active Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    "em1_aprt_power": RpcSensorDescription(
+        key="em1",
+        sub_key="aprt_power",
+        name="Apparent Power",
+        native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
+        device_class=SensorDeviceClass.APPARENT_POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    "em1_current": RpcSensorDescription(
+        key="em1",
+        sub_key="current",
+        name="Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    "em1_voltage": RpcSensorDescription(
+        key="em1",
+        sub_key="voltage",
+        name="Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    "em1_freq": RpcSensorDescription(
+        key="em1",
+        sub_key="freq",
+        name="Frequency",
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    "em1_pf": RpcSensorDescription(
+        key="em1",
+        sub_key="pf",
+        name="Power Factor",
+        device_class=SensorDeviceClass.POWER_FACTOR,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    "em1data_total_act_energy": RpcSensorDescription(
+        key="em1data",
+        sub_key="total_act_energy",
+        name="Energy",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+    ),
+    "em1data_total_act_ret_energy": RpcSensorDescription(
+        key="em1data",
+        sub_key="total_act_ret_energy",
+        name="Returned Energy",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+    ),
 }
 
 

--- a/custom_components/shelly_cloud_diy/entities/descriptions.py
+++ b/custom_components/shelly_cloud_diy/entities/descriptions.py
@@ -797,6 +797,73 @@ RPC_SENSORS: Final[dict[str, RpcSensorDescription]] = {
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
     ),
+    # ------------------------------------------------------------------
+    # Power meter — ``pm1:<id>``, used by the dedicated meters (Shelly PM
+    # Mini Gen3) and by metered channels of some Gen3 devices.
+    #
+    # Field names differ from the energy-meter components and are taken from
+    # the native HA Shelly integration (``sensor.py``, ``*_pm1``): power is
+    # ``apower`` (not ``act_power``), and the two energy counters are
+    # *nested* dicts — ``aenergy.total`` / ``ret_aenergy.total`` — rather
+    # than flat values, hence the ``value_fn``. There is no ``pm1data``
+    # component; the totals live inside ``pm1`` itself.
+    # ------------------------------------------------------------------
+    "pm1_apower": RpcSensorDescription(
+        key="pm1",
+        sub_key="apower",
+        name="Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    "pm1_voltage": RpcSensorDescription(
+        key="pm1",
+        sub_key="voltage",
+        name="Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    "pm1_current": RpcSensorDescription(
+        key="pm1",
+        sub_key="current",
+        name="Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    "pm1_freq": RpcSensorDescription(
+        key="pm1",
+        sub_key="freq",
+        name="Frequency",
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    "pm1_aenergy": RpcSensorDescription(
+        key="pm1",
+        sub_key="aenergy",
+        name="Energy",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda value: value.get("total") if isinstance(value, dict) else None,
+    ),
+    "pm1_ret_aenergy": RpcSensorDescription(
+        key="pm1",
+        sub_key="ret_aenergy",
+        name="Returned Energy",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda value: value.get("total") if isinstance(value, dict) else None,
+    ),
 }
 
 

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.12-beta1"
+  "version": "0.6.12-beta2"
 }

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.11"
+  "version": "0.6.12-beta1"
 }

--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -381,6 +381,59 @@ def _create_rpc_sensors(
                             coordinator, device_id, desc, idx, key, attr
                         ))
 
+    # Energy meter — single-phase channels (``em1:<idx>`` instantaneous,
+    # ``em1data:<idx>`` cumulative). The 2-channel meters (Shelly Pro EM-50)
+    # use these instead of the phase-prefixed ``em``/``emdata`` fields of the
+    # Pro 3EM, which is why a relay-plus-meter device previously surfaced only
+    # its ``switch:0`` entities. Each channel is its own component index, so
+    # the plain field names are unambiguous. ``calibration`` / ``errors`` /
+    # ``id`` are metadata, not sensors.
+    for key in status:
+        if match := re.match(r"em1:(\d+)", key):
+            idx = int(match.group(1))
+            data = status[key]
+            if not isinstance(data, dict):
+                continue
+            for attr, desc_key in [
+                ("act_power", "em1_act_power"),
+                ("aprt_power", "em1_aprt_power"),
+                ("current", "em1_current"),
+                ("voltage", "em1_voltage"),
+                ("freq", "em1_freq"),
+                ("pf", "em1_pf"),
+            ]:
+                if data.get(attr) is None:
+                    continue
+                desc = RPC_SENSORS.get(desc_key)
+                if desc:
+                    uid = f"{device_id}_{key}_{attr}"
+                    if uid not in created:
+                        created.add(uid)
+                        entities.append(RpcSensor(
+                            coordinator, device_id, desc, idx, key, attr
+                        ))
+
+    for key in status:
+        if match := re.match(r"em1data:(\d+)", key):
+            idx = int(match.group(1))
+            data = status[key]
+            if not isinstance(data, dict):
+                continue
+            for attr, desc_key in [
+                ("total_act_energy", "em1data_total_act_energy"),
+                ("total_act_ret_energy", "em1data_total_act_ret_energy"),
+            ]:
+                if data.get(attr) is None:
+                    continue
+                desc = RPC_SENSORS.get(desc_key)
+                if desc:
+                    uid = f"{device_id}_{key}_{attr}"
+                    if uid not in created:
+                        created.add(uid)
+                        entities.append(RpcSensor(
+                            coordinator, device_id, desc, idx, key, attr
+                        ))
+
     # Virtual components (READ-ONLY) — Gen2/Gen3 "virtual" number/enum/text
     # components (e.g. created by a script or a Wall Display) surface their
     # current value under ``<type>:<id>.value`` in the cloud status. We expose

--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -434,6 +434,36 @@ def _create_rpc_sensors(
                             coordinator, device_id, desc, idx, key, attr
                         ))
 
+    # Power meter — ``pm1:<idx>`` (Shelly PM Mini Gen3 and metered channels of
+    # other Gen3 devices). Field names differ from the energy meters: power is
+    # ``apower``, and the two counters are nested dicts whose ``total`` the
+    # description's ``value_fn`` unwraps — so presence, not ``is None``, is the
+    # right gate here.
+    for key in status:
+        if match := re.match(r"pm1:(\d+)", key):
+            idx = int(match.group(1))
+            data = status[key]
+            if not isinstance(data, dict):
+                continue
+            for attr, desc_key in [
+                ("apower", "pm1_apower"),
+                ("voltage", "pm1_voltage"),
+                ("current", "pm1_current"),
+                ("freq", "pm1_freq"),
+                ("aenergy", "pm1_aenergy"),
+                ("ret_aenergy", "pm1_ret_aenergy"),
+            ]:
+                if data.get(attr) is None:
+                    continue
+                desc = RPC_SENSORS.get(desc_key)
+                if desc:
+                    uid = f"{device_id}_{key}_{attr}"
+                    if uid not in created:
+                        created.add(uid)
+                        entities.append(RpcSensor(
+                            coordinator, device_id, desc, idx, key, attr
+                        ))
+
     # Virtual components (READ-ONLY) — Gen2/Gen3 "virtual" number/enum/text
     # components (e.g. created by a script or a Wall Display) surface their
     # current value under ``<type>:<id>.value`` in the cloud status. We expose

--- a/tests/test_em1_energy_meter.py
+++ b/tests/test_em1_energy_meter.py
@@ -1,0 +1,142 @@
+"""Unit tests for single-phase energy-meter channels (``em1`` / ``em1data``).
+
+Reported on the simon42 forum (2026-08-03): on a Shelly Pro EM-50 only the
+relay came through, the energy measurement stayed invisible although the
+diagnostics file clearly contained the values. Cause: the 2-channel meters
+report per-channel ``em1:<id>`` / ``em1data:<id>`` components, while the
+creation loops only knew the phase-prefixed ``em`` / ``emdata`` shape of the
+Pro 3EM.
+
+These tests drive the real RPC creation loop with a fake coordinator — no
+running HA required.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+from custom_components.shelly_cloud_diy.sensor import (
+    RpcSensor,
+    _create_rpc_sensors as create_rpc_sensors,
+)
+
+DEVICE_ID = "proem50a1b2c3"
+
+
+class _FakeCoordinator:
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {device_id: {"status": status, "device_code": "SPEM-002CEBEU50", "online": True}}
+        self.data = self.devices
+        self.last_update_success = True
+
+
+# Shape of a Pro EM-50: one relay plus two independent meter channels.
+_EM50_STATUS: dict[str, Any] = {
+    "sys": {"mac": "AABBCCDDEEFF"},
+    "switch:0": {"id": 0, "output": False},
+    "em1:0": {
+        "id": 0,
+        "current": 1.234,
+        "voltage": 230.1,
+        "act_power": 250.7,
+        "aprt_power": 283.9,
+        "pf": 0.88,
+        "freq": 50.0,
+        "calibration": "factory",
+    },
+    "em1:1": {
+        "id": 1,
+        "current": 0.5,
+        "voltage": 229.8,
+        "act_power": -110.2,
+        "aprt_power": 115.0,
+        "pf": 0.96,
+        "freq": 50.0,
+        "calibration": "factory",
+    },
+    "em1data:0": {"id": 0, "total_act_energy": 12345.6, "total_act_ret_energy": 78.9},
+    "em1data:1": {"id": 1, "total_act_energy": 500.0, "total_act_ret_energy": 4200.5},
+}
+
+
+def _build(status: dict[str, Any]):
+    coord = _FakeCoordinator(DEVICE_ID, status)
+    sensors = create_rpc_sensors(DEVICE_ID, status, set(), coord)
+    return sensors, {e.unique_id: e for e in sensors}
+
+
+def test_both_channels_create_measurement_and_energy_entities():
+    sensors, by_uid = _build(_EM50_STATUS)
+    em1 = [e for e in sensors if isinstance(e, RpcSensor) and ":" in e.unique_id]
+    # 6 measurements + 2 counters, per channel.
+    assert len([u for u in by_uid if "_em1:0_" in u]) == 6
+    assert len([u for u in by_uid if "_em1:1_" in u]) == 6
+    assert len([u for u in by_uid if "_em1data:0_" in u]) == 2
+    assert len([u for u in by_uid if "_em1data:1_" in u]) == 2
+    assert em1  # sanity: entities were actually built
+
+
+def test_values_are_read_from_the_right_channel():
+    _s, by_uid = _build(_EM50_STATUS)
+    assert by_uid[f"{DEVICE_ID}_em1:0_act_power"].native_value == 250.7
+    assert by_uid[f"{DEVICE_ID}_em1:1_act_power"].native_value == -110.2
+    assert by_uid[f"{DEVICE_ID}_em1:0_voltage"].native_value == 230.1
+    assert by_uid[f"{DEVICE_ID}_em1data:1_total_act_ret_energy"].native_value == 4200.5
+
+
+def test_channel_is_reflected_in_the_name():
+    _s, by_uid = _build(_EM50_STATUS)
+    assert by_uid[f"{DEVICE_ID}_em1:0_act_power"].name == "Active Power"
+    assert by_uid[f"{DEVICE_ID}_em1:1_act_power"].name == "Active Power 2"
+    assert by_uid[f"{DEVICE_ID}_em1data:0_total_act_energy"].name == "Energy"
+    assert by_uid[f"{DEVICE_ID}_em1data:1_total_act_energy"].name == "Energy 2"
+
+
+def test_energy_counters_carry_statistics_metadata():
+    """Without these the counters never reach the HA energy dashboard."""
+    _s, by_uid = _build(_EM50_STATUS)
+    e = by_uid[f"{DEVICE_ID}_em1data:0_total_act_energy"]
+    assert e.device_class is SensorDeviceClass.ENERGY
+    assert e.state_class is SensorStateClass.TOTAL_INCREASING
+    p = by_uid[f"{DEVICE_ID}_em1:0_act_power"]
+    assert p.device_class is SensorDeviceClass.POWER
+    assert p.state_class is SensorStateClass.MEASUREMENT
+
+
+def test_unique_ids_are_distinct():
+    sensors, by_uid = _build(_EM50_STATUS)
+    assert len(by_uid) == len(sensors)
+
+
+def test_null_and_missing_fields_are_skipped():
+    status = {
+        "sys": {"mac": "x"},
+        "em1:0": {"id": 0, "act_power": 12.0, "voltage": None, "pf": None},
+        "em1data:0": {"id": 0, "total_act_energy": 1.0},
+    }
+    _s, by_uid = _build(status)
+    assert f"{DEVICE_ID}_em1:0_act_power" in by_uid
+    assert f"{DEVICE_ID}_em1:0_voltage" not in by_uid
+    assert f"{DEVICE_ID}_em1:0_pf" not in by_uid
+    assert f"{DEVICE_ID}_em1:0_current" not in by_uid
+    assert f"{DEVICE_ID}_em1data:0_total_act_ret_energy" not in by_uid
+
+
+def test_malformed_component_does_not_raise():
+    status = {"sys": {"mac": "x"}, "em1:0": "not-a-dict", "em1data:0": None}
+    sensors, _ = _build(status)
+    assert not [e for e in sensors if "em1" in (e.unique_id or "")]
+
+
+def test_em1_does_not_collide_with_three_phase_em():
+    """``em1``/``em1data`` and ``em``/``emdata`` must not match each other."""
+    status = {
+        "sys": {"mac": "x"},
+        "em:0": {"a_act_power": 100.0, "total_act_power": 300.0},
+        "emdata:0": {"total_act": 5000.0},
+    }
+    _s, by_uid = _build(status)
+    assert f"{DEVICE_ID}_em:0_a_act_power" in by_uid
+    assert f"{DEVICE_ID}_emdata:0_total_act" in by_uid
+    assert not [u for u in by_uid if "em1" in u]

--- a/tests/test_gen2_detection.py
+++ b/tests/test_gen2_detection.py
@@ -1,0 +1,64 @@
+"""Unit tests for the structural Gen2/Gen3 detection (``is_gen2_status``).
+
+Shelly Cloud sends ``_dev_info`` only for BLE-bridged devices, so for every
+real Gen2/Gen3 Shelly this structural inference decides whether the device is
+routed to the RPC entity builders or to the Gen1 block ones. A misroute means
+zero entities, not a degraded set.
+
+Regression guard for the energy meters: a relay-less meter carries nothing but
+its ``em`` / ``em1`` components plus a device temperature, so before the meter
+components were listed it was recognised only by the incidental
+``temperature:0``.
+"""
+from __future__ import annotations
+
+from custom_components.shelly_cloud_diy.const import device_gen, is_gen2_status
+
+
+def test_relay_less_three_phase_meter_is_gen2():
+    """Shelly Pro 3EM without the incidental ``temperature:0``."""
+    assert is_gen2_status({"em:0": {}, "emdata:0": {}, "sys": {}, "cloud": {}}) is True
+
+
+def test_relay_less_single_phase_meter_is_gen2():
+    """2-channel meter shape (Pro EM-50) without its ``switch:0``."""
+    assert is_gen2_status({"em1:0": {}, "em1data:0": {}, "cloud": {}}) is True
+    assert is_gen2_status({"em1data:1": {}}) is True
+
+
+def test_classic_component_shapes_still_detected():
+    assert is_gen2_status({"switch:0": {}}) is True
+    assert is_gen2_status({"temperature:0": {}, "humidity:0": {}}) is True
+    assert is_gen2_status({"number:200": {"value": 1}}) is True
+
+
+def test_gen1_status_is_not_gen2():
+    """The bare ``cloud`` key must never count — Gen1 carries one as well."""
+    gen1 = {
+        "relays": [{"ison": False}],
+        "meters": [{"power": 0.0}],
+        "emeters": [{"power": 12.0}],
+        "cloud": {"enabled": True, "connected": True},
+        "sys": {},
+        "wifi_sta": {"connected": True},
+        "tmp": {"tC": 21.0},
+        "temperature": 21.0,
+    }
+    assert is_gen2_status(gen1) is False
+    assert device_gen(gen1) == "G1"
+
+
+def test_indexless_system_keys_alone_are_not_gen2():
+    assert is_gen2_status({"sys": {"mac": "x"}}) is False
+    assert is_gen2_status({"cloud": {"connected": True}}) is False
+    assert is_gen2_status({}) is False
+
+
+def test_gen1_emeters_key_does_not_match_the_meter_alternatives():
+    """``emeters`` starts with ``em`` — it must not be mistaken for ``em:<id>``."""
+    assert is_gen2_status({"emeters": [{"power": 1.0}]}) is False
+
+
+def test_dev_info_still_wins_for_ble_devices():
+    ble = {"temperature:0": {}, "humidity:0": {}, "_dev_info": {"gen": "GBLE"}}
+    assert device_gen(ble) == "GBLE"

--- a/tests/test_pm1_power_meter.py
+++ b/tests/test_pm1_power_meter.py
@@ -1,0 +1,128 @@
+"""Unit tests for the power-meter component (``pm1:<id>``).
+
+Used by the dedicated meters (Shelly PM Mini Gen3) and by metered channels of
+other Gen3 devices. Two things make it unlike the energy meters, and both are
+what these tests pin down:
+
+* the field names differ — power is ``apower``, not ``act_power``;
+* the energy counters are *nested* dicts (``aenergy.total`` /
+  ``ret_aenergy.total``), not flat values, and there is no ``pm1data``
+  component to hold them.
+
+Shapes taken from the native HA Shelly integration (``sensor.py``, ``*_pm1``).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+from custom_components.shelly_cloud_diy.const import is_gen2_status
+from custom_components.shelly_cloud_diy.sensor import (
+    _create_rpc_sensors as create_rpc_sensors,
+)
+
+DEVICE_ID = "pmmini3a1b2c3"
+
+
+class _FakeCoordinator:
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {device_id: {"status": status, "device_code": "S3PM-001PCEU16", "online": True}}
+        self.data = self.devices
+        self.last_update_success = True
+
+
+# A PM Mini Gen3: a pure meter — no relay, no device temperature.
+_PM_MINI_STATUS: dict[str, Any] = {
+    "cloud": {"connected": True},
+    "pm1:0": {
+        "id": 0,
+        "voltage": 234.7,
+        "current": 0.322,
+        "apower": 55.0,
+        "freq": 50.0,
+        "aenergy": {"total": 1234.5, "by_minute": [0.0], "minute_ts": 1754300000},
+        "ret_aenergy": {"total": 12.0, "by_minute": [0.0], "minute_ts": 1754300000},
+        "calibration": "factory",
+    },
+}
+
+
+def _build(status: dict[str, Any]):
+    coord = _FakeCoordinator(DEVICE_ID, status)
+    sensors = create_rpc_sensors(DEVICE_ID, status, set(), coord)
+    return sensors, {e.unique_id: e for e in sensors}
+
+
+def test_pure_meter_is_recognised_as_gen2():
+    """Without this the RPC builders never run and the device stays empty."""
+    assert is_gen2_status(_PM_MINI_STATUS) is True
+    assert is_gen2_status({"pm1:0": {}}) is True
+
+
+def test_all_six_measurements_become_entities():
+    sensors, by_uid = _build(_PM_MINI_STATUS)
+    assert len(sensors) == 6
+    for attr in ("apower", "voltage", "current", "freq", "aenergy", "ret_aenergy"):
+        assert f"{DEVICE_ID}_pm1:0_{attr}" in by_uid
+
+
+def test_flat_measurements_read_through():
+    _s, by_uid = _build(_PM_MINI_STATUS)
+    assert by_uid[f"{DEVICE_ID}_pm1:0_apower"].native_value == 55.0
+    assert by_uid[f"{DEVICE_ID}_pm1:0_voltage"].native_value == 234.7
+    assert by_uid[f"{DEVICE_ID}_pm1:0_current"].native_value == 0.322
+    assert by_uid[f"{DEVICE_ID}_pm1:0_freq"].native_value == 50.0
+
+
+def test_nested_energy_counters_are_unwrapped():
+    """``aenergy`` is a dict — the entity must report ``total``, not the dict."""
+    _s, by_uid = _build(_PM_MINI_STATUS)
+    assert by_uid[f"{DEVICE_ID}_pm1:0_aenergy"].native_value == 1234.5
+    assert by_uid[f"{DEVICE_ID}_pm1:0_ret_aenergy"].native_value == 12.0
+
+
+def test_energy_counters_carry_statistics_metadata():
+    _s, by_uid = _build(_PM_MINI_STATUS)
+    e = by_uid[f"{DEVICE_ID}_pm1:0_aenergy"]
+    assert e.device_class is SensorDeviceClass.ENERGY
+    assert e.state_class is SensorStateClass.TOTAL_INCREASING
+    p = by_uid[f"{DEVICE_ID}_pm1:0_apower"]
+    assert p.device_class is SensorDeviceClass.POWER
+    assert p.state_class is SensorStateClass.MEASUREMENT
+
+
+def test_malformed_nested_counter_yields_none_not_a_crash():
+    status = {"pm1:0": {"apower": 1.0, "aenergy": "not-a-dict", "ret_aenergy": {}}}
+    _s, by_uid = _build(status)
+    assert by_uid[f"{DEVICE_ID}_pm1:0_aenergy"].native_value is None
+    assert by_uid[f"{DEVICE_ID}_pm1:0_ret_aenergy"].native_value is None
+
+
+def test_second_channel_is_named_and_kept_apart():
+    status = {
+        "pm1:0": {"apower": 10.0},
+        "pm1:1": {"apower": 20.0},
+    }
+    _s, by_uid = _build(status)
+    assert by_uid[f"{DEVICE_ID}_pm1:0_apower"].name == "Power"
+    assert by_uid[f"{DEVICE_ID}_pm1:1_apower"].name == "Power 2"
+    assert by_uid[f"{DEVICE_ID}_pm1:1_apower"].native_value == 20.0
+
+
+def test_missing_fields_are_skipped():
+    status = {"pm1:0": {"apower": 5.0, "voltage": None}}
+    sensors, by_uid = _build(status)
+    assert len(sensors) == 1
+    assert f"{DEVICE_ID}_pm1:0_voltage" not in by_uid
+
+
+def test_pm1_does_not_collide_with_em1():
+    """``pm1`` and ``em1`` must stay separate components."""
+    status = {
+        "pm1:0": {"apower": 5.0},
+        "em1:0": {"act_power": 7.0},
+    }
+    _s, by_uid = _build(status)
+    assert by_uid[f"{DEVICE_ID}_pm1:0_apower"].native_value == 5.0
+    assert by_uid[f"{DEVICE_ID}_em1:0_act_power"].native_value == 7.0


### PR DESCRIPTION
Reported on the [simon42 forum](https://community.simon42.com/t/ueber-die-shelly-cloud-freigegebenen-shelly-in-ha-anzeigen/41047/3) by @Tobias79 (2026-08-03): on a **Shelly Pro EM-50** only the relay came through, the energy measurement stayed invisible — although the values were plainly present in the diagnostics download.

Chasing that turned up three separate gaps in how metering devices are handled.

## 1. `em1` / `em1data` — the 2-channel meters (`c6ccdfc`)

The creation loops only knew `em:<id>` / `emdata:<id>`, the **phase-prefixed** shape of the Pro 3EM. The 2-channel meters report **per channel**: `em1:<id>` for the instantaneous values and `em1data:<id>` for the counters. With no handler for those, a relay-plus-meter device surfaced its `switch:0` entities and nothing else — exactly the reported symptom.

Adds per channel: active power, apparent power, current, voltage, frequency, power factor, plus both energy counters as `TOTAL_INCREASING` so they reach the energy dashboard.

## 2. Relay-less meters were not recognised as Gen2 at all (`23ca703`)

`is_gen2_status()` infers the device generation from the shape of the status, and it is not a nicety: Shelly Cloud sends `_dev_info` **only** for BLE-bridged devices, so for every real Gen2/Gen3 Shelly this pattern is the *only* thing routing the device to the RPC entity builders. Misrouted, an RPC status reaches the Gen1 block builders, which find nothing in it — zero entities, not a degraded set.

The metering components were missing from that pattern. A **Pro 3EM** carries nothing but `em:0` / `emdata:0` and a device temperature, so it was recognised purely by the incidental `temperature:0` (confirmed against the diagnostics keys in #8); the Pro EM-50 got by on its `switch:0`. Both are coincidences.

Also drops `cloud` and `sys` from the alternation: they are not components and carry no `:<id>` suffix, so those alternatives could never match. The comment records why they must not return with an optional index — a Gen1 status has a bare `cloud` key too, which would classify **every** Gen1 device as Gen2.

## 3. `pm1` power meters (`7995cdd`)

Dedicated meters (**PM Mini Gen3**) and the metered channels of some Gen3 devices report through `pm1:<id>`, which had neither detection nor sensors. A pure PM meter has no relay and no device temperature, so without change 2 it would not even reach the RPC path.

Field names follow the native HA Shelly integration and differ from `em1`: power is `apower`, and the energy counters are **nested** dicts whose `total` gets unwrapped — there is no `pm1data` component. Deviating from core deliberately, voltage/current/frequency are created **enabled**: on a dedicated meter those are the point of the device, not noise on a switch.

## Testing

`86 tests green on both HA 2025.1.4 / py3.12 and HA 2026.7.2 / py3.14` (`ALL ENVIRONMENTS GREEN`).

New: `tests/test_em1_energy_meter.py` (8), `tests/test_gen2_detection.py` (7), `tests/test_pm1_power_meter.py` (9). They pin the things that would silently break: `em1` vs `em`, `pm1` vs `em1`, Gen1 `emeters` not being mistaken for `em:<id>`, Gen1 status never counting as Gen2, and the nested `aenergy.total` unwrapping without crashing on a malformed payload.

Devices that already worked are untouched — the component families are matched separately and Gen1 detection is unchanged.

## Status

Shipped as [`v0.6.12-beta1`](https://github.com/notDIRK/shelly-cloud-diy-ha/releases/tag/v0.6.12-beta1) and [`v0.6.12-beta2`](https://github.com/notDIRK/shelly-cloud-diy-ha/releases/tag/v0.6.12-beta2). Fixed from the component structure, **not** from hardware — there is no Pro EM-50 or PM Mini here. Waiting on the reporter's confirmation before promoting to stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgfwN3zAZvU2q3nZmxCJC4