### PR TITLE
feat(binary_sensor): report devices that stop checking in with the cloud

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -105,6 +105,7 @@ Lücke schließt dieses Projekt.
 |---|---|---|
 | ☁️ **Cloud-Polling** | Liest den Status jedes Geräts, das dein Shelly-Account sieht — eigene, geteilte, entfernte und BLE-überbrückte (Shelly-BLU-Familie über ein BLU-Gateway). | ✅ ausgeliefert |
 | 🔌 **Opt-in-Entities** | Schalter, Lampen, Rollladen, Sensoren, Binary Sensors, Buttons — nur für die Geräte angelegt, die du auswählst, damit es keine Doppler mit der LAN-Integration gibt. | ✅ ausgeliefert |
+| 📡 **Ausfall-Erkennung** | Ein **Reporting**-Sensor je Gerät, der abfällt, sobald sich ein Gerät nicht mehr meldet — das Signal, das `cloud.connected` nicht liefern kann (siehe unten). | ✅ ausgeliefert |
 | 📈 **Energie-Verlaufsimport** | Importiert historische Energiedaten in die Home-Assistant-Langzeitstatistik. | ✅ ausgeliefert |
 | ⚙️ **Config- + Options-Flow** | `auth_key` einfügen; Poll-Intervall und Geräte-Auswahl später anpassen. | ✅ ausgeliefert |
 | 🌍 **Lokalisierte UI** | Englische und deutsche Übersetzungen für jeden sichtbaren Text. | ✅ ausgeliefert |
@@ -116,6 +117,43 @@ Lücke schließt dieses Projekt.
 Sie läuft **parallel** zur Shelly Cloud und zur Shelly-App — sie übernimmt oder
 blockiert keine anderen Clients — und **erfordert nicht**, dass Home Assistant im
 öffentlichen Internet exponiert ist.
+
+### Mitbekommen, wenn ein Gerät stirbt
+
+Jedes Gerät bekommt einen **Reporting**-Binärsensor (Kategorie Diagnose). Er fällt
+ab, sobald sich das Gerät nicht mehr bei der Shelly Cloud meldet — genau so sieht
+ein Stromausfall von der Cloud aus, und es funktioniert auch dann, wenn der
+Ausfall das Netzwerk deines Home Assistant mitreißt, denn die Cloud steht nicht
+bei dir im Haus.
+
+Es gibt ihn, weil die naheliegenden Signale nicht funktionieren. Gemessen an
+einem realen Konto mit 64 Geräten:
+
+- `cloud.connected` stand **13 Minuten** nach dem physischen Trennen eines Geräts
+  noch auf *verbunden* — und zwar für *jedes* Gerät des Kontos, auch für seit
+  Stunden stumme. Es ist ein Transport-Flag, das die Cloud zwischenspeichert,
+  kein Lebenszeichen. (Der separate `Cloud`-Sensor zeigt den Rohwert weiterhin,
+  standardmäßig deaktiviert.)
+- Geräte verschwinden zwar irgendwann aus der Geräteliste der Cloud, das dauerte
+  aber bis zu zehn Minuten — und die Liste lässt auch gesunde Geräte zufällig aus.
+
+Die Bewertung stützt sich deshalb auf das Einzige, was die Cloud nicht erfinden
+kann: dass das Gerät einen neuen Datensatz geschickt hat — gemessen an der Uhr
+von Home Assistant.
+
+**Das Fenster gilt je Gerät und passt sich an.** Die normalen Meldeabstände
+unterscheiden sich um Größenordnungen: ein Zwischenstecker mit Leistungsmessung
+meldet jede Minute, ein unbenutzter Plus RGBW PM lag bei 29 Minuten, ein
+BLE-Sensor bei drei Tagen — alle völlig gesund. Der eingestellte Wert
+(Optionen → *Gerät als offline melden nach*, Standard 30 min) ist deshalb ein
+**Basiswert**: ein von Natur aus stilleres Gerät bekommt automatisch ein weiteres
+Fenster, Batterie- und BLE-Geräte ein eigenes, und solange der Rhythmus eines
+Geräts unbekannt ist, gilt eine Stunde Karenz. Ein kleinerer Wert beschleunigt
+die Erkennung also bei Geräten, die durchgehend melden — etwa dem Zwischenstecker
+an der Gefriertruhe — ohne die stillen Geräte zu Fehlalarmen zu machen.
+
+Bricht das Abfragen selbst weg (Cloud-Ausfall, abgelehnter `auth_key`), wird der
+Sensor **nicht verfügbar**, statt die ganze Flotte für tot zu erklären.
 
 ---
 

--- a/README.de.md
+++ b/README.de.md
@@ -122,9 +122,16 @@ blockiert keine anderen Clients — und **erfordert nicht**, dass Home Assistant
 
 Jedes Gerät bekommt einen **Reporting**-Binärsensor (Kategorie Diagnose). Er fällt
 ab, sobald sich das Gerät nicht mehr bei der Shelly Cloud meldet — genau so sieht
-ein Stromausfall von der Cloud aus, und es funktioniert auch dann, wenn der
-Ausfall das Netzwerk deines Home Assistant mitreißt, denn die Cloud steht nicht
-bei dir im Haus.
+ein Stromausfall von der Cloud aus.
+
+Damit klar ist, was das bringt und was nicht: für ein Gerät, das Home Assistant
+im LAN erreicht, merkt die native Integration den Ausfall ohnehin — vermutlich
+sogar früher. Die Cloud-Sicht lohnt sich für Geräte, zu denen Home Assistant
+**gar keinen lokalen Weg** hat — ein geteiltes Gerät, ein zweiter Standort, ein
+BLU-Sensor hinter fremdem Gateway — wo es sonst überhaupt kein Lebenszeichen
+gibt. Sie ist **kein** Mittel, den eigenen Ausfall zu überstehen: liegt dein
+Netz, erreicht auch Home Assistant die Cloud nicht, und der Sensor sagt das,
+indem er nicht verfügbar wird, statt zu raten.
 
 Es gibt ihn, weil die naheliegenden Signale nicht funktionieren. Gemessen an
 einem realen Konto mit 64 Geräten:

--- a/README.de.md
+++ b/README.de.md
@@ -312,6 +312,13 @@ IP, MAC) werden automatisch geschwärzt, und die Datei listet unter
 den Coordinator-Gesundheitsstand (letzter erfolgreicher Abruf und letzter
 Fehler), um die Diagnose zu beschleunigen.
 
+Geht es um den **Reporting**-Sensor — ein Gerät gilt als offline, ist aber
+nachweislich in Ordnung, oder es schlägt nie an — beantwortet derselbe Download
+das direkt: der `reporting`-Block nennt, wie lange das Gerät tatsächlich still
+ist, wie viel Stille ihm gerade zusteht, ob das der eingestellte Wert ist oder
+ein weiteres Fenster, das sich das Gerät verdient hat, und ob sein Rhythmus
+überhaupt schon gelernt wurde.
+
 Bei Fehlern hilft es, Debug-Logging für `custom_components.shelly_cloud_diy` zu
 aktivieren (Einstellungen → Geräte & Dienste → Shelly Cloud DIY → Debug-
 Protokollierung aktivieren) und das Problem zu reproduzieren.

--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ redacted automatically, and the file lists exactly what was withheld under
 `redacted_keys`. It also includes the integration's coordinator health (last
 update success and last error) to speed up diagnosis.
 
+If the question is about the **Reporting** sensor — a device flagged offline
+that is demonstrably fine, or one that never flags at all — the same download
+answers it directly: the `reporting` block states how long the device has
+actually been silent, how much silence it is currently allowed, whether that
+allowance is the configured one or a wider one the device earned, and whether
+its cadence has been learned yet.
+
 For errors, enabling debug logging for `custom_components.shelly_cloud_diy`
 (Settings → Devices & Services → Shelly Cloud DIY → Enable debug logging)
 and reproducing the problem adds a useful timeline.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Gen2 / BLE-gateway coverage** in one package. That is the gap this project close
 |---|---|---|
 | ☁️ **Cloud polling** | Reads device state for every device visible to your Shelly account — owned, shared, remote, and BLE-bridged (Shelly BLU family via a BLU Gateway). | ✅ shipped |
 | 🔌 **Opt-in entities** | Switches, lights, covers, sensors, binary sensors, buttons — materialised only for the devices you choose, so you avoid duplicates with the LAN integration. | ✅ shipped |
