### PR TITLE
fix(sensor): add missing attributes

### DIFF
--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -204,6 +204,8 @@ def _create_rpc_sensors(
                 ("apower", "switch_power"),
                 ("voltage", "switch_voltage"),
                 ("current", "switch_current"),
+                ("aenergy", "switch_energy"),
+                ("temperature", "switch_temperature"),
             ]:
                 if attr in data:
                     desc = RPC_SENSORS.get(desc_key)


### PR DESCRIPTION
This commit adds the attributes aenergy and temperature to the Gen2/Gen3 RPC sensors. Previously they were missing so the sensor entities were not shown in Home Assistant.

Before:
<img width="617" height="1010" alt="grafik" src="https://github.com/user-attachments/assets/a1624f94-7964-4334-9d6e-ff6e0a22bfc8" />


After:
<img width="617" height="1010" alt="grafik" src="https://github.com/user-attachments/assets/a6b1a670-f75b-49e4-a23c-a233f3e4be99" />
