### PR TITLE
fix: device picker survives a vanished device (#25), ppm unit per HA version (#26)

### DIFF
--- a/custom_components/shelly_cloud_diy/config_flow.py
+++ b/custom_components/shelly_cloud_diy/config_flow.py
@@ -80,12 +80,22 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 def _build_device_options(
     devices: dict[str, dict[str, Any]],
     names: dict[str, str],
+    keep_ids: list[str] | None = None,
 ) -> list[SelectOptionDict]:
     """Build multi-select option list: labelled devices, online-first then by name.
 
     ``devices`` is the raw ``devices_status`` dict from ``/device/all_status``
     (keys are device_ids, values carry at least ``code``, ``_dev_info``, etc.).
     ``names`` maps device_id → user-set name (may be a subset of the devices).
+
+    ``keep_ids`` are device ids the user has already saved. Any of them missing
+    from ``devices`` still gets an option, listed last and labelled as
+    unavailable. Without this the form becomes unsubmittable: the saved value is
+    pre-ticked but is not among the permitted options, so Home Assistant rejects
+    the WHOLE form with "value must be one of [...]" — which also blocks adding
+    a perfectly fine new device. Note this is not the same as being offline;
+    offline devices are still listed (with a ⚠ prefix). A device has to drop out
+    of the cloud listing entirely, which happens. (#25)
     """
     options: list[tuple[bool, str, str, str]] = []
     for did, status in devices.items():
@@ -116,7 +126,29 @@ def _build_device_options(
     # Online first (True sorts before False when we invert), then by
     # lower-cased name, then by id.
     options.sort(key=lambda t: (not t[0], t[1], t[2]))
-    return [SelectOptionDict(value=did, label=label) for _, _, did, label in options]
+    result = [SelectOptionDict(value=did, label=label) for _, _, did, label in options]
+
+    # Saved devices the cloud is not listing right now, appended last so the
+    # normal fleet stays at the top. The label says why they look odd and what
+    # to do; keeping them selectable is the whole point — the user can now
+    # deliberately drop one instead of being stuck. (#25)
+    if keep_ids:
+        known = set(devices)
+        for did in keep_ids:
+            if not isinstance(did, str) or did in known:
+                continue
+            known.add(did)
+            name = names.get(did)
+            base = name if name else "Shelly"
+            result.append(
+                SelectOptionDict(
+                    value=did,
+                    label=f"⚠ {base} ({did}) — not in the current cloud listing, "
+                          f"untick to remove",
+                )
+            )
+
+    return result
 
 
 async def _fetch_devices_and_names(
@@ -453,8 +485,20 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Single form mirroring the config flow's bulk-action + list UX."""
+        current_opts = self.config_entry.options
+
+        # Read the saved selection BEFORE building the options, so devices the
+        # cloud is not listing right now survive as choices instead of making
+        # the form unsubmittable. (#25)
+        raw_enabled = current_opts.get(CONF_ENABLED_DEVICES)
+        saved_ids = (
+            [d for d in raw_enabled if isinstance(d, str)]
+            if isinstance(raw_enabled, list)
+            else []
+        )
+
         options = _build_device_options(
-            self._pending_devices, self._pending_names
+            self._pending_devices, self._pending_names, keep_ids=saved_ids
         )
         all_ids = [opt["value"] for opt in options]
 
@@ -478,13 +522,11 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
             opts[CONF_ENABLED_DEVICES] = selected
             return self._save(opts)
 
-        current_opts = self.config_entry.options
         if current_opts.get(CONF_CREATE_ALL_INITIALLY):
             default_enabled = all_ids
         else:
-            raw_enabled = current_opts.get(CONF_ENABLED_DEVICES)
             if isinstance(raw_enabled, list):
-                default_enabled = [d for d in raw_enabled if isinstance(d, str)]
+                default_enabled = saved_ids
             else:
                 # Pre-v0.4.0 entry being edited for the first time — default
                 # to "all currently visible" so the user sees their fleet

--- a/custom_components/shelly_cloud_diy/entities/descriptions.py
+++ b/custom_components/shelly_cloud_diy/entities/descriptions.py
@@ -13,7 +13,6 @@ from typing import Any, Callable, Final
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
@@ -28,6 +27,28 @@ from homeassistant.const import (
 )
 
 from aioshelly.const import MODEL_NAMES
+
+# Parts-per-million unit, resolved per Home Assistant version. (#26)
+#
+# ``CONCENTRATION_PARTS_PER_MILLION`` is deprecated and scheduled for removal in
+# Core 2027.8; merely importing it on a recent HA logs a deprecation warning at
+# every start, for every user, whether or not they own a gas sensor — the table
+# below is built at import time. ``UnitOfRatio`` is the replacement, but it does
+# NOT exist on the oldest HA this integration supports (verified: ImportError on
+# 2025.1.4), so a straight swap would trade one group of users for another.
+#
+# Both resolve to the same value, ``"ppm"``, so preferring the new name and
+# falling back to the old one is behaviourally identical on every version. The
+# order matters: the fallback must only be reached when the new name is absent,
+# because the deprecation fires on import, not on use.
+try:
+    from homeassistant.const import UnitOfRatio
+
+    _PARTS_PER_MILLION: Final = UnitOfRatio.PARTS_PER_MILLION
+except ImportError:  # HA older than the rename
+    from homeassistant.const import (  # noqa: F401
+        CONCENTRATION_PARTS_PER_MILLION as _PARTS_PER_MILLION,
+    )
 
 
 def get_model_name(device_code: str) -> str:
@@ -208,7 +229,7 @@ BLOCK_SENSORS: Final[dict[tuple[str, str], BlockSensorDescription]] = {
     ("sensor", "concentration"): BlockSensorDescription(
         key="sensor|concentration",
         name="Gas Concentration",
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=_PARTS_PER_MILLION,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:molecule",
     ),

--- a/tests/test_device_picker_missing_device.py
+++ b/tests/test_device_picker_missing_device.py
@@ -1,0 +1,126 @@
+"""The device picker must stay submittable when a saved device vanishes (#25).
+
+Reported by @Frido1980. The picker's permitted values came purely from the
+current ``/device/all_status`` response, while the pre-ticked selection came
+from what the user saved earlier. When a saved device was missing from that
+response, its id was no longer an allowed value — so Home Assistant rejected
+the ENTIRE form with ``value must be one of [...]``, and a newly bought Shelly
+sitting right there in the list could not be added either.
+
+Being merely offline does not cause this: offline devices are still listed, with
+a ⚠ prefix. The device has to disappear from the cloud listing altogether, which
+is what happened to the reporter (his device had also gone offline in the Shelly
+app itself).
+
+These tests drive the real option builder and the real voluptuous schema, so the
+selector's validation is what decides — not a reimplementation of it.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import voluptuous as vol
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from custom_components.shelly_cloud_diy.config_flow import _build_device_options
+
+PRESENT = "aabbccddee01"
+GONE = "aabbccddee99"
+NEW = "aabbccddee02"
+
+DEVICES: dict[str, dict[str, Any]] = {
+    PRESENT: {"code": "SNSW-001X16EU", "cloud": {"connected": True}},
+    NEW: {"code": "SNSW-001X16EU", "cloud": {"connected": True}},
+}
+NAMES = {PRESENT: "Hallway", NEW: "Garage", GONE: "Shed Pump"}
+
+
+def _validate(options, selection):
+    """Run a selection through the same selector the form uses."""
+    schema = vol.Schema(
+        {
+            vol.Optional("enabled_devices"): SelectSelector(
+                SelectSelectorConfig(
+                    options=options,
+                    multiple=True,
+                    mode=SelectSelectorMode.LIST,
+                )
+            )
+        }
+    )
+    return schema({"enabled_devices": selection})
+
+
+def test_reproduces_the_reported_failure_without_keep_ids():
+    """Without the fix the saved-but-missing id is rejected — the actual bug."""
+    options = _build_device_options(DEVICES, NAMES)
+    with pytest.raises(vol.Invalid):
+        _validate(options, [PRESENT, GONE])
+
+
+def test_form_stays_submittable_with_keep_ids():
+    """With the saved ids passed in, the same selection validates."""
+    options = _build_device_options(DEVICES, NAMES, keep_ids=[PRESENT, GONE])
+    result = _validate(options, [PRESENT, GONE])
+    assert set(result["enabled_devices"]) == {PRESENT, GONE}
+
+
+def test_the_new_device_can_now_be_added():
+    """The reporter's actual goal: add a new device while a saved one is gone."""
+    options = _build_device_options(DEVICES, NAMES, keep_ids=[PRESENT, GONE])
+    result = _validate(options, [PRESENT, GONE, NEW])
+    assert NEW in result["enabled_devices"]
+
+
+def test_missing_device_can_be_deliberately_dropped():
+    """Unticking it must be allowed — that is how the user gets rid of it."""
+    options = _build_device_options(DEVICES, NAMES, keep_ids=[PRESENT, GONE])
+    result = _validate(options, [PRESENT])
+    assert result["enabled_devices"] == [PRESENT]
+
+
+def test_missing_device_is_labelled_and_sorted_last():
+    options = _build_device_options(DEVICES, NAMES, keep_ids=[PRESENT, GONE])
+    assert options[-1]["value"] == GONE
+    label = options[-1]["label"]
+    assert "Shed Pump" in label          # keep the name the user knows
+    assert GONE in label                 # and the id, for identification
+    assert "not in the current cloud listing" in label
+    assert "untick to remove" in label   # say what to do about it
+
+
+def test_present_devices_are_untouched():
+    """The normal fleet must render exactly as before — no duplicates, no churn."""
+    plain = _build_device_options(DEVICES, NAMES)
+    kept = _build_device_options(DEVICES, NAMES, keep_ids=[PRESENT, GONE])
+    assert kept[: len(plain)] == plain
+    assert len(kept) == len(plain) + 1
+
+
+def test_no_duplicate_when_saved_device_is_present():
+    """A saved id that IS in the listing must not be added a second time."""
+    options = _build_device_options(DEVICES, NAMES, keep_ids=[PRESENT, NEW])
+    values = [o["value"] for o in options]
+    assert len(values) == len(set(values)) == 2
+
+
+def test_keep_ids_tolerates_junk():
+    """Stored options are user-editable JSON; malformed entries must not raise."""
+    options = _build_device_options(
+        DEVICES, NAMES, keep_ids=[PRESENT, None, 42, "", GONE]  # type: ignore[list-item]
+    )
+    values = [o["value"] for o in options]
+    assert GONE in values
+    assert None not in values and 42 not in values
+
+
+def test_unnamed_missing_device_still_gets_a_label():
+    """No stored name (never renamed in the app) must not produce a blank label."""
+    options = _build_device_options(DEVICES, {}, keep_ids=[GONE])
+    assert GONE in options[-1]["label"]
+    assert options[-1]["label"].strip() != ""

--- a/tests/test_ppm_unit_compat.py
+++ b/tests/test_ppm_unit_compat.py
@@ -1,0 +1,67 @@
+"""The parts-per-million unit must be right on BOTH ends of the HA range (#26).
+
+Reported by @elad-eyal: every start logged
+
+    The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from
+    shelly_cloud_diy. It will be removed in HA Core 2027.8.
+
+The trap is that the obvious fix breaks the other end. ``UnitOfRatio`` does not
+exist on HA 2025.1.4, the oldest version this integration supports — importing
+it there raises ImportError outright. So the code resolves the unit per version,
+and these tests pin down both halves of that bargain: the value must be
+identical everywhere, and the modern name must actually be preferred where it
+exists (otherwise the deprecation, and the 2027.8 removal, still apply).
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.shelly_cloud_diy.entities import descriptions
+from custom_components.shelly_cloud_diy.entities.descriptions import BLOCK_SENSORS
+
+
+def test_unit_value_is_ppm_on_every_supported_version():
+    """Whatever the constant is called here, the value users see must be 'ppm'."""
+    assert descriptions._PARTS_PER_MILLION == "ppm"
+
+
+def test_gas_concentration_sensor_carries_the_unit():
+    """The Shelly Gas concentration sensor is the only consumer — check it."""
+    desc = BLOCK_SENSORS[("sensor", "concentration")]
+    assert desc.native_unit_of_measurement == "ppm"
+
+
+def test_modern_name_is_preferred_where_it_exists():
+    """On HA versions that have UnitOfRatio, we must be using it.
+
+    Without this, someone could 'fix' a future import error by reaching for the
+    deprecated constant again and the warning would quietly come back — which is
+    exactly the state #26 reported.
+    """
+    try:
+        from homeassistant.const import UnitOfRatio
+    except ImportError:
+        pytest.skip("HA predates UnitOfRatio — the fallback branch is correct here")
+
+    assert descriptions._PARTS_PER_MILLION is UnitOfRatio.PARTS_PER_MILLION
+
+
+def test_deprecated_constant_is_not_imported_unconditionally():
+    """The old name may appear only inside the ImportError fallback.
+
+    A plain top-level import would emit the deprecation warning on modern HA
+    even if the value were never used, because HA raises it on attribute access
+    at import time. Source-level check, because by the time a test runs the
+    import has already happened and the warning is long gone.
+    """
+    from pathlib import Path
+
+    source = Path(descriptions.__file__).read_text(encoding="utf-8")
+    occurrences = source.count("CONCENTRATION_PARTS_PER_MILLION")
+    # One mention in the explanatory comment, one in the fallback import.
+    assert occurrences == 2, (
+        f"expected the deprecated constant exactly twice (comment + guarded "
+        f"fallback), found {occurrences} — is it imported unconditionally again?"
+    )
+    guarded = source.split("except ImportError")[1]
+    assert "CONCENTRATION_PARTS_PER_MILLION" in guarded

--- a/tests/test_switch_energy_temperature.py
+++ b/tests/test_switch_energy_temperature.py
@@ -1,0 +1,125 @@
+"""Switch channels must expose their energy counter and device temperature.
+
+Contributed as PR #24 by @walnuss0815, who noticed the entities were missing on
+his hardware. The cause was not a missing description — ``switch_energy`` and
+``switch_temperature`` had existed all along, including the ``value_fn``s that
+unpack the nested shapes. They were simply never listed in the creation loop in
+``sensor.py``, so they could never fire.
+
+That is a silent failure mode: a description can sit in the table looking
+correct forever while nothing ever builds an entity from it. Hence these tests —
+they assert on the entities the loop actually produces, so dropping an entry
+from that list breaks a test instead of quietly costing users their sensors.
+
+The nested shapes are the other half. A switch reports ``aenergy`` as
+``{"total": ..., "by_minute": [...], "minute_ts": ...}`` and ``temperature`` as
+``{"tC": ..., "tF": ...}``; a naive handler would surface the dict itself.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+from custom_components.shelly_cloud_diy.sensor import (
+    _create_rpc_sensors as create_rpc_sensors,
+)
+
+DEVICE_ID = "plus1pm4f5a6b"
+
+
+class _FakeCoordinator:
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {
+            device_id: {
+                "status": status,
+                "device_code": "SNSW-001P16EU",
+                "online": True,
+            }
+        }
+        self.data = self.devices
+        self.last_update_success = True
+
+
+# A Shelly Plus 1PM: relay plus metering, including the two fields at issue.
+_SWITCH_STATUS: dict[str, Any] = {
+    "cloud": {"connected": True},
+    "sys": {"mac": "AABBCCDDEEFF"},
+    "switch:0": {
+        "id": 0,
+        "output": True,
+        "apower": 61.4,
+        "voltage": 232.1,
+        "current": 0.271,
+        "aenergy": {"total": 4321.7, "by_minute": [0.0], "minute_ts": 1755000000},
+        "temperature": {"tC": 42.3, "tF": 108.1},
+    },
+}
+
+
+def _build(status: dict[str, Any]):
+    coord = _FakeCoordinator(DEVICE_ID, status)
+    sensors = create_rpc_sensors(DEVICE_ID, status, set(), coord)
+    return {s.unique_id: s for s in sensors}
+
+
+def test_energy_and_temperature_entities_are_created():
+    """The regression PR #24 fixed: both were absent from the creation loop."""
+    by_uid = _build(_SWITCH_STATUS)
+    assert f"{DEVICE_ID}_switch:0_aenergy" in by_uid
+    assert f"{DEVICE_ID}_switch:0_temperature" in by_uid
+
+
+def test_nested_values_are_unpacked_not_surfaced_as_dicts():
+    """``aenergy.total`` and ``temperature.tC``, not the containing dicts."""
+    by_uid = _build(_SWITCH_STATUS)
+    assert by_uid[f"{DEVICE_ID}_switch:0_aenergy"].native_value == 4321.7
+    assert by_uid[f"{DEVICE_ID}_switch:0_temperature"].native_value == 42.3
+
+
+def test_energy_counter_is_dashboard_compatible():
+    """TOTAL_INCREASING + ENERGY is what the HA energy dashboard requires."""
+    energy = _build(_SWITCH_STATUS)[f"{DEVICE_ID}_switch:0_aenergy"]
+    assert energy.device_class == SensorDeviceClass.ENERGY
+    assert energy.state_class == SensorStateClass.TOTAL_INCREASING
+
+
+def test_temperature_is_diagnostic_and_measured():
+    temp = _build(_SWITCH_STATUS)[f"{DEVICE_ID}_switch:0_temperature"]
+    assert temp.device_class == SensorDeviceClass.TEMPERATURE
+    assert temp.state_class == SensorStateClass.MEASUREMENT
+
+
+def test_the_previously_working_sensors_still_work():
+    """Power, voltage and current must not have been disturbed."""
+    by_uid = _build(_SWITCH_STATUS)
+    assert by_uid[f"{DEVICE_ID}_switch:0_apower"].native_value == 61.4
+    assert by_uid[f"{DEVICE_ID}_switch:0_voltage"].native_value == 232.1
+    assert by_uid[f"{DEVICE_ID}_switch:0_current"].native_value == 0.271
+
+
+def test_relayless_switch_creates_nothing_extra():
+    """A switch without metering must not gain empty energy/temperature entities."""
+    status = {
+        "sys": {"mac": "AABBCCDDEEFF"},
+        "switch:0": {"id": 0, "output": False},
+    }
+    by_uid = _build(status)
+    assert f"{DEVICE_ID}_switch:0_aenergy" not in by_uid
+    assert f"{DEVICE_ID}_switch:0_temperature" not in by_uid
+
+
+def test_covers_and_lights_get_the_same_treatment():
+    """The loop covers switch|light|cover — a metered cover must benefit too."""
+    status = {
+        "sys": {"mac": "AABBCCDDEEFF"},
+        "cover:0": {
+            "id": 0,
+            "apower": 12.0,
+            "aenergy": {"total": 99.5},
+            "temperature": {"tC": 31.0},
+        },
+    }
+    by_uid = _build(status)
+    assert by_uid[f"{DEVICE_ID}_cover:0_aenergy"].native_value == 99.5
+    assert by_uid[f"{DEVICE_ID}_cover:0_temperature"].native_value == 31.0


### PR DESCRIPTION
Two independent bug fixes plus the test that was promised for #24. Deliberately not using `Fixes #N` so the closing comments land before the issues close.

### #25 — device picker becomes unsubmittable

Reported by @Frido1980. The picker's permitted values came purely from the current `/device/all_status` response, while the pre-ticked selection came from the saved options. A saved device missing from that response was no longer an allowed value, so Home Assistant rejected the **whole form** — blocking the addition of a perfectly fine new device too.

Offline is not the trigger; offline devices are still listed with a ⚠. The device has to drop out of the cloud listing entirely.

Saved-but-missing ids now get an option of their own, appended last and labelled `not in the current cloud listing, untick to remove`. Keeping them selectable is the point: the user can drop one deliberately instead of waiting for it to come back, which is the workaround the reporter had to use.

Options flow only — the config flow runs at initial setup, where there is no saved selection to preserve.

### #26 — deprecated ppm constant

Reported by @elad-eyal. `CONCENTRATION_PARTS_PER_MILLION` is removed in Core 2027.8 and logged a warning at every start for every user, regardless of hardware, because the description table is built at import time.

The obvious fix breaks the other end. Measured rather than assumed: `UnitOfRatio` does **not** exist on HA 2025.1.4, the oldest supported version — the import raises `ImportError` there. The unit is therefore resolved per version, preferring the new name and reaching the old one only where the new one is absent. Order matters: the deprecation fires on import, not on use.

Verified: 2025.1.4 → `'ppm'` (str, fallback branch), 2026.7.2 → `UnitOfRatio.PARTS_PER_MILLION`.

### Tests for #24

@walnuss0815's contribution is already merged separately (with his authorship preserved). This adds the test I promised him: the descriptions had existed all along and only the creation-loop entries were missing, which is a failure mode that can hide indefinitely. Control-checked — 5 of the 7 fail with his two lines removed; the 2 that survive are the negative cases, which correctly hold either way.

---

113 passed +1 skipped / 114 passed across both matrix venvs. The skip is the `UnitOfRatio` test on the old end, which is the intended asymmetry and proves both branches are exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxqg751CivULXbU63q5WDZ