+| 📡 **Offline detection** | A per-device **Reporting** sensor that turns off when a device stops checking in — the signal `cloud.connected` cannot give you (see below). | ✅ shipped |
 | 📈 **Energy history import** | Imports historical energy data into Home Assistant long-term statistics. | ✅ shipped |
 | ⚙️ **Config + options flow** | Paste your `auth_key`; tune the poll interval and per-device enablement later. | ✅ shipped |
 | 🌍 **Localised UI** | English and German translations for every user-visible string. | ✅ shipped |
@@ -111,6 +112,40 @@ Gen2 / BLE-gateway coverage** in one package. That is the gap this project close
 It runs **alongside** Shelly Cloud and the Shelly app — it does not take over or
 lock out other clients — and **does not require** Home Assistant to be exposed to
 the public internet.
+
+### Knowing when a device dies
+
+Every device gets a **Reporting** binary sensor (diagnostic category). It turns
+off when the device stops checking in with Shelly Cloud — which is what a power
+cut looks like from the cloud's side, and it keeps working when the outage takes
+your Home Assistant's own network with it, because the cloud is not in your house.
+
+It exists because the obvious signals do not work. Measured against a live
+64-device account:
+
+- `cloud.connected` still read **connected** thirteen minutes after a device was
+  physically unplugged, and read connected for *every* device on the account —
+  including ones silent for hours. It is a transport flag the cloud caches, not
+  a liveness signal. (The separate `Cloud` sensor still exposes it, disabled by
+  default, for anyone who wants the raw value.)
+- Devices do eventually vanish from the cloud's fleet listing, but that took up
+  to ten minutes, and the listing also omits healthy devices at random.
+
+So the verdict is based on the one thing the cloud cannot fake — the device
+having pushed a new snapshot — timed on Home Assistant's own clock.
+
+**The window is per device, and adapts.** Normal cadences differ by orders of
+magnitude: a metering plug reports every 60 s, an idle Plus RGBW PM went 29
+minutes between reports, a BLE beacon three days — all perfectly healthy. So the
+configured value (Options → *Report a device as offline after*, default 30 min)
+is a **base**: a device that is naturally quieter earns a wider window on its
+own, battery and BLE devices get their own, and until a device's cadence is
+known it gets an hour of grace. Lowering the setting therefore speeds up
+detection on devices that report continuously — a freezer's metering plug, say —
+without turning your quiet devices into false alarms.
+
+If polling itself breaks (cloud outage, rejected `auth_key`), the sensor goes
+**unavailable** rather than reporting your whole fleet as dead.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -117,8 +117,16 @@ the public internet.
 
 Every device gets a **Reporting** binary sensor (diagnostic category). It turns
 off when the device stops checking in with Shelly Cloud — which is what a power
-cut looks like from the cloud's side, and it keeps working when the outage takes
-your Home Assistant's own network with it, because the cloud is not in your house.
+cut looks like from the cloud's side.
+
+To be clear about what this does and does not buy you: for a device Home
+Assistant can reach on your LAN, the native integration already notices when it
+goes away, and probably sooner. The cloud view earns its keep for devices Home
+Assistant has **no local path to at all** — a shared device, a second site, a
+BLU sensor behind someone else's gateway — where there is otherwise no liveness
+signal whatsoever. It is not a way to survive your own outage: if your network
+is down, Home Assistant cannot reach the cloud either, and the sensor says so by
+going unavailable rather than guessing.
 
 It exists because the obvious signals do not work. Measured against a live
 64-device account:

--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -5,8 +5,12 @@ import logging
 import re
 from typing import Any
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -42,6 +46,13 @@ async def async_setup_entry(
             return entities
         device_data = coordinator.devices.get(device_id, {})
         status = device_data.get("status", {})
+
+        # Offline detection is device-wide, not component-derived, so it is
+        # created before the status check below — a device whose status we
+        # cannot read yet is exactly one worth watching.
+        entities.extend(
+            _create_reporting_sensor(device_id, created_entities, coordinator)
+        )
 
         if not status:
             return entities
@@ -87,6 +98,95 @@ async def async_setup_entry(
     entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_NEW_DEVICE, async_add_device)
     )
