### PR TITLE
docs(security): document exactly what happens with the user's auth key

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -206,6 +206,14 @@ Formular ausfüllen und nicht auf eine Freigabe warten.
 > Passwort. Zum Rotieren: Shelly-Passwort in der App ändern — der alte Key wird
 > serverseitig invalidiert und ein neuer generiert.
 
+Du installierst Code von einem Fremden und gibst ihm einen Zugang zum gesamten
+Konto. Deshalb steht in **[Was diese Integration mit deinem Auth-Key macht](docs/AUTH_KEY.de.md)**,
+wohin der Schlüssel geht, wo er liegt, wohin er nie geht — und wie du jede
+einzelne dieser Aussagen in etwa zwei Minuten selbst nachprüfst, mit Befehlen,
+die du tippst, statt mit einem Skript von mir. Dort stehen auch die Punkte, mit
+denen ich nicht zufrieden bin; eine Seite, die nur gute Nachrichten aufzählt,
+wäre das Lesen nicht wert.
+
 ---
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ form, or wait for approval.
 > password. To rotate it, change your Shelly account password in the App — the
 > old key invalidates server-side and a new one is generated.
 
+You are installing code from a stranger and handing it an account-wide
+credential, so **[what this integration does with your auth key](docs/AUTH_KEY.md)**
+spells out where the key travels, where it is stored, where it never goes, and
+how to verify every one of those claims yourself in about two minutes — with
+commands you type, not a script I wrote. It also names the parts I am not happy
+about, because a page that only listed good news would not be worth reading.
+
 ---
 
 ## Setup

--- a/custom_components/shelly_cloud_diy/api/cloud_control.py
+++ b/custom_components/shelly_cloud_diy/api/cloud_control.py
@@ -19,6 +19,33 @@ screen in the app).
 Shelly documents a rate limit of **1 request per second per account**; callers
 are responsible for respecting that budget. v1 and v2 share that budget. See
 ``docs/ROADMAP.md`` for the integration's overall rate-limit strategy.
+
+Credential handling — canonical statement
+-----------------------------------------
+**This module is the only place in the integration that touches the user's
+auth_key.** That is a deliberate property, not an accident: it makes the claim
+"here is everywhere your credential goes" checkable with a single ``grep``
+rather than a matter of trust. ``docs/AUTH_KEY.md`` is written for users and
+points here; if you change anything in this section, change that file too.
+
+Rules this module keeps, each one user-visible:
+
+1. **One destination.** Every request goes to ``self._base_url``, built once in
+   ``_normalise_base_url`` from the server URI the user entered at setup. There
+   is no hard-coded fallback host and no second destination for the key.
+2. **No implicit attachment.** The helpers (``_post`` / ``_post_json``) do not
+   silently add credentials for their callers. ``_post`` attaches the key
+   because every v1 endpoint requires it; ``_post_json`` attaches nothing, so
+   each v2 caller passes it explicitly and stays visible to ``grep``. Keep it
+   that way — an auto-attaching helper would make the audit trail incomplete.
+3. **Never logged.** No log record may carry the key or any structure holding
+   it. Log *that* a key was rejected, never the value; log URLs only where the
+   key is not in the query string.
+4. **Never in diagnostics.** ``diagnostics.py`` deliberately does not read
+   ``entry.data``. Diagnostics downloads get attached to public bug reports.
+
+Every site that transmits the key is marked ``# CREDENTIAL:`` below, so the
+three transmissions can be enumerated by reading, not by inference.
 """
 from __future__ import annotations
 
@@ -112,6 +139,9 @@ class ShellyCloudControl:
             request_timeout_s: Per-request timeout. Default 10 s.
         """
         self._session = session
+        # CREDENTIAL (stored, not sent): the only copy this integration keeps.
+        # It lives on the instance and is never written anywhere else — not to
+        # a log, not to disk, not into diagnostics. See the module docstring.
         self._auth_key = auth_key
         self._base_url = self._normalise_base_url(server_uri)
         self._timeout = aiohttp.ClientTimeout(total=request_timeout_s)
