### PR TITLE
fix(config_flow): translate the bulk-action selector (#18)

### DIFF
--- a/custom_components/shelly_cloud_diy/config_flow.py
+++ b/custom_components/shelly_cloud_diy/config_flow.py
@@ -243,12 +243,11 @@ class ShellyCloudDiyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         UX: the user can either tick/untick individual devices in the
         list and submit, or use the bulk action radio as a shortcut.
-        Picking "Alle Geräte anhaken" or "Alle Geräte abwählen" and
-        clicking *Submit* **re-renders** the form with the list
-        live-updated (all ticked or all unticked) and the radio reset
-        to "Manuelle Auswahl". The user then verifies / fine-tunes
-        and clicks Submit a second time to actually save — only the
-        "Manuelle Auswahl" submit persists the entry.
+        Picking ``all`` or ``none`` and clicking *Submit* **re-renders**
+        the form with the list live-updated (all ticked or all unticked)
+        and the radio reset to ``manual``. The user then verifies /
+        fine-tunes and clicks Submit a second time to actually save —
+        only a ``manual`` submit persists the entry.
         """
         options = _build_device_options(
             self._pending_devices, self._pending_names
@@ -297,21 +296,13 @@ class ShellyCloudDiyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "bulk_action", default="manual"
                 ): SelectSelector(
                     SelectSelectorConfig(
-                        options=[
-                            SelectOptionDict(
-                                value="manual",
-                                label="Manuelle Auswahl — Submit speichert die Liste unten",
-                            ),
-                            SelectOptionDict(
-                                value="all",
-                                label="Alle Geräte anhaken (Submit aktualisiert die Liste — noch nicht speichern)",
-                            ),
-                            SelectOptionDict(
-                                value="none",
-                                label="Alle Geräte abwählen (Submit aktualisiert die Liste — noch nicht speichern)",
-                            ),
-                        ],
+                        # Labels come from the ``selector.bulk_action.options``
+                        # block in strings.json / translations. Hard-coded
+                        # ``label=`` values bypass translation entirely and
+                        # show the same text in every language (#18).
+                        options=["manual", "all", "none"],
                         mode=SelectSelectorMode.LIST,
+                        translation_key="bulk_action",
                     )
                 ),
                 vol.Optional(
@@ -515,21 +506,13 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                     "bulk_action", default="manual"
                 ): SelectSelector(
                     SelectSelectorConfig(
-                        options=[
-                            SelectOptionDict(
-                                value="manual",
-                                label="Manuelle Auswahl — Submit speichert die Liste unten",
-                            ),
-                            SelectOptionDict(
-                                value="all",
-                                label="Alle Geräte anhaken (Submit aktualisiert die Liste — noch nicht speichern)",
-                            ),
-                            SelectOptionDict(
-                                value="none",
-                                label="Alle Geräte abwählen (Submit aktualisiert die Liste — noch nicht speichern)",
-                            ),
-                        ],
+                        # Labels come from the ``selector.bulk_action.options``
+                        # block in strings.json / translations. Hard-coded
+                        # ``label=`` values bypass translation entirely and
+                        # show the same text in every language (#18).
+                        options=["manual", "all", "none"],
                         mode=SelectSelectorMode.LIST,
+                        translation_key="bulk_action",
                     )
                 ),
                 vol.Optional(

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.12"
+  "version": "0.6.13-beta1"
 }

--- a/custom_components/shelly_cloud_diy/strings.json
+++ b/custom_components/shelly_cloud_diy/strings.json
@@ -132,5 +132,14 @@
         }
       }
     }
+  },
+  "selector": {
+    "bulk_action": {
+      "options": {
+        "manual": "Manual selection — Submit saves the list below",
+        "all": "Tick all devices (Submit updates the list — does not save yet)",
+        "none": "Untick all devices (Submit updates the list — does not save yet)"
+      }
+    }
   }
 }

--- a/custom_components/shelly_cloud_diy/translations/de.json
+++ b/custom_components/shelly_cloud_diy/translations/de.json
@@ -150,5 +150,14 @@
         }
       }
     }
+  },
+  "selector": {
+    "bulk_action": {
+      "options": {
+        "manual": "Manuelle Auswahl — Submit speichert die Liste unten",
+        "all": "Alle Geräte anhaken (Submit aktualisiert die Liste — noch nicht speichern)",
+        "none": "Alle Geräte abwählen (Submit aktualisiert die Liste — noch nicht speichern)"
+      }
+    }
   }
 }

--- a/custom_components/shelly_cloud_diy/translations/en.json
+++ b/custom_components/shelly_cloud_diy/translations/en.json
@@ -150,5 +150,14 @@
         }
       }
     }
+  },
+  "selector": {
+    "bulk_action": {
+      "options": {
+        "manual": "Manual selection — Submit saves the list below",
+        "all": "Tick all devices (Submit updates the list — does not save yet)",
+        "none": "Untick all devices (Submit updates the list — does not save yet)"
+      }
+    }
   }
 }

--- a/tests/test_bulk_action_translation.py
+++ b/tests/test_bulk_action_translation.py
@@ -1,0 +1,81 @@
+"""Regression guard for the bulk-action selector translation (issue #18).
+
+@elad-eyal reported the device picker showing German radio-button labels in an
+otherwise English UI on first install. Cause: the three options were built with
+hard-coded ``label=`` literals in ``config_flow.py``, which bypasses Home
+Assistant's translation lookup entirely — every user saw German regardless of
+their language.
+
+The fix routes the labels through ``translation_key="bulk_action"`` and the
+``selector`` block of the translation files. These tests pin both halves: that
+the source no longer carries literal labels, and that every translation file
+actually supplies the keys the selector will ask for.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+COMPONENT = Path(__file__).resolve().parents[1] / "custom_components" / "shelly_cloud_diy"
+CONFIG_FLOW = COMPONENT / "config_flow.py"
+
+TRANSLATION_FILES = [
+    COMPONENT / "strings.json",
+    COMPONENT / "translations" / "en.json",
+    COMPONENT / "translations" / "de.json",
+]
+
+# The values the selector submits. Every translation file must cover exactly
+# these — no more (dead entry), no fewer (untranslated option).
+EXPECTED_OPTIONS = {"manual", "all", "none"}
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("path", TRANSLATION_FILES, ids=lambda p: p.name)
+def test_selector_block_covers_every_option(path: Path):
+    data = _load(path)
+    options = data["selector"]["bulk_action"]["options"]
+    assert set(options) == EXPECTED_OPTIONS
+    for key, text in options.items():
+        assert text.strip(), f"{path.name}: option {key!r} is empty"
+
+
+def test_en_and_de_agree_on_the_key_set():
+    """A language added to one file only reintroduces the bug for the other."""
+    en = _load(COMPONENT / "translations" / "en.json")["selector"]
+    de = _load(COMPONENT / "translations" / "de.json")["selector"]
+    assert en.keys() == de.keys()
+    for selector_key in en:
+        assert en[selector_key]["options"].keys() == de[selector_key]["options"].keys()
+
+
+def test_strings_json_matches_english_translation():
+    """strings.json is the source of truth HA falls back to — keep it in sync."""
+    strings = _load(COMPONENT / "strings.json")["selector"]
+    en = _load(COMPONENT / "translations" / "en.json")["selector"]
+    assert strings == en
+
+
+def test_english_and_german_actually_differ():
+    """Guards against copying the German text into en.json to 'fix' the report."""
+    en = _load(COMPONENT / "translations" / "en.json")["selector"]["bulk_action"]["options"]
+    de = _load(COMPONENT / "translations" / "de.json")["selector"]["bulk_action"]["options"]
+    for key in EXPECTED_OPTIONS:
+        assert en[key] != de[key], f"option {key!r} is identical in en and de"
+
+
+def test_config_flow_carries_no_hardcoded_labels():
+    source = CONFIG_FLOW.read_text(encoding="utf-8")
+    for literal in ("Manuelle Auswahl", "Alle Geräte anhaken", "Alle Geräte abwählen"):
+        assert literal not in source, f"hard-coded label {literal!r} is back"
+
+
+def test_both_flows_use_the_translation_key():
+    """The config flow and the options flow each render this picker."""
+    source = CONFIG_FLOW.read_text(encoding="utf-8")
+    assert source.count('translation_key="bulk_action"') == 2


### PR DESCRIPTION
Fixes #18.

The three "Bulk action" radio labels in the device picker were hard-coded German string literals in `config_flow.py`. That bypassed Home Assistant's translation lookup entirely, so **every** user in **every** language saw German — this was never a missing translation, it was a string that was never translatable.

Both render paths were affected: the config flow and the options flow.

**Fix:** `translation_key="bulk_action"` plus a matching `selector` block in `strings.json`, `translations/en.json` and `translations/de.json`. `translation_key` support on `SelectSelector` was verified against both ends of the supported HA range (2025.1.4 and 2026.7.2) before tagging the beta.

**Tests:** 8 new in `tests/test_bulk_action_translation.py`, pinning down that no literals remain, that `en`/`de` carry the same key set, and that `en != de`. Green in both matrix venvs.

Shipped as `v0.6.13-beta1` for confirmation; promoting to stable because the bug affects every user in every language while a beta only reaches those who opted into pre-releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxqg751CivULXbU63q5WDZ