+
+
+def _create_reporting_sensor(
+    device_id: str,
+    created: set[str],
+    coordinator: ShellyCloudCoordinator,
+) -> list[BinarySensorEntity]:
+    """Create the device-wide "Reporting" sensor, once per device.
+
+    Unlike the other builders this one derives nothing from the status: every
+    device gets exactly one, including devices whose status is empty or whose
+    generation we cannot classify. Those are if anything the ones most worth
+    watching.
+    """
+    uid = f"{device_id}_reporting"
+    if uid in created:
+        return []
+    created.add(uid)
+    return [ShellyReportingBinarySensor(coordinator, device_id)]
+
+
+class ShellyReportingBinarySensor(ShellyBaseEntity, BinarySensorEntity):
+    """Whether the device is still reporting to Shelly Cloud.
+
+    This is the honest counterpart to the ``Cloud`` binary sensor above.
+    That one mirrors ``cloud.connected``, which the cloud caches: measured on
+    a live account, it read *connected* for a device that had been physically
+    unplugged 13 minutes earlier, and for every device on the account
+    including BLE beacons silent for three days. It is a transport flag the
+    cloud never revises, not a liveness signal.
+
+    This sensor instead keys off the only thing the cloud cannot fake: that
+    the device pushed a new snapshot. The coordinator fingerprints each
+    payload and stamps its own monotonic clock when the fingerprint changes,
+    then compares that against a per-device staleness window.
+
+    ``on`` (connected) therefore means "checked in recently enough", and
+    ``off`` means "silent for longer than this device ever normally is" —
+    which is what a power cut looks like from the cloud's side.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "Reporting"
+
+    def __init__(
+        self, coordinator: ShellyCloudCoordinator, device_id: str
+    ) -> None:
+        """Initialize the reporting sensor."""
+        super().__init__(coordinator, device_id, 0)
+        self._attr_unique_id = f"{device_id}_reporting"
+
+    @property
+    def available(self) -> bool:
+        """Return if the verdict itself can be trusted.
+
+        Deliberately *not* the base class's availability, which keys off the
+        device being present and online — this entity exists to report
+        precisely the case where it is not, and an unavailable entity says
+        nothing.
+
+        It does go unavailable when our own polling breaks: during a cloud
+        outage or an auth failure we have no evidence about any device, and
+        silently reporting the whole fleet as dead would be worse than
+        admitting we cannot tell.
+        """
+        return (
+            self.coordinator.last_update_success
+            and self._device_id in self.coordinator.checkins
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True while the device is still checking in."""
+        return self.coordinator.is_reporting(self._device_id)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose the window this verdict was made against.
+
+        Worth surfacing because it is per-device and adapts: a quiet device
+        earns a wider window than the configured default, and without this
+        the user would have no way to see why one device tolerates far more
+        silence than another.
+        """
+        record = self.coordinator.checkins.get(self._device_id)
+        if record is None:
+            return None
+        return {"stale_after_s": int(record.stale_after_s)}
 
 
 def _create_block_sensors(

--- a/custom_components/shelly_cloud_diy/config_flow.py
+++ b/custom_components/shelly_cloud_diy/config_flow.py
@@ -47,9 +47,13 @@ from .const import (
     CONF_CREATE_ALL_INITIALLY,
     CONF_ENABLED_DEVICES,
     CONF_LOCAL_GATEWAY_URL,
+    CONF_OFFLINE_AFTER,
     CONF_POLL_INTERVAL,
     CONF_SERVER_URI,
     DOMAIN,
+    OFFLINE_AFTER_DEFAULT,
+    OFFLINE_AFTER_MAX,
+    OFFLINE_AFTER_MIN,
     POLL_INTERVAL_DEFAULT,
     POLL_INTERVAL_MAX,
     POLL_INTERVAL_MIN,
@@ -433,6 +437,9 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                         user_input.get(CONF_POLL_INTERVAL, POLL_INTERVAL_DEFAULT)
                     ),
                     CONF_LOCAL_GATEWAY_URL: safe_gw,
+                    CONF_OFFLINE_AFTER: int(
+                        user_input.get(CONF_OFFLINE_AFTER, OFFLINE_AFTER_DEFAULT)
+                    ),
                 }
 
                 # Fetch the current fleet + names so the device-selection
@@ -463,12 +470,20 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
             self.config_entry.options.get(CONF_POLL_INTERVAL, POLL_INTERVAL_DEFAULT)
         )
         current_gw = self.config_entry.options.get(CONF_LOCAL_GATEWAY_URL, "")
+        current_offline = int(
+            self.config_entry.options.get(CONF_OFFLINE_AFTER, OFFLINE_AFTER_DEFAULT)
+        )
 
         schema = vol.Schema(
             {
                 vol.Required(
                     CONF_POLL_INTERVAL, default=current_interval
                 ): vol.All(int, vol.Range(min=POLL_INTERVAL_MIN, max=POLL_INTERVAL_MAX)),
+                vol.Required(
+                    CONF_OFFLINE_AFTER, default=current_offline
+                ): vol.All(
+                    int, vol.Range(min=OFFLINE_AFTER_MIN, max=OFFLINE_AFTER_MAX)
+                ),
                 vol.Optional(
                     CONF_LOCAL_GATEWAY_URL, default=current_gw
                 ): str,

--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -42,6 +42,24 @@ POLL_INTERVAL_MIN = 3
 POLL_INTERVAL_MAX = 60
 POLL_INTERVAL_DEFAULT = 5
 
+# ── Offline detection ("Reporting" binary sensor) ──────────────────
+#
+# How long a mains-powered device may stay silent before its "Reporting"
+# binary sensor drops to *disconnected*. This is only the BASE window: the
+# coordinator widens it per device to cover the slowest cadence it has
+# actually observed, so a naturally quiet device does not flap.
+#
+# The default is deliberately generous. Measured on a 64-device account
+# (2026-08-16): 34 of 35 mains Shellys reported within 70 s — but a Plus
+# RGBW PM sitting idle went 25 minutes between reports, with nothing wrong.
+# A 3-minute default would have produced a permanent false alarm on it.
+# Users who care about fast detection on a metering device (freezer plug,
+# …) can tighten this; the per-device widening keeps the quiet devices sane.
+CONF_OFFLINE_AFTER = "offline_after_minutes"
+OFFLINE_AFTER_DEFAULT = 30
+OFFLINE_AFTER_MIN = 2
+OFFLINE_AFTER_MAX = 24 * 60
+
 # ── Historical sync (unchanged from pre-pivot) ─────────────────────
 
 HISTORICAL_SYNC_INTERVAL = 24 * 60 * 60  # daily

--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -15,6 +15,7 @@ import asyncio
 import logging
 import re
 import time
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -36,10 +37,13 @@ from .api.cloud_control import (
 from .const import (
     CONF_CREATE_ALL_INITIALLY,
     CONF_ENABLED_DEVICES,
+    CONF_OFFLINE_AFTER,
     CONF_POLL_INTERVAL,
     DOMAIN,
+    OFFLINE_AFTER_DEFAULT,
     POLL_INTERVAL_DEFAULT,
     SIGNAL_NEW_DEVICE,
+    device_gen,
 )
 
 # Gap between the v1 poll completing and the v2 name lookup firing, so we
@@ -79,6 +83,53 @@ SLEEP_STALE_FLOOR_S = 4 * 3600
 # Hard ceiling on the staleness window, so a device configured with an absurd
 # wakeup period cannot stay "available" indefinitely after it dies.
 SLEEP_STALE_CAP_S = 24 * 3600
+
+# ── Offline detection: "is this device still reporting?" ──────────────
+#
+# Measured against a live 64-device account on 2026-08-16, because every
+# cheaper signal turned out to be a lie:
+#
+#   * ``cloud.connected`` stayed ``true`` 13 minutes after a device was
+#     physically unplugged, and read ``true`` for all 35 mains devices —
+#     including ones that had not reported in a quarter of an hour.
+#   * ``_dev_info.online`` read ``true`` for all 29 BLE/BLU devices,
+#     including one that had been silent for three days.
+#   * Disappearing from ``/device/all_status`` does happen, but takes up to
+#     ~10 minutes and the endpoint also omits devices spontaneously.
+#
+# What is trustworthy is that the device pushed *something* — which is what
+# ``checkin_marker`` fingerprints. So "reporting" means "we have seen a new
+# fingerprint recently enough", measured on our own monotonic clock.
+
+# Multiplier applied to the widest check-in gap actually observed for a
+# device, to derive its personal staleness window. A device that normally
+# reports every 25 minutes must not be called dead at 30.
+REPORT_GAP_MARGIN = 2.0
+
+# Floor applied until a device's cadence is actually known. Learned gaps live
+# in memory only, so every HA restart starts from zero knowledge — and a user
+# who tightened the window for their metering plug would otherwise get a false
+# alarm on their quiet devices after every restart. Measured worst case for a
+# healthy mains device was a 29-minute gap (an idle Plus RGBW PM), so an hour
+# of grace covers it with margin. Once one real gap has been observed the
+# configured window takes over, which for a device reporting every minute is
+# roughly two minutes after startup.
+REPORT_UNLEARNED_FLOOR_S = 60 * 60
+
+# Ceiling on what a single observed gap may teach us. A device that really
+# was offline for hours would otherwise "learn" that outage as its normal
+# cadence and could never report an outage again.
+REPORT_LEARN_CAP_S = 2 * 3600
+
+# Base window for BLE/BLU devices bridged through a gateway. They are
+# battery beacons: measured median silence 19 minutes, maximum 3 days, with
+# nothing wrong. They cannot run a heartbeat (no scripting, no mains), so
+# the only safe base is a generous one.
+REPORT_STALE_BLE_S = 24 * 3600
+
+# Hard ceiling on any device's staleness window, so neither the learned gap
+# nor a misconfigured option can push detection out indefinitely.
+REPORT_STALE_CAP_S = 7 * 24 * 3600
 
 # Delay before the post-command status refresh (seconds). Long enough for the
 # Shelly Cloud to propagate the new state (so the poll confirms rather than
@@ -120,6 +171,24 @@ def sleep_period_s(status: dict[str, Any]) -> int:
     return SLEEP_ASSUMED_PERIOD_S if status.get("_sleeping") is True else 0
 
 
+def sleep_window_s(status: dict[str, Any]) -> float:
+    """Return how long a deep-sleep device may stay silent, 0 if it is not one.
+
+    Split out of :meth:`ShellyCloudCoordinator._evaluate_sleep_state` so that
+    offline detection can reuse the *length* of the window. Reusing the
+    deadline instead would be wrong twice over: it shrinks as the device stays
+    silent, and offline detection measures from its own last-check-in stamp,
+    so the two would compound into roughly half the intended tolerance.
+    """
+    period = sleep_period_s(status)
+    if not period:
+        return 0.0
+    return min(
+        max(period * SLEEP_STALE_MULTIPLIER, SLEEP_STALE_FLOOR_S),
+        SLEEP_STALE_CAP_S,
+    )
+
+
 def checkin_marker(status: dict[str, Any]) -> tuple[Any, ...]:
     """Return the fields that change whenever the device pushes a new snapshot.
 
@@ -139,6 +208,46 @@ def checkin_marker(status: dict[str, Any]) -> tuple[Any, ...]:
         sys_block.get("uptime"),
         status.get("ts"),
     )
+
+
+@dataclass
+class CheckinRecord:
+    """What we know about one device's reporting behaviour.
+
+    Timestamps are ``time.monotonic`` values stamped by us, never clocks read
+    out of the payload: ``_updated`` carries no timezone, ``ts`` can lag the
+    rest of the payload by hours, and device clocks drift. The payload fields
+    are only ever compared for *change* (see :func:`checkin_marker`).
+    """
+
+    marker: tuple[Any, ...]
+    last_checkin: float
+    base_window_s: float
+    # Widest gap between two consecutive check-ins we have actually seen for
+    # this device. Starts at 0 and only ever grows, so the window adapts
+    # towards fewer false alarms and never towards more.
+    widest_gap_s: float = 0.0
+    # True while the device is missing from the poll, and set as soon as it
+    # goes missing so the gap that spans the absence is not mistaken for the
+    # device's normal cadence.
+    absent: bool = False
+
+    @property
+    def stale_after_s(self) -> float:
+        """Seconds of silence after which this device counts as not reporting.
+
+        Until we have seen this device report twice we do not know its cadence,
+        so the floor applies and the device is given the benefit of the doubt.
+        """
+        if self.widest_gap_s <= 0.0:
+            window = max(self.base_window_s, REPORT_UNLEARNED_FLOOR_S)
+        else:
+            window = max(self.base_window_s, self.widest_gap_s * REPORT_GAP_MARGIN)
+        return min(window, REPORT_STALE_CAP_S)
+
+    def is_reporting(self, now: float) -> bool:
+        """Whether the last check-in is still inside the staleness window."""
+        return (now - self.last_checkin) < self.stale_after_s
 
 
 class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
