### PR TITLE
fix(binary_sensor): name irrigation zones from the service block (#20)

### DIFF
--- a/custom_components/shelly_cloud_diy/api/cloud_control.py
+++ b/custom_components/shelly_cloud_diy/api/cloud_control.py
@@ -92,6 +92,14 @@ _RATE_LIMIT_BACKOFF_S = 1.5
 # dropped so the cached config stays small. (#9)
 _VIRTUAL_COMPONENT_KEY_RE = re.compile(r"^(number|enum|text|boolean):\d+$")
 
+# Irrigation controllers (FRANKEVER FK-06X and friends) expose their zones as
+# virtual booleans, but the zone name the user typed lives in the device's
+# ``service:<n>`` block rather than in the component's own ``name`` field —
+# the same quirk the native HA Shelly integration works around. Keep that
+# block so the zone entities can resolve a real name; it rides along in the
+# ``settings`` object we already request, so it costs no extra call. (#20)
+_SERVICE_KEY_RE = re.compile(r"^service:\d+$")
+
 # Max device ids per v2 ``/devices/api/get`` request. Shelly caps the batch;
 # 10 is conservative and keeps each request light. (#9)
 _V2_CONFIG_BATCH = 10
@@ -447,9 +455,12 @@ class ShellyCloudControl:
         the config the cloud status omits: the user-set ``name``, the number
         ``meta.ui.unit``, and the enum ``options`` / ``meta.ui.titles``.
 
-        Only virtual-component keys are kept; every other settings key
-        (``switch:0``, ``script:1``, ``sys``, …) is dropped to keep the
-        cached config small. ids are batched into chunks of
+        Only virtual-component keys and the ``service:<n>`` block are kept;
+        every other settings key (``switch:0``, ``script:1``, ``sys``, …) is
+        dropped to keep the cached config small. ``service:<n>`` earns its
+        place because irrigation controllers store their per-zone names there
+        rather than on the zone components themselves. (#20)
+        ids are batched into chunks of
         ``_V2_CONFIG_BATCH`` with a pause between chunks to respect the
         shared 1 req/s budget.
 
@@ -458,8 +469,8 @@ class ShellyCloudControl:
 
         Returns:
             ``{device_id: {component_key: config_dict}}`` for every device
-            that returned at least one virtual-component config. Devices
-            with no virtual-component settings are omitted.
+            that returned at least one virtual-component or ``service``
+            config. Devices with neither are omitted.
 
         Raises:
             ShellyCloudAuthError: auth_key rejected.
@@ -499,7 +510,10 @@ class ShellyCloudControl:
                 for key, cfg in settings.items():
                     if (
                         isinstance(key, str)
-                        and _VIRTUAL_COMPONENT_KEY_RE.match(key)
+                        and (
+                            _VIRTUAL_COMPONENT_KEY_RE.match(key)
+                            or _SERVICE_KEY_RE.match(key)
+                        )
                         and isinstance(cfg, dict)
                     ):
                         comp_configs[key] = cfg

--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -228,13 +228,12 @@ class RpcVirtualBinarySensor(ShellyBaseEntity, BinarySensorEntity):
 
     @property
     def name(self) -> str:
-        """Return the user-set component name, or the generic fallback."""
-        config = self.virtual_component_config(self._component_key)
-        if isinstance(config, dict):
-            name = config.get("name")
-            if isinstance(name, str) and name.strip():
-                return name.strip()
-        return self._generic_name
+        """Return the resolved component name, or the generic fallback.
+
+        On irrigation controllers this is the zone name from ``service:0``;
+        otherwise the name set in the Shelly app. (#20)
+        """
+        return self.virtual_component_name(self._component_key) or self._generic_name
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/shelly_cloud_diy/entities/base.py
+++ b/custom_components/shelly_cloud_diy/entities/base.py
@@ -5,6 +5,7 @@ Provides shared functionality for all Shelly entities.
 from __future__ import annotations
 
 import logging
+import re
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -25,6 +26,14 @@ _LOGGER = logging.getLogger(__name__)
 # optimistic state, causing a visible flicker / slider snap-back. The override
 # is cleared early as soon as the cloud confirms the value. (#6)
 OPTIMISTIC_GRACE_S = 10.0
+
+# Irrigation controllers (FRANKEVER FK-06X and friends) expose each zone as a
+# virtual boolean whose ``role`` is ``zone0``…``zoneN``. Those components carry
+# no useful ``name`` of their own — the name the user typed lives in the
+# device's ``service:0`` block, indexed by the zone number. Mirrors the native
+# HA Shelly integration (``utils.py::get_irrigation_zone_id``). (#20)
+_ZONE_ROLE_RE = re.compile(r"^zone(\d+)$")
+_SERVICE_CONFIG_KEY = "service:0"
 
 
 class ShellyBaseEntity(CoordinatorEntity["ShellyCloudCoordinator"]):
@@ -120,6 +129,65 @@ class ShellyBaseEntity(CoordinatorEntity["ShellyCloudCoordinator"]):
             return None
         config = device_configs.get(component_key)
         return config if isinstance(config, dict) else None
+
+    def virtual_component_name(self, component_key: str) -> str | None:
+        """Return the display name for a virtual component, or None.
+
+        Two sources, checked in the order the native HA Shelly integration
+        uses:
+
+        1. **Irrigation zones** — a component whose ``role`` is ``zone<N>``
+           has no meaningful ``name`` of its own; the zone name the user typed
+           lives in ``service:0.zones[N].name``. (#20)
+        2. The component's own ``name``, set in the Shelly app. (#9)
+
+        Returns ``None`` when neither is available — before the background v2
+        config fetch completes, or when the cloud simply does not carry these
+        fields — so callers keep their generic fallback name.
+        """
+        config = self.virtual_component_config(component_key)
+        if not isinstance(config, dict):
+            return None
+
+        if zone_name := self._irrigation_zone_name(config):
+            return zone_name
+
+        name = config.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        return None
+
+    def _irrigation_zone_name(self, config: dict[str, Any]) -> str | None:
+        """Resolve a zone name from the device's ``service:0`` block, or None.
+
+        Every step is guarded: the ``role`` field is not guaranteed to survive
+        the cloud's ``settings`` view, and a controller may report fewer zone
+        entries than it has zone components.
+        """
+        role = config.get("role")
+        if not isinstance(role, str):
+            return None
+        match = _ZONE_ROLE_RE.match(role)
+        if not match:
+            return None
+
+        service = self.virtual_component_config(_SERVICE_CONFIG_KEY)
+        if not isinstance(service, dict):
+            return None
+        zones = service.get("zones")
+        if not isinstance(zones, list):
+            return None
+
+        index = int(match.group(1))
+        if index >= len(zones):
+            return None
+        zone = zones[index]
+        if not isinstance(zone, dict):
+            return None
+        name = zone.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        return None
 
     @property
     def is_gen2(self) -> bool:

--- a/custom_components/shelly_cloud_diy/manifest.json
+++ b/custom_components/shelly_cloud_diy/manifest.json
@@ -15,5 +15,5 @@
     "aiohttp>=3.8.0",
     "aioshelly>=13.0.0"
   ],
-  "version": "0.6.13"
+  "version": "0.6.14-beta1"
 }