@@ -157,6 +187,9 @@ class ShellyCloudControl:
         back off properly.
         """
         url = f"{self._base_url}{path}"
+        # CREDENTIAL (sent 1/3): form field on every v1 endpoint. Destination is
+        # ``self._base_url`` — i.e. the server URI the user entered, nothing
+        # else. ``payload`` must never reach a log record. (docs/AUTH_KEY.md)
         payload = {"auth_key": self._auth_key}
         if extra:
             payload.update({k: str(v) for k, v in extra.items() if v is not None})
@@ -203,6 +236,11 @@ class ShellyCloudControl:
             # Shelly returned a structured error. Common causes: invalid auth_key
             # (isok=false + errors field) vs. unknown device (isok=false + data=null).
             errors = data.get("errors")
+            # NOT a credential site: this matches Shelly's error *text*, it
+            # never touches the key itself. Called out because the audit grep
+            # in docs/AUTH_KEY.md returns this line too, and a reader should
+            # not have to wonder about it. The raised message carries
+            # ``errors`` (Shelly's own wording), never the credential.
             if errors and "invalid_auth_key" in str(errors).lower():
                 raise ShellyCloudAuthError(f"Auth rejected: {errors}")
             raise ShellyCloudError(f"Shelly Cloud API error on {path}: {errors or data}")
@@ -436,6 +474,10 @@ class ShellyCloudControl:
             if offset:
                 # Space successive requests out under the 1 req/s limit.
                 await asyncio.sleep(_RATE_LIMIT_BACKOFF_S)
+            # CREDENTIAL (sent 2/3): JSON body field. The v2 API takes the key
+            # in the body, not as a Bearer header. Passed explicitly here
+            # rather than injected by ``_post_json`` so that every transmission
+            # stays greppable. (docs/AUTH_KEY.md)
             payload = {
                 "auth_key": self._auth_key,
                 "ids": chunk,
@@ -560,9 +602,27 @@ class ShellyCloudControl:
             raise ValueError("go_to_pos must be 0..100")
 
         if gen2:
-            # v2 cover endpoint: auth_key goes in the query string, and a
-            # single ``position`` field carries either the direction string
-            # or the numeric target position.
+            # v2 cover endpoint: a single ``position`` field carries either the
+            # direction string or the numeric target position.
+            #
+            # CREDENTIAL (sent 3/3) — and the one wart, documented as such in
+            # docs/AUTH_KEY.md: the key rides in the QUERY STRING here, not the
+            # body. The recipient is Shelly, who issued it, and the connection
+            # is HTTPS, so this is not disclosure to a third party — but URLs
+            # are typically logged more liberally and kept longer than bodies,
+            # on their servers.
+            #
+            # Measured 2026-08-11 against the live API: the endpoint accepts the
+            # key in the BODY too. No key -> 401 invalid_token; key in the body,
+            # bogus device id -> 400 no_permissions, i.e. authentication passed
+            # and only authorisation failed. So the query string is NOT required
+            # and this could move into the body.
+            #
+            # Not moved yet on purpose: nobody here owns cover hardware, so the
+            # full command path cannot be confirmed end to end, and changing
+            # working control code on inference alone to win a logging nuance on
+            # someone else's servers is a bad trade. Needs one confirmation from
+            # a user with a cover Shelly, then this becomes a two-line change.
             position: str | int | None = (
                 direction if direction is not None else go_to_pos
             )

--- a/docs/AUTH_KEY.de.md
+++ b/docs/AUTH_KEY.de.md
@@ -1,0 +1,223 @@
+# Was diese Integration mit deinem Shelly-Auth-Key macht
+
+*[English version](AUTH_KEY.md)*
+
+Diese Integration fragt dich nach einem Shelly-Cloud-Auth-Key. Dieser Schlüssel
+kann viel, und du installierst hier Code von einem Fremden aus dem Internet.
+Diese Seite sagt dir genau, wohin der Schlüssel geht, wo er liegt, wohin er nie
+geht — und wie du jede einzelne dieser Aussagen in etwa zwei Minuten selbst
+nachprüfst, ohne irgendetwas auszuführen, das ich geschrieben habe.
+
+Wenn du nur einen Absatz liest: der Schlüssel wird in **einer einzigen Datei**
+benutzt, geht **ausschließlich an die Serveradresse, die du bei der Einrichtung
+eingetragen hast**, steht in keinem Log, taucht in keiner Diagnose-Datei auf und
+geht weder an mich noch an irgendeinen Dritten. Die unangenehmen Teile stehen
+weiter unten, und es gibt welche.
+
+---
+
+## Was der Schlüssel ist und was er kann
+
+Der Auth-Key stammt aus der Shelly-App unter *Benutzereinstellungen →
+Autorisierungs-Cloud-Key*. Er ist ein **Zugang zum gesamten Konto**: alles, was
+du in der App kannst, kann auch der Schlüssel — jedes Gerät des Kontos lesen und
+jedes Gerät des Kontos schalten. Es gibt keine Nur-Lesen-Variante und keine
+Beschränkung auf einzelne Geräte. Das ist Shellys Entwurf, keine Entscheidung
+dieser Integration.
+
+**Widerrufen:** ändere das Passwort deines Shelly-Kontos. Der Schlüssel wird
+serverseitig neu erzeugt, der alte ist damit sofort wertlos. Einen eigenen
+„Schlüssel widerrufen"-Knopf gibt es nicht.
+
+Weil sich ein Schlüssel nicht einschränken lässt, ist das vernünftige
+Gedankenmodell: *dieser Schlüssel ist dein Shelly-Passwort in anderer Form.*
+Alles Weitere folgt daraus, das ernst zu nehmen.
+
+---
+
+## Wohin der Schlüssel geht
+
+Genau eine Datei fasst ihn überhaupt an:
+`custom_components/shelly_cloud_diy/api/cloud_control.py`.
+
+Selbst nachsehen:
+
+```bash
+grep -rn "_auth_key" custom_components/shelly_cloud_diy/
+```
+
+Fünf Treffer, und es lohnt sich zu wissen, was jeder davon ist:
+
+| Was es ist | Wo |
+|---|---|
+| auf der Client-Instanz abgelegt | `ShellyCloudControl.__init__` |
+| **gesendet** — Formularfeld, v1-Endpunkte | `_post` |
+| **gesendet** — JSON-Body-Feld, v2-Metadaten | `get_device_configs` |
+| **gesendet** — Query-Parameter, v2-Cover | `roller_control` |
+| nicht der Schlüssel — ein Textvergleich auf eine Fehlermeldung | Fehlerbehandlung in `_post` |
+
+Es sind also **drei** Stellen, die ihn übertragen. Jede Übertragung steht
+ausgeschrieben an der Aufrufstelle; die Hilfsmethoden hängen **nicht** still
+Zugangsdaten an. Genau das macht den `grep` oben vollständig statt bloß
+ungefähr.
+
+Alle drei senden an `self._base_url`. Dieser Wert entsteht einmalig in
+`_normalise_base_url` aus der Serveradresse, die **du** bei der Einrichtung
+eingetragen hast (z. B. `shelly-42-eu.shelly.cloud`, in der App auf derselben
+Seite wie der Schlüssel). Es gibt im Code kein zweites Ziel für den Schlüssel und
+keinen fest verdrahteten Ersatzhost.
+
+Damit du dich überzeugen kannst, dass es überhaupt keinen anderen ausgehenden
+Verkehr gibt:
+
+```bash
+grep -rnE "session\.(get|post|request)|ws_connect|https?://" custom_components/shelly_cloud_diy/
+```
+
+Das einzige Nicht-Shelly-Ziel, das dabei auftaucht, ist eine Gateway-URL für den
+CSV-Import, die **du** selbst konfigurierst — siehe unten.
+
+---
+
+## Wohin der Schlüssel nicht geht
+
+**Nicht ins Log.** Debug-Logging für diese Integration einzuschalten gibt den
+Schlüssel nicht aus. Die Logzeilen, die `auth_key` überhaupt erwähnen, sind
+Meldungen *über* eine Ablehnung („auth_key rejected — skipping"), nie der Wert
+selbst.
+
+```bash
+grep -rn "_LOGGER" custom_components/shelly_cloud_diy/ | grep -i "auth\|key\|token"
+```
+
+**Nicht in die Diagnose-Datei.** Das Diagnose-Modul liest die gespeicherten
+Daten des Config-Eintrags gar nicht an; es exportiert nur den Geräte-Schnappschuss
+und die Fleet-Map, mit geschwärzten Namen, IPs, MACs und SSIDs. Die Datei ist
+rund 130 Zeilen lang, also kurz genug zum vollständigen Lesen:
+`custom_components/shelly_cloud_diy/diagnostics.py`. Das ist wichtig, weil
+Diagnose-Dateien genau das sind, was Leute an öffentliche Fehlerberichte hängen.
+
+**Nicht an mich und an keinen Dritten.** Es gibt keine Telemetrie, keine
+Analytics, kein Crash-Reporting, kein „Nach-Hause-Telefonieren". Die Integration
+deklariert zwei Abhängigkeiten, `aiohttp` und `aioshelly`, die ohnehin beide zu
+Home Assistant gehören (`manifest.json`).
+
+**Nicht an das CSV-Gateway.** Die Integration kann Energie-CSVs von einer
+Gateway-URL holen, die du selbst angibst. Diese Anfrage ist ein schlichtes `GET`
+**ohne jede Zugangsinformation**, und die URL wird vorher geprüft: andere
+Protokolle und Loopback-Ziele werden abgelehnt, die Integration lässt sich also
+nicht auf dein eigenes Home Assistant zurückrichten (`utils/http.py`,
+`validate_gateway_url`).
+
+---
+
+## Wo der Schlüssel liegt — der Teil, den ich lieber nicht schreiben würde
+
+Home Assistant speichert die Daten von Config-Einträgen in
+`<config>/.storage/core.config_entries`, **im Klartext**. Dein Shelly-Schlüssel
+steht unverschlüsselt in dieser Datei, genau wie die Zugangsdaten jeder anderen
+Integration, die du installiert hast.
+
+So arbeitet Home Assistant für alle Integrationen; es gibt keinen unterstützten
+Weg, sich davon auszunehmen, und ich werde nicht so tun als ob. Die praktischen
+Folgen musst du selbst abwägen:
+
+- wer dein Home-Assistant-Konfigurationsverzeichnis lesen kann, kann den
+  Schlüssel lesen
+- dasselbe gilt für jedes **Backup** dieses Verzeichnisses, auch für
+  automatische und für alles, was in einen Cloud-Speicher hochgeladen wird
+- wenn du ein Backup zur Fehlersuche weitergibst — an wen auch immer, mich
+  eingeschlossen — geh davon aus, dass der Schlüssel mitgegangen ist, und wechsle
+  ihn danach
+
+---
+
+## Ein Schönheitsfehler, offen gesagt
+
+Eine der drei Übertragungen — der Gen2-Cover-Befehl in `roller_control` — hängt
+den Schlüssel als **Query-Parameter** an statt ihn in den Body zu legen.
+
+Drei Dinge halten das klein, eines hält es auf der Liste:
+
+- Empfänger ist Shelly, die den Schlüssel ausgestellt haben und damit ohnehin
+  alles können. Es ist keine Preisgabe an einen Dritten.
+- Die Verbindung ist HTTPS, die Query-Zeile ist unterwegs also nicht sichtbar.
+- Es passiert nur, wenn du tatsächlich eine Beschattung fährst.
+
+Was bleibt: URLs werden in Server-Infrastruktur typischerweise großzügiger
+protokolliert und länger aufbewahrt als Request-Bodies — auf Shellys Servern,
+nicht auf deinen. Das kann ich nicht messen und will darüber nicht spekulieren.
+
+**Gemessen am 2026-08-11:** der Endpunkt akzeptiert den Schlüssel auch im Body.
+Ohne Schlüssel antwortet er `401 invalid_token`; mit Schlüssel im Body antwortet
+er auf ein nicht existierendes Gerät `400 no_permissions` — die Authentifizierung
+war also erfolgreich und nur die Berechtigung fehlte. Der Query-Parameter ist
+damit **von der API nicht verlangt** und ließe sich verlegen.
+
+Verlegt habe ich ihn trotzdem noch nicht, aus einem Grund: ich besitze keine
+Cover-Hardware. Ich kann belegen, dass die Authentifizierung über den Body
+funktioniert, aber nicht, dass ein echter Fahrbefehl auf diesem Weg durchläuft.
+Funktionierenden Steuercode auf einen Analogieschluss hin zu ändern, um eine
+Logging-Nuance auf fremden Servern zu gewinnen, ist ein schlechtes Geschäft.
+**Wenn du einen Rollladen-Shelly hast und beim Testen helfen magst, sag bitte in
+einem Issue Bescheid** — mehr braucht es nicht.
+
+---
+
+## Selbst nachprüfen, in zwei Minuten
+
+Führe das gegen den installierten Code aus
+(`<config>/custom_components/shelly_cloud_diy/`) oder gegen einen Checkout.
+Nichts davon führt Code von mir aus.
+
+```bash
+# 1. Jede Stelle, die den Schlüssel benutzt — erwartet: 5 Treffer, alle in api/cloud_control.py
+grep -rn "_auth_key" custom_components/shelly_cloud_diy/
+
+# 2. Jede ausgehende Anfrage der gesamten Integration
+grep -rnE "session\.(get|post|request)|ws_connect" custom_components/shelly_cloud_diy/
+
+# 3. Jede fest eingetragene URL. Erwartet: Doku-Links aus Fehlermeldungen, die
+#    http/https-Schema-Behandlung in _normalise_base_url und das CSV-Gateway-
+#    Beispiel in einem Docstring. NICHT finden solltest du einen fest
+#    verdrahteten API-Host — die Serveradresse kommt immer aus deiner Konfiguration.
+grep -rnE "https?://" custom_components/shelly_cloud_diy/
+
+# 4. Beleg, dass der Schlüssel nicht in deinen Logs steht (im HA-Konfigverzeichnis)
+grep -c "$(: 'deinen Schlüssel hier selbst einsetzen — nicht in ein Skript schreiben')" home-assistant.log
+```
+
+Prüfung 4 ist bewusst dir überlassen, und das ist auch der ganze Grund, warum es
+in diesem Repository **kein** „prüfe meine Installation"-Skript gibt: so ein
+Werkzeug müsste deinen Schlüssel lesen, um nach ihm suchen zu können, und seine
+Ausgabe ist genau das, was Leute in öffentliche Issues kopieren. Ein Prüfer, der
+mit dem ausgeliefert wird, was er prüft, und immer „alles gut" ausgibt, wäre
+zudem nichts wert — du würdest darauf vertrauen, dass sich das Projekt selbst ein
+Zeugnis ausstellt. Ein `grep`, den du selbst getippt hast, hat beide Probleme
+nicht.
+
+Wenn du prüfen willst, ob das von HACS Installierte diesem Repository entspricht:
+die Release-ZIPs werden von GitHub Actions aus dem getaggten Commit gebaut, du
+kannst den installierten Ordner also gegen den Quelltext deiner Version
+vergleichen.
+
+---
+
+## Was dieses Dokument nicht behauptet
+
+- **Nichts über Shellys Seite.** Was deren Server protokollieren, wie lange sie
+  es aufbewahren und wer es lesen kann, weiß ich nicht und kontrolliere ich
+  nicht.
+- **Nichts über die Sicherheit von Home Assistants Speicher**, außer der oben
+  genannten Klartext-Tatsache.
+- **Nichts über künftige Versionen**, außer diesem: diese Datei ist Teil des
+  Quelltexts, und die Handhabung des Schlüssels zu ändern, ohne diese Datei zu
+  ändern, wäre ein meldenswerter Fehler.
+- **Das ist kein Audit durch Dritte.** Es ist eine Beschreibung, die du prüfen
+  kannst, geschrieben von dem, der den Code geschrieben hat. Die Prüfungen zählen
+  mehr als die Beschreibung — deshalb stehen sie hier.
+
+Etwas gefunden, das dem oben Gesagten widerspricht? Bitte
+[ein Issue aufmachen](https://github.com/notDIRK/shelly-cloud-diy-ha/issues) —
+dann ist es ein Fehler in der Software oder auf dieser Seite, und beides will ich
+wissen.

--- a/docs/AUTH_KEY.de.md
+++ b/docs/AUTH_KEY.de.md
@@ -99,8 +99,9 @@ Diagnose-Dateien genau das sind, was Leute an öffentliche Fehlerberichte hänge
 
 **Nicht an mich und an keinen Dritten.** Es gibt keine Telemetrie, keine
 Analytics, kein Crash-Reporting, kein „Nach-Hause-Telefonieren". Die Integration
-deklariert zwei Abhängigkeiten, `aiohttp` und `aioshelly`, die ohnehin beide zu
-Home Assistant gehören (`manifest.json`).
+deklariert in `manifest.json` genau zwei Abhängigkeiten: `aiohttp`, Teil von
+Home Assistants eigenem Unterbau, und `aioshelly`, dieselbe Bibliothek, die auch
+die eingebaute Shelly-Integration benutzt. Nichts Exotisches, nichts von mir.
 
 **Nicht an das CSV-Gateway.** Die Integration kann Energie-CSVs von einer
 Gateway-URL holen, die du selbst angibst. Diese Anfrage ist ein schlichtes `GET`
@@ -142,6 +143,9 @@ Drei Dinge halten das klein, eines hält es auf der Liste:
 - Empfänger ist Shelly, die den Schlüssel ausgestellt haben und damit ohnehin
   alles können. Es ist keine Preisgabe an einen Dritten.
 - Die Verbindung ist HTTPS, die Query-Zeile ist unterwegs also nicht sichtbar.
+  (`https://` wird automatisch ergänzt, wenn du das Schema weglässt. Wenn du bei
+  der Einrichtung bewusst eine `http://`-Adresse eingetragen hast, gilt das
+  nicht — und der Rest auch nicht, also tu das nicht.)
 - Es passiert nur, wenn du tatsächlich eine Beschattung fährst.
 
 Was bleibt: URLs werden in Server-Infrastruktur typischerweise großzügiger
@@ -183,8 +187,14 @@ grep -rnE "session\.(get|post|request)|ws_connect" custom_components/shelly_clou
 #    verdrahteten API-Host — die Serveradresse kommt immer aus deiner Konfiguration.
 grep -rnE "https?://" custom_components/shelly_cloud_diy/
 
-# 4. Beleg, dass der Schlüssel nicht in deinen Logs steht (im HA-Konfigverzeichnis)
-grep -c "$(: 'deinen Schlüssel hier selbst einsetzen — nicht in ein Skript schreiben')" home-assistant.log
+# 4. Beleg, dass der Schlüssel nicht in deinen Logs steht. Im HA-Konfig-
+#    verzeichnis ausführen und <DEIN-KEY> durch den echten Wert ersetzen.
+#    Erwartet: 0
+grep -cF '<DEIN-KEY>' home-assistant.log
+
+#    So landet dein Schlüssel in der Shell-History. Entweder danach löschen
+#    oder das ganz vermeiden, indem du ihn an einer Eingabeaufforderung tippst:
+read -rsp 'key: ' K && grep -cF "$K" home-assistant.log; unset K
 ```
 
 Prüfung 4 ist bewusst dir überlassen, und das ist auch der ganze Grund, warum es

--- a/docs/AUTH_KEY.de.md
+++ b/docs/AUTH_KEY.de.md
@@ -188,13 +188,23 @@ grep -c "$(: 'deinen Schlüssel hier selbst einsetzen — nicht in ein Skript sc
 ```
 
 Prüfung 4 ist bewusst dir überlassen, und das ist auch der ganze Grund, warum es
-in diesem Repository **kein** „prüfe meine Installation"-Skript gibt: so ein
-Werkzeug müsste deinen Schlüssel lesen, um nach ihm suchen zu können, und seine
-Ausgabe ist genau das, was Leute in öffentliche Issues kopieren. Ein Prüfer, der
-mit dem ausgeliefert wird, was er prüft, und immer „alles gut" ausgibt, wäre
-zudem nichts wert — du würdest darauf vertrauen, dass sich das Projekt selbst ein
-Zeugnis ausstellt. Ein `grep`, den du selbst getippt hast, hat beide Probleme
-nicht.
+in diesem Repository **kein** „prüfe meine Installation"-Skript gibt.
+
+Der entscheidende Grund ist nicht, dass so ein Werkzeug unangenehm zu schreiben
+wäre. Er ist: **ein Prüfer, den das Projekt mitliefert, kann das Projekt nicht
+überprüfen.** Läge in diesem Repository ein Skript, das dieses Repository
+untersucht und „alles gut" ausgibt, würdest du mir zweimal vertrauen statt
+einmal — und eine Prüfung, die nicht schlecht ausgehen kann, ist keine Prüfung.
+Sie würde außerdem verrotten: sie testet gegen Erwartungen, die beim Schreiben
+festgelegt wurden, und meldet still weiter „alles gut", nachdem sich der Code
+darunter bewegt hat. Ein `grep`, den du selbst getippt hast, hat beide Probleme
+nicht und bleibt wahr, egal was ich ändere.
+
+Es gibt einen zweiten, kleineren Grund: um dein Log nach deinem Schlüssel zu
+durchsuchen, müsste das Werkzeug deinen Schlüssel lesen, und sein Bericht ist
+genau das, was Leute in öffentliche Issues kopieren. Der Punkt ist lösbar — ein
+Werkzeug könnte über Hashes vergleichen und nie etwas Sensibles ausgeben — und
+genau deshalb ist er der *zweite* Grund und nicht der erste.
 
 Wenn du prüfen willst, ob das von HACS Installierte diesem Repository entspricht:
 die Release-ZIPs werden von GitHub Actions aus dem getaggten Commit gebaut, du

--- a/docs/AUTH_KEY.md
+++ b/docs/AUTH_KEY.md
@@ -1,0 +1,211 @@
+# What this integration does with your Shelly auth key
+
+*[Deutsche Fassung](AUTH_KEY.de.md)*
+
+This integration asks you for a Shelly cloud auth key. That key is powerful, and
+you are installing code from a stranger on the internet. This page tells you
+exactly where the key travels, where it is stored, where it never goes, and how
+to check every one of those claims yourself in about two minutes — without
+running anything I wrote.
+
+If you only read one paragraph: the key is used in **one file**, is sent **only
+to the server address you typed in during setup**, is never logged, never
+appears in a diagnostics download, and is never sent to me or to any third
+party. The uncomfortable parts are further down, and there are some.
+
+---
+
+## What the key is, and what it can do
+
+The auth key comes from the Shelly App under *User settings → Authorization
+cloud key*. It is a **full-account credential**: anything you can do in the
+Shelly App, the key can do — read every device on the account and control every
+device on the account. There is no read-only variant and no per-device scoping.
+That is Shelly's design, not a choice this integration makes.
+
+**Revoking it:** change your Shelly account password. The key is regenerated
+server-side, which makes the old one useless immediately. There is no separate
+"revoke key" button.
+
+Because a key cannot be scoped, the sensible mental model is: *this key is your
+Shelly password in a different shape.* Everything below follows from taking that
+seriously.
+
+---
+
+## Where the key goes
+
+Exactly one file ever touches it:
+`custom_components/shelly_cloud_diy/api/cloud_control.py`.
+
+Check for yourself:
+
+```bash
+grep -rn "_auth_key" custom_components/shelly_cloud_diy/
+```
+
+Five hits, and it is worth knowing what each one is:
+
+| What it is | Where |
+|---|---|
+| stored on the client instance | `ShellyCloudControl.__init__` |
+| **sent** — form field, v1 endpoints | `_post` |
+| **sent** — JSON body field, v2 metadata | `get_device_configs` |
+| **sent** — query parameter, v2 cover | `roller_control` |
+| not the key — a substring test on an error message | `_post` error handling |
+
+So there are **three** places that transmit it. Every transmission is written
+out explicitly at the call site; the helper methods do not silently attach
+credentials, which is what makes the `grep` above complete rather than
+indicative.
+
+All three send to `self._base_url`. That value is built once, in
+`_normalise_base_url`, from the server address **you** typed during setup
+(e.g. `shelly-42-eu.shelly.cloud`, shown in the app on the same screen as the
+key). There is no second destination for the key anywhere in the code, and no
+hard-coded fallback host.
+
+To satisfy yourself that there is no other outbound traffic at all:
+
+```bash
+grep -rnE "session\.(get|post|request)|ws_connect|https?://" custom_components/shelly_cloud_diy/
+```
+
+The only non-Shelly destination that appears is a gateway URL for CSV import
+that **you** configure yourself — see below.
+
+---
+
+## Where the key does not go
+
+**Not into the logs.** Turning on debug logging for this integration does not
+print the key. The log lines that mention `auth_key` at all are messages *about*
+a rejection ("auth_key rejected — skipping"), never the value.
+
+```bash
+grep -rn "_LOGGER" custom_components/shelly_cloud_diy/ | grep -i "auth\|key\|token"
+```
+
+**Not into diagnostics downloads.** The diagnostics module never reads the
+config entry's stored data; it only exports the device snapshot and the fleet
+map, with names, IPs, MACs and SSIDs redacted. The file is about 130 lines —
+short enough to read in full: `custom_components/shelly_cloud_diy/diagnostics.py`.
+This matters because diagnostics downloads are the thing people attach to public
+bug reports.
+
+**Not to me, and not to any third party.** There is no telemetry, no analytics,
+no crash reporting, no "phone home". The integration declares two dependencies,
+`aiohttp` and `aioshelly`, both of which ship with Home Assistant anyway
+(`manifest.json`).
+
+**Not to the CSV gateway.** The integration can fetch energy CSVs from a gateway
+URL you supply yourself. That request is a plain `GET` with **no credential
+attached**, and the URL is validated first — non-HTTP schemes and loopback
+targets are rejected, so the integration cannot be pointed back at your own Home
+Assistant (`utils/http.py`, `validate_gateway_url`).
+
+---
+
+## Where the key is stored — the part I would rather not have to write
+
+Home Assistant stores config entry data in
+`<config>/.storage/core.config_entries`, **in plain text**. Your Shelly key sits
+in that file, unencrypted, exactly like the credentials of every other
+integration you have installed.
+
+This is how Home Assistant works for all integrations; there is no supported way
+for an integration to opt out, and I am not going to pretend otherwise. The
+practical consequences are yours to weigh:
+
+- anyone who can read your Home Assistant config directory can read the key
+- the same is true of any **backup** of that directory, including automatic ones
+  and anything you upload to cloud storage
+- if you share a backup for debugging — with anyone, including me — assume the
+  key went with it, and rotate it afterwards
+
+---
+
+## One wart, stated plainly
+
+One of the three transmissions — the Gen2 cover command in `roller_control` —
+passes the key as a **query parameter** rather than in the request body.
+
+Three things keep this small, and one thing keeps it on the list:
+
+- The recipient is Shelly, who issued the key and can already do everything with
+  it. This is not disclosure to a third party.
+- The connection is HTTPS, so the query string is not visible in transit.
+- It only happens when you actually operate a cover.
+
+What remains is that URLs tend to be logged more liberally, and retained longer,
+than request bodies — on Shelly's servers, not on yours. I cannot measure that
+and will not speculate about it.
+
+**Measured on 2026-08-11:** the endpoint accepts the key in the request body
+too. Sending no key returns `401 invalid_token`; sending it in the body returns
+`400 no_permissions` for a non-existent device — meaning authentication
+succeeded and only authorization failed. So the query parameter is **not
+required by the API** and can be moved.
+
+I have not moved it yet, for one reason: I own no cover hardware, so I can prove
+that authentication works via the body but not that a real cover command
+completes that way. Changing working control code on inference alone, to gain a
+logging nuance on someone else's servers, is a bad trade. **If you own a cover
+Shelly and are willing to test it, please say so in an issue** — that is all
+this needs.
+
+---
+
+## Check it yourself, in two minutes
+
+Run these against the installed code
+(`<config>/custom_components/shelly_cloud_diy/`) or against a checkout. None of
+them run anything I wrote.
+
+```bash
+# 1. Every place the key is used — expect 5 hits, all in api/cloud_control.py
+grep -rn "_auth_key" custom_components/shelly_cloud_diy/
+
+# 2. Every outbound request in the whole integration
+grep -rnE "session\.(get|post|request)|ws_connect" custom_components/shelly_cloud_diy/
+
+# 3. Every hard-coded URL. Expect: documentation links shown in error messages,
+#    the http/https scheme handling in _normalise_base_url, and the CSV gateway
+#    example in a docstring. What you should NOT find is a hard-coded API host —
+#    the server address always comes from your own configuration.
+grep -rnE "https?://" custom_components/shelly_cloud_diy/
+
+# 4. Prove the key is not in your own logs (run in your HA config directory)
+grep -c "$(: 'paste your key here yourself — do not put it in a script')" home-assistant.log
+```
+
+Check 4 is deliberately left for you to complete by hand, and that is the whole
+reason there is no "audit my installation" tool in this repository: such a tool
+would have to read your key in order to search for it, and its output is exactly
+the kind of thing people paste into public issues. A checker that ships with the
+thing it checks and always prints "all good" would also be worth nothing — you
+would be trusting the project to grade itself. A `grep` you typed yourself has
+neither problem.
+
+If you want to verify that what HACS installed matches this repository: release
+ZIPs are built by GitHub Actions from the tagged commit, so you can diff the
+installed folder against the source for the version you are running.
+
+---
+
+## What this document does not claim
+
+- **Nothing about Shelly's side.** What their servers log, how long they keep
+  it, and who can read it is outside my knowledge and outside my control.
+- **Nothing about Home Assistant's storage security** beyond stating the
+  plain-text fact above.
+- **Nothing about future versions**, except this: this file is part of the
+  source, and changing how the key is handled without changing this file would
+  be a bug worth reporting.
+- **This is not a third-party audit.** It is a description you can check,
+  written by the person who wrote the code. The checks matter more than the
+  description; that is why they are here.
+
+Found something that contradicts any of the above? Please
+[open an issue](https://github.com/notDIRK/shelly-cloud-diy-ha/issues) — that is
+a bug in the software or in this page, and either way I want to know.

--- a/docs/AUTH_KEY.md
+++ b/docs/AUTH_KEY.md
@@ -94,9 +94,10 @@ This matters because diagnostics downloads are the thing people attach to public
 bug reports.
 
 **Not to me, and not to any third party.** There is no telemetry, no analytics,
-no crash reporting, no "phone home". The integration declares two dependencies,
-`aiohttp` and `aioshelly`, both of which ship with Home Assistant anyway
-(`manifest.json`).
+no crash reporting, no "phone home". The integration declares exactly two
+dependencies in `manifest.json`: `aiohttp`, which is part of Home Assistant's
+own core stack, and `aioshelly`, the same library Home Assistant's built-in
+Shelly integration uses. Nothing exotic, nothing of mine.
 
 **Not to the CSV gateway.** The integration can fetch energy CSVs from a gateway
 URL you supply yourself. That request is a plain `GET` with **no credential
@@ -135,6 +136,9 @@ Three things keep this small, and one thing keeps it on the list:
 - The recipient is Shelly, who issued the key and can already do everything with
   it. This is not disclosure to a third party.
 - The connection is HTTPS, so the query string is not visible in transit.
+  (`https://` is added automatically if you leave the scheme off. If you
+  deliberately typed an `http://` address at setup, this does not hold — and
+  neither does any of the rest, so do not do that.)
 - It only happens when you actually operate a cover.
 
 What remains is that URLs tend to be logged more liberally, and retained longer,
@@ -175,8 +179,13 @@ grep -rnE "session\.(get|post|request)|ws_connect" custom_components/shelly_clou
 #    the server address always comes from your own configuration.
 grep -rnE "https?://" custom_components/shelly_cloud_diy/
 
-# 4. Prove the key is not in your own logs (run in your HA config directory)
-grep -c "$(: 'paste your key here yourself — do not put it in a script')" home-assistant.log
+# 4. Prove the key is not in your own logs. Run this in your HA config
+#    directory and replace <YOUR-KEY> with the actual value. Expect: 0
+grep -cF '<YOUR-KEY>' home-assistant.log
+
+#    Your key ends up in your shell history this way. Either clear it
+#    afterwards, or avoid it entirely by typing the key at a prompt instead:
+read -rsp 'key: ' K && grep -cF "$K" home-assistant.log; unset K
 ```
 
 Check 4 is deliberately left for you to complete by hand, and that is the whole

--- a/docs/AUTH_KEY.md
+++ b/docs/AUTH_KEY.md
@@ -180,12 +180,22 @@ grep -c "$(: 'paste your key here yourself — do not put it in a script')" home
 ```
 
 Check 4 is deliberately left for you to complete by hand, and that is the whole
-reason there is no "audit my installation" tool in this repository: such a tool
-would have to read your key in order to search for it, and its output is exactly
-the kind of thing people paste into public issues. A checker that ships with the
-thing it checks and always prints "all good" would also be worth nothing — you
-would be trusting the project to grade itself. A `grep` you typed yourself has
-neither problem.
+reason there is no "audit my installation" tool in this repository.
+
+The decisive reason is not that such a tool would be awkward to write. It is
+that **a checker shipped by the project cannot verify the project.** If this
+repository contained a script that examined this repository and printed "all
+good", you would be trusting me twice over instead of once — and a check that
+cannot come out badly is not a check. Any such tool would also rot: it would
+test against expectations hard-coded at the time of writing, and quietly keep
+reporting "all good" after the code moved underneath it. A `grep` you typed
+yourself has neither problem, and it stays true no matter what I change.
+
+There is a second, smaller reason: to search your log for your key, the tool
+would have to read your key, and its report is exactly the kind of thing people
+paste into public issues. That one is solvable — the tool could compare hashes
+and never print anything sensitive — which is precisely why it is the *second*
+reason and not the first.
 
 If you want to verify that what HACS installed matches this repository: release
 ZIPs are built by GitHub Actions from the tagged commit, so you can diff the


### PR DESCRIPTION
Adds `docs/AUTH_KEY.md` and its German mirror, plus the matching in-code markers.

**Read the rendered doc before merging** — this makes public commitments, and merging publishes it (README links it, HACS renders the README).

- [docs/AUTH_KEY.md](https://github.com/notDIRK/shelly-cloud-diy-ha/blob/docs/auth-key-transparency/docs/AUTH_KEY.md)
- [docs/AUTH_KEY.de.md](https://github.com/notDIRK/shelly-cloud-diy-ha/blob/docs/auth-key-transparency/docs/AUTH_KEY.de.md)

**Why no audit script.** A checker would have to read the key in order to search for it; its output is exactly what people paste into public issues; and one shipped alongside the thing it checks amounts to the project grading itself. So the document hands the reader `grep` commands they type themselves instead.

**What is deliberately uncomfortable in it.** The key cannot be scoped to one device. Home Assistant stores it in `.storage/core.config_entries` in plain text. One of the three transmissions passes it as a query parameter.

**Verified, not asserted.** The audit greps in the document return what it says they return (5 hits, all in one file; 3 outbound call sites; no hard-coded API host), and `diagnostics.py` never reads `entry.data`.

**Corrects a wrong code comment.** It claimed the v2 cover endpoint requires the key in the query string. Measured against the live API: no key → `401 invalid_token`; key in the body with a non-existent device id → `400 no_permissions`, i.e. authentication passed. So the query string is not required. Not changed here — there is no cover hardware available to confirm the full command path, and changing working control code on inference alone to win a logging nuance on Shelly's servers is a bad trade. Recorded at the call site with an open invitation to any user who owns a cover.

Docs and comments only, no behaviour change. 94 tests green in both matrix venvs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxqg751CivULXbU63q5WDZ