@@ -207,6 +316,93 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         # where that fingerprint first appeared). Drives the staleness window
         # for deep-sleep battery devices. (#13)
         self._sleep_seen: dict[str, tuple[tuple, float]] = {}
+        # device_id → CheckinRecord, for EVERY device rather than only the
+        # sleeping ones. Kept separate from ``_sleep_seen`` on purpose: that
+        # one drops mains devices by design (#13), while offline detection
+        # needs exactly those. Entries survive a device's absence from the
+        # poll — that absence is the very thing the "Reporting" sensor has to
+        # be able to report — and are bounded by the size of the account.
+        self.checkins: dict[str, CheckinRecord] = {}
+
+    # ── Offline detection bookkeeping ─────────────────────────────────
+
+    def _base_window_s(self, status: dict[str, Any]) -> float:
+        """Return the base staleness window for one device.
+
+        Three classes, because their normal silence differs by orders of
+        magnitude (all three measured on a live account, see the constants
+        above):
+
+        * **deep-sleep battery devices** — reuse the window (#13) already
+          derived from ``wakeup_period``, so both features agree on what
+          "still checking in" means for them.
+        * **BLE/BLU beacons** — silent for hours to days by design.
+        * **mains devices** — the user-configurable window.
+        """
+        if sleep := sleep_window_s(status):
+            return sleep
+        if device_gen(status) == "GBLE":
+            return REPORT_STALE_BLE_S
+        return self.offline_after_s
+
+    def _record_checkin(
+        self,
+        device_id: str,
+        status: dict[str, Any],
+        now: float,
+    ) -> None:
+        """Update the check-in record for a device present in this poll."""
+        marker = checkin_marker(status)
+        base = self._base_window_s(status)
+        record = self.checkins.get(device_id)
+
+        if record is None:
+            # First sight counts as a check-in: we have no evidence the device
+            # is gone, and the alternative would flag every device as offline
+            # for one window after each HA restart.
+            self.checkins[device_id] = CheckinRecord(
+                marker=marker, last_checkin=now, base_window_s=base
+            )
+            return
+
+        record.base_window_s = base
+        if record.marker == marker:
+            # Present but silent — the window keeps running.
+            record.absent = False
+            return
+
+        gap = now - record.last_checkin
+        # Only learn a cadence from a gap the device spent *present and
+        # silent*. A gap that spans an absence is not evidence of a slow
+        # device, and learning from it would let one real outage widen the
+        # window until the next outage could never be detected.
+        if not record.absent and gap <= REPORT_LEARN_CAP_S:
+            record.widest_gap_s = max(record.widest_gap_s, gap)
+        record.marker = marker
+        record.last_checkin = now
+        record.absent = False
+
+    def is_reporting(self, device_id: str) -> bool | None:
+        """Whether ``device_id`` has checked in recently enough.
+
+        ``None`` when we have never seen the device, so a freshly created
+        entity reports *unknown* rather than asserting an outage it has no
+        evidence for.
+        """
+        record = self.checkins.get(device_id)
+        if record is None:
+            return None
+        return record.is_reporting(time.monotonic())
+
+    @property
+    def offline_after_s(self) -> float:
+        """Configured base window for mains devices, in seconds."""
+        minutes = self._options.get(CONF_OFFLINE_AFTER, OFFLINE_AFTER_DEFAULT)
+        try:
+            minutes = float(minutes)
+        except (TypeError, ValueError):
+            minutes = OFFLINE_AFTER_DEFAULT
+        return max(minutes, 1.0) * 60.0
 
     # ── Deep-sleep freshness bookkeeping (#13) ────────────────────────
 
@@ -251,11 +447,7 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         else:
             last_seen = previous[1]
 
-        window = min(
-            max(period * SLEEP_STALE_MULTIPLIER, SLEEP_STALE_FLOOR_S),
-            SLEEP_STALE_CAP_S,
-        )
-        return True, last_seen + window
+        return True, last_seen + sleep_window_s(status)
 
     # ── Properties platform code may inspect ──────────────────────────
 
@@ -361,6 +553,9 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 device_id, status, now
             )
 