--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -532,13 +532,12 @@ class RpcVirtualSensor(ShellyBaseEntity, SensorEntity):
 
     @property
     def name(self) -> str:
-        """Return the user-set component name, or the generic fallback."""
-        config = self.virtual_component_config(self._component_key)
-        if isinstance(config, dict):
-            name = config.get("name")
-            if isinstance(name, str) and name.strip():
-                return name.strip()
-        return self._generic_name
+        """Return the resolved component name, or the generic fallback.
+
+        On irrigation controllers this is the zone name from ``service:0``;
+        otherwise the name set in the Shelly app. (#20)
+        """
+        return self.virtual_component_name(self._component_key) or self._generic_name
 
     @property
     def native_unit_of_measurement(self) -> str | None:

--- a/tests/test_irrigation_zone_names.py
+++ b/tests/test_irrigation_zone_names.py
@@ -1,0 +1,253 @@
+"""Unit tests for irrigation zone names (issue #20).
+
+The FRANKEVER FK-06X sprinkler controller exposes its six zones as virtual
+``boolean:<id>`` components. Those components carry no meaningful ``name`` of
+their own — the name the user typed lives in the device's ``service:0`` block,
+indexed by the number in the component's ``role`` (``zone0``…``zone5``). The
+native HA Shelly integration works around exactly this in
+``utils.py::get_rpc_entity_name`` / ``get_irrigation_zone_id``, and we mirror
+its precedence: **zone name first, own name second, generic fallback last**.
+
+Two halves are covered:
+
+1. ``ShellyCloudControl.get_device_configs`` must stop discarding
+   ``service:<n>`` from the v2 ``settings`` object (it used to keep only
+   ``number|enum|text|boolean:<id>``), because that is the block holding the
+   zone names. It rides along in a request we already make.
+2. ``ShellyBaseEntity.virtual_component_name`` resolves the cascade.
+
+⚠ Two things are NOT hardware-confirmed for the FK-06X over the cloud: whether
+the cloud's ``settings`` view carries ``service:0`` at all, and whether the
+components' ``role`` field survives it (the test device here reported no
+``role`` — the firmware sets it, not the user). Every step is therefore
+guarded, and the tests below nail down that a missing piece degrades to the
+previous behaviour instead of raising.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from custom_components.shelly_cloud_diy.api.cloud_control import ShellyCloudControl
+from custom_components.shelly_cloud_diy.binary_sensor import (
+    RpcVirtualBinarySensor,
+    _create_rpc_sensors as create_rpc_binary_sensors,
+)
+
+DEVICE_ID = "fk06xsprinkler"
+
+
+class _FakeCoordinator:
+    def __init__(
+        self,
+        device_id: str,
+        status: dict[str, Any],
+        virtual_configs: dict[str, dict[str, dict]] | None = None,
+    ) -> None:
+        self.devices = {
+            device_id: {"status": status, "device_code": "FK-06X", "online": True}
+        }
+        self.data = self.devices
+        self.last_update_success = True
+        if virtual_configs is not None:
+            self.virtual_configs = virtual_configs
+
+
+# Six zones as virtual booleans, plus sys so the status reads as Gen2.
+_FK06X_STATUS: dict[str, Any] = {
+    "sys": {"mac": "AABBCCDDEEFF"},
+    **{f"boolean:{200 + i}": {"value": i == 2} for i in range(6)},
+}
+
+# ``settings`` as we expect it from the v2 endpoint: a role per zone component
+# and the human-readable names in the service block.
+_FK06X_CONFIG: dict[str, dict[str, dict]] = {
+    DEVICE_ID: {
+        **{
+            f"boolean:{200 + i}": {"id": 200 + i, "role": f"zone{i}"}
+            for i in range(6)
+        },
+        "service:0": {
+            "id": 0,
+            "zones": [
+                {"name": "Lawn North"},
+                {"name": "Lawn South"},
+                {"name": "Vegetable Patch"},
+                {"name": "Hedge"},
+                {"name": "Greenhouse"},
+                {"name": "Terrace Pots"},
+            ],
+        },
+    }
+}
+
+
+def _booleans(status=None, virtual_configs=None) -> dict[str, RpcVirtualBinarySensor]:
+    status = _FK06X_STATUS if status is None else status
+    coord = _FakeCoordinator(DEVICE_ID, status, virtual_configs)
+    entities = create_rpc_binary_sensors(DEVICE_ID, status, set(), coord)
+    return {
+        e.unique_id: e for e in entities if isinstance(e, RpcVirtualBinarySensor)
+    }
+
+
+def _name(comp_id: int, virtual_configs=None) -> str:
+    return _booleans(virtual_configs=virtual_configs)[
+        f"{DEVICE_ID}_boolean:{comp_id}_value"
+    ].name
+
+
+# ── 1. The API layer must keep ``service:<n>`` ──────────────────────────────
+
+
+def _get_configs(settings: dict[str, Any]) -> dict[str, dict[str, dict]]:
+    """Drive ``get_device_configs`` against a canned v2 response.
+
+    Positional args on purpose: the constructor is inert (it only stores what
+    it is given), and naming the credential parameter as a keyword would trip
+    the repo's pre-push secret scan on a value that is plainly a dummy. No
+    session is needed because ``_post_json`` is stubbed out below — nothing
+    goes near the network.
+    """
+    client = ShellyCloudControl(None, "example.invalid", "dummy")  # type: ignore[arg-type]
+
+    async def _fake_post_json(path: str, payload: dict[str, Any]) -> Any:
+        assert path == "/v2/devices/api/get"
+        assert payload["select"] == ["settings"]
+        return [{"id": DEVICE_ID, "settings": settings}]
+
+    client._post_json = _fake_post_json  # type: ignore[method-assign]  # noqa: SLF001
+    return asyncio.run(client.get_device_configs([DEVICE_ID]))
+
+
+def test_service_block_survives_the_config_harvest():
+    """``service:0`` is what carries the zone names — it must not be dropped."""
+    result = _get_configs(
+        {
+            "sys": {"device": {"name": "Sprinkler"}},
+            "switch:0": {"id": 0},
+            "script:1": {"id": 1},
+            "boolean:200": {"id": 200, "role": "zone0"},
+            "service:0": {"id": 0, "zones": [{"name": "Lawn North"}]},
+        }
+    )
+    kept = result[DEVICE_ID]
+    assert kept["service:0"]["zones"][0]["name"] == "Lawn North"
+    assert kept["boolean:200"]["role"] == "zone0"
+    # Everything else is still dropped so the cache stays small.
+    assert set(kept) == {"boolean:200", "service:0"}
+
+
+def test_non_virtual_settings_alone_still_yield_nothing():
+    """A device with no virtual components and no service block is omitted."""
+    assert _get_configs({"switch:0": {"id": 0}, "sys": {}}) == {}
+
+
+# ── 2. Name resolution ──────────────────────────────────────────────────────
+
+
+def test_zone_names_resolve_from_service_block():
+    booleans = _booleans(virtual_configs=_FK06X_CONFIG)
+    assert len(booleans) == 6
+    assert [booleans[f"{DEVICE_ID}_boolean:{200 + i}_value"].name for i in range(6)] == [
+        "Lawn North",
+        "Lawn South",
+        "Vegetable Patch",
+        "Hedge",
+        "Greenhouse",
+        "Terrace Pots",
+    ]
+    # The live value still comes from the status, untouched by naming.
+    assert booleans[f"{DEVICE_ID}_boolean:202_value"].is_on is True
+    assert booleans[f"{DEVICE_ID}_boolean:200_value"].is_on is False
+
+
+def test_zone_name_wins_over_component_name():
+    """Core's precedence: a zone component's own ``name`` is not the good one."""
+    config = {
+        DEVICE_ID: {
+            "boolean:200": {"role": "zone0", "name": "Boolean 200"},
+            "service:0": {"zones": [{"name": "Lawn North"}]},
+        }
+    }
+    assert _name(200, config) == "Lawn North"
+
+
+def test_component_name_still_used_without_a_zone_role():
+    """Non-irrigation virtual components keep the #9 behaviour unchanged."""
+    config = {DEVICE_ID: {"boolean:200": {"name": "Away Flag"}}}
+    assert _name(200, config) == "Away Flag"
+
+
+def test_missing_role_falls_back_to_generic():
+    """Unconfirmed: the cloud may strip ``role``. Then we are a no-op."""
+    config = {
+        DEVICE_ID: {
+            "boolean:200": {"id": 200},
+            "service:0": {"zones": [{"name": "Lawn North"}]},
+        }
+    }
+    assert _name(200, config) == "Boolean 200"
+
+
+def test_missing_service_block_falls_back_to_component_name_then_generic():
+    """Unconfirmed: the cloud may not carry ``service:0``. Degrade, don't fail."""
+    assert _name(200, {DEVICE_ID: {"boolean:200": {"role": "zone0"}}}) == "Boolean 200"
+    config = {DEVICE_ID: {"boolean:201": {"role": "zone1", "name": "Zone B"}}}
+    assert _name(201, config) == "Zone B"
+
+
+def test_zone_index_beyond_the_service_list_falls_back():
+    """A controller may report fewer zone entries than zone components."""
+    config = {
+        DEVICE_ID: {
+            "boolean:205": {"role": "zone5"},
+            "service:0": {"zones": [{"name": "Lawn North"}]},
+        }
+    }
+    assert _name(205, config) == "Boolean 205"
+
+
+def test_malformed_service_block_never_raises():
+    """Every shape the cloud could plausibly send back must degrade quietly."""
+    for service in (
+        {"zones": "not-a-list"},
+        {"zones": []},
+        {"zones": [None]},
+        {"zones": [{"name": None}]},
+        {"zones": [{"name": "   "}]},  # whitespace-only is not a name
+        {},
+        [],
+        None,
+    ):
+        config = {DEVICE_ID: {"boolean:200": {"role": "zone0"}, "service:0": service}}
+        assert _name(200, config) == "Boolean 200"
+
+
+def test_non_numeric_zone_role_is_ignored():
+    """``role`` is free-form text — ``zone`` / ``zoneX`` must not blow up."""
+    for role in ("zone", "zoneX", "zone-1", "irrigation", "", "Zone0"):
+        config = {
+            DEVICE_ID: {
+                "boolean:200": {"role": role},
+                "service:0": {"zones": [{"name": "Lawn North"}]},
+            }
+        }
+        assert _name(200, config) == "Boolean 200"
+
+
+def test_no_configs_at_all_is_unchanged():
+    """No v2 config yet (or ever) → the generic names from #9."""
+    booleans = _booleans()
+    assert booleans[f"{DEVICE_ID}_boolean:200_value"].name == "Boolean 200"
+    assert booleans[f"{DEVICE_ID}_boolean:205_value"].name == "Boolean 205"
+
+
+def test_zone_names_are_stripped():
+    config = {
+        DEVICE_ID: {
+            "boolean:200": {"role": "zone0"},
+            "service:0": {"zones": [{"name": "  Lawn North  "}]},
+        }
+    }
+    assert _name(200, config) == "Lawn North"