+            # Offline detection runs for every device, sleeping or not.
+            self._record_checkin(device_id, status, now)
+
             new_devices[device_id] = {
                 "status": status,
                 "online": online,
@@ -397,6 +592,14 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         for gone in set(self._sleep_seen) - set(new_devices):
             if now - self._sleep_seen[gone][1] > SLEEP_STALE_CAP_S:
                 self._sleep_seen.pop(gone, None)
+
+        # Mark devices missing from this poll. Absence alone is deliberately
+        # NOT an outage: ``/device/all_status`` omits devices spontaneously
+        # (see the pruning note above), so the record keeps ageing against its
+        # own window and only trips once the device has actually been silent
+        # for longer than it ever normally is. That is the debounce.
+        for gone_id in set(self.checkins) - set(new_devices):
+            self.checkins[gone_id].absent = True
 
         self.devices = new_devices
 

--- a/custom_components/shelly_cloud_diy/diagnostics.py
+++ b/custom_components/shelly_cloud_diy/diagnostics.py
@@ -95,6 +95,9 @@ async def async_get_device_diagnostics(
             "device_id": device_id,
             "coordinator": coordinator_health,
             "note": "device not in the current coordinator snapshot",
+            # Included here in particular: a device missing from the poll is
+            # exactly the case the reporting verdict exists to explain.
+            "reporting": _reporting_diagnostics(coordinator, device_id),
         }
 
     return {
@@ -104,7 +107,36 @@ async def async_get_device_diagnostics(
         # so anyone attaching this to a bug report knows what was withheld.
         "redacted_keys": sorted(DEVICE_TO_REDACT),
         "sleep": _sleep_diagnostics(record),
+        "reporting": _reporting_diagnostics(coordinator, device_id),
         "record": async_redact_data(record, DEVICE_TO_REDACT),
+    }
+
+
+def _reporting_diagnostics(
+    coordinator: Any, device_id: str
+) -> dict[str, Any] | None:
+    """Explain the "Reporting" verdict in numbers a reader can check.
+
+    The record holds monotonic timestamps, which say nothing in a dump. What
+    a bug report needs is: how long has this device actually been silent, how
+    much silence is it allowed, and is the allowance the configured one or a
+    wider one this device earned by being naturally quiet.
+    """
+    checkins = getattr(coordinator, "checkins", None)
+    if not isinstance(checkins, dict):
+        return None
+    checkin = checkins.get(device_id)
+    if checkin is None:
+        return None
+
+    return {
+        "silent_for_s": round(time.monotonic() - checkin.last_checkin, 1),
+        "stale_after_s": round(checkin.stale_after_s, 1),
+        "base_window_s": round(checkin.base_window_s, 1),
+        "widest_observed_gap_s": round(checkin.widest_gap_s, 1),
+        "cadence_learned": checkin.widest_gap_s > 0,
+        "missing_from_last_poll": checkin.absent,
+        "reporting": checkin.is_reporting(time.monotonic()),
     }
 
 

--- a/custom_components/shelly_cloud_diy/strings.json
+++ b/custom_components/shelly_cloud_diy/strings.json
@@ -54,13 +54,15 @@
     "step": {
       "init": {
         "title": "Shelly Cloud DIY options",
-        "description": "Adjust how often the integration polls Shelly Cloud for state and, optionally, the local gateway URL used by the historical-data service. Device selection follows on the next step.",
+        "description": "Adjust how often the integration polls Shelly Cloud for state, when a silent device counts as offline and, optionally, the local gateway URL used by the historical-data service. Device selection follows on the next step.",
         "data": {
           "poll_interval": "Poll interval (seconds)",
+          "offline_after_minutes": "Report a device as offline after (minutes)",
           "local_gateway_url": "Local gateway URL (optional, for EM historical data)"
         },
         "data_description": {
           "poll_interval": "3–60 s. Lower values feel snappier but consume more of Shelly's 1 req/s rate-limit budget.",
+          "offline_after_minutes": "2–1440 min, default 30. Each device's \"Reporting\" sensor turns off once the device has been silent this long. It is only a base value: a device that is naturally quieter earns a wider window on its own, and battery or BLE devices are handled separately. Lowering it therefore mainly speeds up detection on devices that report continuously, such as power-metering plugs.",
           "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data."
         }
       },

--- a/custom_components/shelly_cloud_diy/translations/de.json
+++ b/custom_components/shelly_cloud_diy/translations/de.json
@@ -54,13 +54,15 @@
     "step": {
       "init": {
         "title": "Shelly Cloud DIY — Optionen",
-        "description": "Passt an, wie oft die Integration die Shelly Cloud abfragt, sowie optional die lokale Gateway-URL für den Historical-Data-Service. Die Geräteauswahl folgt im nächsten Schritt.",
+        "description": "Passt an, wie oft die Integration die Shelly Cloud abfragt, ab wann ein stilles Gerät als offline gilt, sowie optional die lokale Gateway-URL für den Historical-Data-Service. Die Geräteauswahl folgt im nächsten Schritt.",
         "data": {
           "poll_interval": "Abfrageintervall (Sekunden)",
+          "offline_after_minutes": "Gerät als offline melden nach (Minuten)",
           "local_gateway_url": "Lokale Gateway-URL (optional, für historische EM-Daten)"
         },
         "data_description": {
           "poll_interval": "3–60 s. Kleinere Werte fühlen sich flotter an, verbrauchen aber mehr von Shellys 1-req/s-Budget.",
+          "offline_after_minutes": "2–1440 min, Standard 30. Der Sensor „Reporting“ eines Geräts fällt ab, sobald das Gerät so lange nichts mehr gemeldet hat. Das ist nur ein Basiswert: ein von Natur aus stilleres Gerät bekommt automatisch ein weiteres Fenster, Batterie- und BLE-Geräte werden getrennt behandelt. Ein kleinerer Wert beschleunigt die Erkennung deshalb vor allem bei Geräten, die durchgehend melden — etwa Zwischenstecker mit Leistungsmessung.",
           "local_gateway_url": "Nur nötig, wenn ein lokales Shelly-Gateway für historische Energiedaten genutzt wird."
         }
       },

--- a/custom_components/shelly_cloud_diy/translations/en.json
+++ b/custom_components/shelly_cloud_diy/translations/en.json
@@ -54,13 +54,15 @@
     "step": {
       "init": {
         "title": "Shelly Cloud DIY options",
-        "description": "Adjust how often the integration polls Shelly Cloud for state and, optionally, the local gateway URL used by the historical-data service. Device selection follows on the next step.",
+        "description": "Adjust how often the integration polls Shelly Cloud for state, when a silent device counts as offline and, optionally, the local gateway URL used by the historical-data service. Device selection follows on the next step.",
         "data": {
           "poll_interval": "Poll interval (seconds)",
+          "offline_after_minutes": "Report a device as offline after (minutes)",
           "local_gateway_url": "Local gateway URL (optional, for EM historical data)"
         },
         "data_description": {
           "poll_interval": "3–60 s. Lower values feel snappier but consume more of Shelly's 1 req/s rate-limit budget.",
+          "offline_after_minutes": "2–1440 min, default 30. Each device's \"Reporting\" sensor turns off once the device has been silent this long. It is only a base value: a device that is naturally quieter earns a wider window on its own, and battery or BLE devices are handled separately. Lowering it therefore mainly speeds up detection on devices that report continuously, such as power-metering plugs.",
           "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data."
         }
       },

--- a/docs/FEATURE-HIGHLIGHTS.de.md
+++ b/docs/FEATURE-HIGHLIGHTS.de.md
@@ -26,6 +26,11 @@ BLU-Familie hinter einem Gateway). Gebaut auf einem klaren Prinzip:
   erreicht — inkl. Shelly-BLU-Sensoren über ein Gateway und Geräte, die aus einem
   anderen Shelly-Konto geteilt wurden.
 - **Volle Generationsabdeckung:** Gen1 + Gen2/Gen3 + BLE-Gateway-Geräte.
+- **Merkt, wenn ein Gerät stirbt** — ein *Reporting*-Sensor je Gerät, gebaut auf
+  gemessenem Verhalten statt auf dem `cloud.connected`-Flag der Cloud (das noch
+  dreizehn Minuten nach dem Trennen eines Geräts *verbunden* meldete). Das kann
+  eine rein lokale Integration strukturell nicht leisten: der Ausfall, den sie
+  melden müsste, ist oft dasselbe Ereignis, das ihr die Sicht aufs Gerät nimmt.
 - Die einzige gepflegte HA-Integration, die Cloud-Control-API-Zugriff **mit
   State-Rücklesen, geteilten Geräten und Gen1/Gen2/BLE-Abdeckung** vereint.
 

--- a/docs/FEATURE-HIGHLIGHTS.de.md
+++ b/docs/FEATURE-HIGHLIGHTS.de.md
@@ -28,9 +28,10 @@ BLU-Familie hinter einem Gateway). Gebaut auf einem klaren Prinzip:
 - **Volle Generationsabdeckung:** Gen1 + Gen2/Gen3 + BLE-Gateway-Geräte.
 - **Merkt, wenn ein Gerät stirbt** — ein *Reporting*-Sensor je Gerät, gebaut auf
   gemessenem Verhalten statt auf dem `cloud.connected`-Flag der Cloud (das noch
-  dreizehn Minuten nach dem Trennen eines Geräts *verbunden* meldete). Das kann
-  eine rein lokale Integration strukturell nicht leisten: der Ausfall, den sie
-  melden müsste, ist oft dasselbe Ereignis, das ihr die Sicht aufs Gerät nimmt.
+  dreizehn Minuten nach dem Trennen eines Geräts *verbunden* meldete). Für Geräte
+  im eigenen LAN deckt die native Integration das schon ab; der Punkt sind die
+  Geräte, zu denen sie **keinen lokalen Weg** hat — geteilt, entfernt oder BLU
+  hinter fremdem Gateway — wo es sonst kein einziges Lebenszeichen gibt.
 - Die einzige gepflegte HA-Integration, die Cloud-Control-API-Zugriff **mit
   State-Rücklesen, geteilten Geräten und Gen1/Gen2/BLE-Abdeckung** vereint.
 

--- a/docs/FEATURE-HIGHLIGHTS.md
+++ b/docs/FEATURE-HIGHLIGHTS.md
@@ -26,6 +26,12 @@ family behind a gateway). But it is built on one firm principle:
   Shelly BLU sensors bridged through a gateway, and devices shared from another
   Shelly account.
 - **Full generation coverage:** Gen1 + Gen2/Gen3 + BLE‑gateway devices.
+- **Notices when a device dies** — a per‑device *Reporting* sensor built on
+  measured behaviour, not on the cloud's `cloud.connected` flag (which still
+  read *connected* thirteen minutes after a device was unplugged). This is
+  something a local‑only integration structurally cannot do: the outage it
+  needs to report is often the same event that takes its own view of the
+  device away.
 - The only maintained HA integration combining Cloud‑Control‑API access **with
   state read‑back, shared‑device support, and Gen1/Gen2/BLE coverage** at once.
 

--- a/docs/FEATURE-HIGHLIGHTS.md
+++ b/docs/FEATURE-HIGHLIGHTS.md
@@ -28,10 +28,10 @@ family behind a gateway). But it is built on one firm principle:
 - **Full generation coverage:** Gen1 + Gen2/Gen3 + BLE‑gateway devices.
 - **Notices when a device dies** — a per‑device *Reporting* sensor built on
   measured behaviour, not on the cloud's `cloud.connected` flag (which still
-  read *connected* thirteen minutes after a device was unplugged). This is
-  something a local‑only integration structurally cannot do: the outage it
-  needs to report is often the same event that takes its own view of the
-  device away.
+  read *connected* thirteen minutes after a device was unplugged). For devices
+  on your own LAN the native integration already covers this; the point here is
+  the devices it has **no local path to** — shared, remote, or BLU behind
+  someone else's gateway — where this is the only liveness signal that exists.
 - The only maintained HA integration combining Cloud‑Control‑API access **with
   state read‑back, shared‑device support, and Gen1/Gen2/BLE coverage** at once.
 