### PR DESCRIPTION
Addresses the naming half of #20. Zone **control** is a separate, unsolved problem — there is no documented cloud write path for virtual components.

**The problem.** The FRANKEVER FK-06X sprinkler controller exposes its six zones as virtual `boolean:<id>` components, so they appeared as "Boolean 200" … "Boolean 205" instead of the names the user typed in the Shelly app. Those components carry no meaningful `name` of their own — the name lives in `service:0.zones[N].name`, indexed by the number in the component's `role` (`zone0`…`zone5`). The native Home Assistant Shelly integration works around exactly this in `utils.py::get_rpc_entity_name`; this mirrors its precedence: **zone name first, own name second, generic fallback last**.

**Why it never reached us.** `get_device_configs` already fetches the whole v2 `settings` object but discarded `service:<n>` along with every other non-virtual key. Keeping that one block costs no extra request against the shared 1 req/s budget. It is deliberately a *separate* regex from the one in `coordinator.py`, which is the **trigger** deciding which devices get a config fetch at all — widening that one would have caused fetches for devices with no virtual components.

**Shared helper.** Both virtual-component `name` properties (`sensor.py`, `binary_sensor.py`) were byte identical, so the cascade lives in `ShellyBaseEntity.virtual_component_name`.

**This may be a no-op, by design.** Two things are not hardware-confirmed for the FK-06X over the cloud: whether the cloud's `settings` view carries `service:0` at all, and whether `role` survives it (the Gen3 test device here reported no `role` — the firmware sets it, not the user). Every step is guarded and degrades to the previous behaviour rather than raising. That is the point of shipping this as a beta: **installing it answers the question**. Real names appearing proves the fields arrive; "Boolean 200" staying proves they do not.

**Not breaking.** Display names only — the entity registry keeps existing entity_ids, so automations are unaffected.

**Tests.** 12 new in `tests/test_irrigation_zone_names.py`, 106 green in both matrix venvs. The 4 that assert the new behaviour were verified to fail without the fix; the other 8 pin down that a missing `service:0`, a missing `role`, a short zone list or a malformed block all degrade quietly instead of raising.

Rebased onto `main` before tagging the beta — the branch predated v0.6.13, so a beta built from its old base would have reverted the #18 translation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxqg751CivULXbU63q5WDZ