--- a/tests/test_offline_reporting.py
+++ b/tests/test_offline_reporting.py
@@ -1,0 +1,479 @@
+"""Unit tests for offline detection — the "Reporting" binary sensor.
+
+Why this feature exists at all, measured against a live 64-device account on
+2026-08-16: every flag the cloud offers for "is this device alive" is a cached
+lie. ``cloud.connected`` still read ``true`` thirteen minutes after a device
+had been physically unplugged, and read ``true`` for all 35 mains devices on
+the account — including one that had not reported for a quarter of an hour.
+``_dev_info.online`` read ``true`` for all 29 BLE devices, one of which had
+been silent for three days. Disappearing from ``/device/all_status`` does
+eventually happen, but takes up to ten minutes and the endpoint also omits
+devices spontaneously.
+
+The one trustworthy fact is that the device pushed a new snapshot, which
+``checkin_marker`` fingerprints. These tests pin the contract built on it:
+
+* a device counts as reporting while it keeps checking in;
+* the window is per-device, because normal cadences differ by orders of
+  magnitude (a metering Mini 1PM reports every 60 s, an idle Plus RGBW PM went
+  25 minutes, a BLE beacon three days — all healthy);
+* a single missing poll is not an outage (the endpoint drops devices);
+* an outage must never be *learned* as a device's normal cadence;
+* and when our own polling breaks we say "unknown", never "everything died".
+
+Driven through the real production code with a lightweight fake coordinator,
+so no running Home Assistant instance is required.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any
+
+from custom_components.shelly_cloud_diy.binary_sensor import (
+    ShellyReportingBinarySensor,
+    _create_reporting_sensor,
+)
+from custom_components.shelly_cloud_diy.const import OFFLINE_AFTER_DEFAULT
+from custom_components.shelly_cloud_diy.coordinator import (
+    REPORT_GAP_MARGIN,
+    REPORT_LEARN_CAP_S,
+    REPORT_STALE_BLE_S,
+    REPORT_STALE_CAP_S,
+    REPORT_UNLEARNED_FLOOR_S,
+    CheckinRecord,
+    ShellyCloudCoordinator,
+    sleep_window_s,
+)
+
+MAINS_ID = "ecda3bc59ec8"
+BLE_ID = "XB106582483818186"
+DEFAULT_WINDOW_S = OFFLINE_AFTER_DEFAULT * 60
+
+
+# ── Fixtures modelled on real payloads ────────────────────────────────
+
+def _mains_status(unixtime: int = 1786890000, updated: str = "2026-08-16 14:20:06") -> dict[str, Any]:
+    """A Gen3 mains device, exactly as the cloud serves it — including the
+    ``cloud.connected: true`` that stays true long after the device is dead."""
+    return {
+        "id": MAINS_ID,
+        "code": "S3SW-001P8EU",
+        "cloud": {"connected": True},
+        "switch:0": {"id": 0, "output": False, "apower": 0.0},
+        "sys": {"unixtime": unixtime, "uptime": 545909},
+        "serial": 1,
+        "_updated": updated,
+    }
+
+
+def _ble_status() -> dict[str, Any]:
+    """A BLU beacon bridged through a gateway: silent for days, yet online."""
+    return {
+        "motion:0": {"id": 0, "motion": False},
+        "devicepower:0": {"id": 0, "battery": {"percent": 100}},
+        "_updated": "2026-08-15 19:47:35",
+        "serial": 27020,
+        "_dev_info": {"id": BLE_ID, "gen": "GBLE", "online": True},
+    }
+
+
+def _pushed(status: dict[str, Any], unixtime: int) -> dict[str, Any]:
+    """``status`` as it looks once the device has pushed a fresh snapshot."""
+    return {
+        **status,
+        "sys": {**status.get("sys", {}), "unixtime": unixtime},
+        "serial": unixtime,
+        "_updated": f"2026-08-16 14:{unixtime % 60:02d}:06",
+    }
+
+
+class _FakeApi:
+    """Serves a canned all-status payload, swappable between polls."""
+
+    def __init__(self, devices_status: dict[str, Any]) -> None:
+        self.devices_status = devices_status
+
+    async def get_all_status(self) -> dict[str, Any]:
+        return {"devices_status": self.devices_status}
+
+
+class _StubHass:
+    def async_create_task(self, coro: Any) -> None:
+        coro.close()
+
+
+def _coordinator(devices_status: dict[str, Any] | None = None, **options: Any) -> ShellyCloudCoordinator:
+    """A coordinator with only the offline-detection wiring in place.
+
+    ``__init__`` wants a HomeAssistant instance and a ConfigEntry; none of the
+    check-in logic does, so bypass it rather than mock all of HA.
+    """
+    coord = object.__new__(ShellyCloudCoordinator)
+    coord._api = _FakeApi(devices_status or {})
+    coord.hass = _StubHass()
+    coord._entry = SimpleNamespace(options={"enabled_devices": [], **options})
+    coord.devices = {}
+    coord._known_device_ids = set()
+    coord.device_names = {}
+    coord._names_attempted = set()
+    coord._name_lookup_in_flight = False
+    coord.virtual_configs = {}
+    coord._vcomp_config_in_flight = False
+    coord._sleep_seen = {}
+    coord.checkins = {}
+    return coord
+
+
+# ── CheckinRecord: the window arithmetic ──────────────────────────────
+
+
+def test_a_device_whose_cadence_is_unknown_gets_the_benefit_of_the_doubt() -> None:
+    """Learned cadences live in memory only, so every restart starts blind.
+    Without this floor, a user who tightened the window for their metering
+    plug would get a false alarm on their quiet devices after every restart."""
+    record = CheckinRecord(marker=(1,), last_checkin=0.0, base_window_s=300.0)
+    assert record.stale_after_s == REPORT_UNLEARNED_FLOOR_S
+
+
+def test_the_configured_window_takes_over_once_the_cadence_is_known() -> None:
+    record = CheckinRecord(
+        marker=(1,), last_checkin=0.0, base_window_s=1800.0, widest_gap_s=60.0
+    )
+    assert record.stale_after_s == 1800.0
+
+
+def test_a_slow_device_earns_a_wider_window_than_configured() -> None:
+    """The Plus RGBW PM case: 25 min between reports, nothing wrong with it."""
+    record = CheckinRecord(
+        marker=(1,), last_checkin=0.0, base_window_s=300.0, widest_gap_s=1500.0
+    )
+    assert record.stale_after_s == 1500.0 * REPORT_GAP_MARGIN
+    # ...and it is still considered alive well past the configured 5 minutes.
+    assert record.is_reporting(now=1200.0) is True
+
+
+def test_the_window_never_shrinks_below_the_configured_base() -> None:
+    """A chatty device must not get a hair-trigger window from a tiny gap."""
+    record = CheckinRecord(
+        marker=(1,), last_checkin=0.0, base_window_s=1800.0, widest_gap_s=60.0
+    )
+    assert record.stale_after_s == 1800.0
+
+
+def test_the_window_is_capped_however_wide_the_gap() -> None:
+    record = CheckinRecord(
+        marker=(1,), last_checkin=0.0, base_window_s=0.0, widest_gap_s=10**9
+    )
+    assert record.stale_after_s == REPORT_STALE_CAP_S
+
+
+def test_silence_past_the_window_is_an_outage() -> None:
+    record = CheckinRecord(
+        marker=(1,), last_checkin=0.0, base_window_s=600.0, widest_gap_s=60.0
+    )
+    assert record.is_reporting(now=599.0) is True
+    assert record.is_reporting(now=601.0) is False
+
+
+# ── _record_checkin: what one poll does to the record ─────────────────
+
+
+def test_first_sight_counts_as_a_check_in() -> None:
+    """Otherwise every device would be 'offline' for one window after each
+    restart, which is the loudest possible way to be wrong."""
+    coord = _coordinator()
+    coord._record_checkin(MAINS_ID, _mains_status(), now=1000.0)
+
+    record = coord.checkins[MAINS_ID]
+    assert record.last_checkin == 1000.0
+    assert record.is_reporting(now=1000.0) is True
+
+
+def test_an_unchanged_payload_does_not_refresh_the_check_in() -> None:
+    """The whole point: the cloud re-serving a cached snapshot is not a sign
+    of life, so the window has to keep running underneath it."""
+    coord = _coordinator()
+    status = _mains_status()
+    coord._record_checkin(MAINS_ID, status, now=1000.0)
+    coord._record_checkin(MAINS_ID, dict(status), now=2000.0)
+
+    assert coord.checkins[MAINS_ID].last_checkin == 1000.0
+
+
+def test_a_new_payload_refreshes_the_check_in_and_teaches_the_cadence() -> None:
+    coord = _coordinator()
+    coord._record_checkin(MAINS_ID, _mains_status(), now=1000.0)
+    coord._record_checkin(MAINS_ID, _pushed(_mains_status(), 42), now=1090.0)
+
+    record = coord.checkins[MAINS_ID]
+    assert record.last_checkin == 1090.0
+    assert record.widest_gap_s == 90.0
+
+
+def test_only_the_widest_gap_is_kept() -> None:
+    coord = _coordinator()
+    coord._record_checkin(MAINS_ID, _mains_status(), now=0.0)
+    coord._record_checkin(MAINS_ID, _pushed(_mains_status(), 11), now=300.0)
+    coord._record_checkin(MAINS_ID, _pushed(_mains_status(), 22), now=360.0)
+
+    assert coord.checkins[MAINS_ID].widest_gap_s == 300.0
+
+
+def test_a_gap_that_spans_an_absence_is_not_learned() -> None:
+    """The regression that would silently disable the feature: if a real
+    outage taught the device its own downtime as a normal cadence, the window
+    would widen after every outage until none could ever be detected again."""
+    coord = _coordinator()
+    coord._record_checkin(MAINS_ID, _mains_status(), now=0.0)
+    coord.checkins[MAINS_ID].absent = True  # vanished from all_status
+    coord._record_checkin(MAINS_ID, _pushed(_mains_status(), 33), now=7200.0)
+
+    record = coord.checkins[MAINS_ID]
+    assert record.widest_gap_s == 0.0, "an outage is not a cadence"
+    assert record.last_checkin == 7200.0, "but it is still a check-in"
+    assert record.absent is False
+
+
+def test_an_implausibly_long_gap_is_not_learned_either() -> None:
+    """Belt and braces for a device that stayed listed while being dead."""
+    coord = _coordinator()
+    coord._record_checkin(MAINS_ID, _mains_status(), now=0.0)
+    coord._record_checkin(
+        MAINS_ID, _pushed(_mains_status(), 44), now=REPORT_LEARN_CAP_S + 1
+    )
+    assert coord.checkins[MAINS_ID].widest_gap_s == 0.0
+
+
+# ── Per-class base windows ────────────────────────────────────────────
+
+
+def test_a_mains_device_uses_the_configured_window() -> None:
+    coord = _coordinator()
+    coord._record_checkin(MAINS_ID, _mains_status(), now=0.0)
+    assert coord.checkins[MAINS_ID].base_window_s == DEFAULT_WINDOW_S
+
+
+def test_the_configured_window_is_honoured() -> None:
+    coord = _coordinator(offline_after_minutes=5)
+    coord._record_checkin(MAINS_ID, _mains_status(), now=0.0)
+    assert coord.checkins[MAINS_ID].base_window_s == 300.0
+
+
+def test_a_nonsense_option_falls_back_to_the_default() -> None:
+    coord = _coordinator(offline_after_minutes="not-a-number")
+    assert coord.offline_after_s == DEFAULT_WINDOW_S
+
+
+def test_a_ble_beacon_gets_its_own_generous_window() -> None:
+    """Measured median silence 19 minutes, maximum three days — and it cannot
+    run a heartbeat to do better, so the mains window would be pure noise."""
+    coord = _coordinator()
+    coord._record_checkin(BLE_ID, _ble_status(), now=0.0)
+    assert coord.checkins[BLE_ID].base_window_s == REPORT_STALE_BLE_S
+
+
+def test_a_sleeping_device_reuses_its_deep_sleep_window() -> None:
+    """So offline detection and availability (#13) cannot disagree about what
+    'still checking in' means for a battery device.
+
+    The *length* of the window, not the deadline: the deadline shrinks as the
+    device stays silent, and this record measures from its own check-in stamp,
+    so pairing the two would compound into half the intended tolerance.
+    """
+    status = {
+        "id": "907069591dc4",
+        "code": "S3SN-0U12A",
+        "cloud": {"connected": False},
+        "temperature:0": {"tC": 21.4},
+        "devicepower:0": {"battery": {"percent": 92}},
+        "sys": {"wakeup_period": 7200, "unixtime": 1786890000, "uptime": 3},
+        "_updated": "2026-08-16 14:20:06",
+    }
+    coord = _coordinator()
+    coord._record_checkin("907069591dc4", status, now=1000.0)
+
+    expected = sleep_window_s(status)
+    assert expected > 0, "fixture really is a deep-sleep device"
+    assert coord.checkins["907069591dc4"].base_window_s == expected
+
+    # A deadline would move with the clock; a window must not.
+    later = _coordinator()
+    later._record_checkin("907069591dc4", status, now=999_000.0)
+    assert later.checkins["907069591dc4"].base_window_s == expected
+
+
+# ── Full poll: absence handling ───────────────────────────────────────
+
+
+def test_a_device_missing_from_the_poll_keeps_its_record() -> None:
+    """It has to: the record is the only thing that can still report the
+    outage once the device is gone from the payload entirely."""
+    api_payload = {MAINS_ID: _mains_status()}
+    coord = _coordinator(api_payload)
+    asyncio.run(coord._async_update_data())
+
+    coord._api.devices_status = {}
+    asyncio.run(coord._async_update_data())
+
+    assert MAINS_ID not in coord.devices
+    assert MAINS_ID in coord.checkins
+    assert coord.checkins[MAINS_ID].absent is True
+
+
+def test_one_missing_poll_is_not_an_outage() -> None:
+    """``/device/all_status`` omits devices spontaneously — that is the whole
+    reason the verdict is time-based rather than presence-based."""
+    coord = _coordinator({MAINS_ID: _mains_status()})
+    asyncio.run(coord._async_update_data())
+
+    coord._api.devices_status = {}
+    asyncio.run(coord._async_update_data())
+
+    assert coord.is_reporting(MAINS_ID) is True
+
+
+def test_sustained_absence_eventually_reads_as_an_outage() -> None:
+    coord = _coordinator({MAINS_ID: _mains_status()})
+    asyncio.run(coord._async_update_data())
+
+    coord._api.devices_status = {}
+    asyncio.run(coord._async_update_data())
+    record = coord.checkins[MAINS_ID]
+    record.widest_gap_s = 60.0  # cadence already known, so the base applies
+    # Rewind the check-in past the window rather than sleeping through it.
+    record.last_checkin -= DEFAULT_WINDOW_S + 1
+
+    assert coord.is_reporting(MAINS_ID) is False
+
+
+def test_a_still_listed_but_silent_device_reads_as_an_outage() -> None:
+    """The measured failure mode: the cloud keeps serving the device, keeps
+    claiming ``cloud.connected: true``, and only the frozen payload gives it
+    away."""
+    coord = _coordinator({MAINS_ID: _mains_status()})
+    asyncio.run(coord._async_update_data())
+    asyncio.run(coord._async_update_data())  # same cached snapshot again
+
+    record = coord.checkins[MAINS_ID]
+    record.widest_gap_s = 60.0  # cadence already known, so the base applies
+    record.last_checkin -= DEFAULT_WINDOW_S + 1
+
+    assert coord.devices[MAINS_ID]["status"]["cloud"]["connected"] is True
+    assert coord.is_reporting(MAINS_ID) is False
+
+
+def test_an_unknown_device_has_no_verdict() -> None:
+    assert _coordinator().is_reporting("never-seen") is None
+
+
+# ── The entity ────────────────────────────────────────────────────────
+
+
+class _EntityCoordinator:
+    """Minimal coordinator surface the reporting entity actually reads."""
+
+    def __init__(
+        self,
+        checkins: dict[str, CheckinRecord],
+        *,
+        devices: dict[str, Any] | None = None,
+        last_update_success: bool = True,
+    ) -> None:
+        self.checkins = checkins
+        self.devices = devices if devices is not None else {}
+        self.data = self.devices
+        self.last_update_success = last_update_success
+
+    def is_reporting(self, device_id: str) -> bool | None:
+        record = self.checkins.get(device_id)
+        return None if record is None else record.is_reporting(time.monotonic())
+
+
+def _entity(
+    *,
+    gone_for: float = 0.0,
+    window: float = DEFAULT_WINDOW_S,
+    learned_gap: float = 60.0,
+    **kwargs: Any,
+) -> ShellyReportingBinarySensor:
+    record = CheckinRecord(
+        marker=(1,),
+        last_checkin=time.monotonic() - gone_for,
+        base_window_s=window,
+        widest_gap_s=learned_gap,
+    )
+    return ShellyReportingBinarySensor(
+        _EntityCoordinator({MAINS_ID: record}, **kwargs), MAINS_ID
+    )
+
+
+def test_the_entity_is_on_while_the_device_reports() -> None:
+    assert _entity(gone_for=60.0).is_on is True
+
+
+def test_the_entity_is_off_once_the_device_goes_silent() -> None:
+    assert _entity(gone_for=DEFAULT_WINDOW_S + 60).is_on is False
+
+
+def test_a_device_of_unknown_cadence_is_not_declared_dead_at_the_base_window() -> None:
+    """Same grace as after a restart, seen from the entity side."""
+    entity = _entity(gone_for=DEFAULT_WINDOW_S + 60, learned_gap=0.0)
+    assert entity.is_on is True
+
+
+def test_the_entity_stays_available_when_the_device_is_gone() -> None:
+    """The crux. The base class would make this unavailable — it keys off the
+    device being present and online — and an unavailable entity cannot report
+    the outage it exists to report."""
+    entity = _entity(gone_for=DEFAULT_WINDOW_S + 60)
+    assert entity.coordinator.devices == {}, "device absent from the poll"
+    assert entity.available is True
+    assert entity.is_on is False
+
+
+def test_a_broken_poll_makes_the_verdict_unavailable_not_negative() -> None:
+    """During a cloud outage we know nothing about any device; declaring the
+    whole fleet dead would be worse than admitting we cannot tell."""
+    entity = _entity(gone_for=60.0, last_update_success=False)
+    assert entity.available is False
+
+
+def test_an_entity_for_an_unseen_device_is_unavailable() -> None:
+    entity = ShellyReportingBinarySensor(_EntityCoordinator({}), MAINS_ID)
+    assert entity.available is False
+    assert entity.is_on is None
+
+
+def test_the_entity_publishes_the_window_it_judged_against() -> None:
+    """Per-device and adaptive, so without it there is no way to see why one
+    device tolerates far more silence than another."""
+    entity = _entity(window=1800.0)
+    assert entity.extra_state_attributes == {"stale_after_s": 1800}
+
+
+def test_the_entity_has_no_attributes_for_an_unseen_device() -> None:
+    entity = ShellyReportingBinarySensor(_EntityCoordinator({}), MAINS_ID)
+    assert entity.extra_state_attributes is None
+
+
+# ── Entity creation ───────────────────────────────────────────────────
+
+
+def test_every_device_gets_exactly_one_reporting_sensor() -> None:
+    coordinator = _EntityCoordinator({})
+    created: set[str] = set()
+
+    first = _create_reporting_sensor(MAINS_ID, created, coordinator)
+    second = _create_reporting_sensor(MAINS_ID, created, coordinator)
+
+    assert len(first) == 1
+    assert first[0].unique_id == f"{MAINS_ID}_reporting"
+    assert second == [], "re-running discovery must not duplicate it"
+
+
+def test_a_device_with_no_readable_status_still_gets_one() -> None:
+    """It is created ahead of the status check on purpose: a device we cannot
+    classify is if anything more worth watching, not less."""
+    assert _create_reporting_sensor(BLE_ID, set(), _EntityCoordinator({})) != []

--- a/tests/test_sleeping_availability.py
+++ b/tests/test_sleeping_availability.py
@@ -314,6 +314,7 @@ def _live_coordinator(devices_status: dict[str, Any]) -> ShellyCloudCoordinator:
     coord.virtual_configs = {}
     coord._vcomp_config_in_flight = False
     coord._sleep_seen = {}
+    coord.checkins = {}
     return coord
 
 


### PR DESCRIPTION
Adds a per-device **Reporting** binary sensor (connectivity, diagnostic category) that turns off once a device has been silent for longer than it ever normally is.

This is the signal needed to notice a power cut *through* the cloud.

**What it does and does not buy you.** For a device Home Assistant can reach on the LAN, the native integration already notices when it goes away — probably sooner. The cloud view earns its keep for devices Home Assistant has **no local path to at all**: a shared device, a second site, a BLU sensor behind someone else's gateway, where there is otherwise no liveness signal whatsoever. It is explicitly *not* a way to survive your own outage — with the local network down, Home Assistant cannot reach the cloud either, which is why the sensor goes unavailable rather than guessing.

## Why not something simpler

Every cheaper signal was measured against a live 64-device account and rejected:

| Signal | Measured behaviour | Verdict |
|---|---|---|
| `cloud.connected` | still read **connected** 13 min after a device was physically unplugged; read connected for **all 35** mains devices, including ones silent for a quarter of an hour | cached transport flag, not liveness |
| `_dev_info.online` | read **true** for **all 29** BLE devices, one silent for three days | same |
| absence from `/device/all_status` | happens, but took up to ~10 min — and the endpoint omits healthy devices at random | too slow, and noisy |

So the verdict keys off the one thing the cloud cannot fake: the device having **pushed a new snapshot**. That is fingerprinted by the existing `checkin_marker()` and stamped on our own monotonic clock — deliberately *not* reading `_updated` as a clock (no timezone, device clocks drift), which is the contract that function already documented.

## Why the window is per-device and adapts

Measured cadences differ by orders of magnitude, **all healthy**:

| Device | Normal gap between reports |
|---|---|
| Mini 1PM Gen3 (metering) | 60 s |
| Plus RGBW PM (idle) | **29 min 15 s** |
| BLE/BLU beacons | up to 3 days |

A single fixed threshold would either miss outages or cry wolf. So the configured value (**default 30 min**, new options-flow field) is a *base*:

- a naturally quieter device widens its own window from the widest gap it has actually been observed to take (`max(base, gap × 2)`);
- **a gap that spans an absence, or exceeds 2 h, is never learned** — otherwise one real outage teaches a device its own downtime as normal and no later outage could ever be detected;
- **an hour of grace applies until a cadence is known**, because learned gaps live in memory only and every restart starts blind — without it, a user who tightened the setting for their metering plug would get false alarms on their quiet devices after every restart;
- battery devices reuse their deep-sleep window (#13); BLE beacons get their own generous base.

Absence from a single poll is deliberately **not** an outage — the record ages against its own window instead. That is the debounce for the endpoint's habit of dropping devices.

When polling itself breaks (cloud outage, rejected `auth_key`) the sensor goes **unavailable** rather than reporting the whole fleet as dead.

## Notable during review

`sleep_window_s()` is new: `_evaluate_sleep_state` previously computed the window inline and only exposed the *deadline*. Offline detection needs the *length* — reusing the deadline would have compounded with this feature's own check-in stamp into roughly half the intended tolerance. Both now share the function.

`_sleep_seen` is intentionally left alone rather than generalised; its tests pin behaviour this feature must not have (mains devices are dropped from it by design). `checkins` sits alongside it and is never pruned — an absent device's record is the only thing that can still report the outage.

## Testing

- **30 new tests** in `tests/test_offline_reporting.py` covering the window arithmetic, both learning guards, per-class bases, absence handling and entity availability.
- **Control run performed:** removing the learning guard fails exactly the two tests written for it.
- Green on **HA 2025.1.4 / py3.12** (157 passed, 1 skipped) and **HA 2026.7.2 / py3.14** (158 passed).
- Translation key sets verified equal between `en.json` and `de.json`.

## Not covered

No live test against a running Home Assistant yet — the unit tests pin the verdict logic, not how the sensor looks in the UI or whether one extra diagnostic entity per device is unwelcome on a large account. The 30-minute default is a judgement call resting on a single measured 29-minute gap; more data is currently blocked by the account's rate limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxqg751CivULXbU63q5WDZ

