### PR TITLE
fix(binary_sensor): stop re-adding the reporting sensor on rediscovery

### DIFF
--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -38,6 +38,14 @@ async def async_setup_entry(
     """Set up Shelly Cloud DIY binary sensors."""
     coordinator: ShellyCloudCoordinator = hass.data[DOMAIN][entry.entry_id]
     created_entities: set[str] = set()
+    # Kept apart from ``created_entities`` because ``async_add_device`` clears
+    # that set for a rediscovered device so component entities can be rebuilt
+    # from a fresher status. The reporting sensor derives nothing from status,
+    # so rebuilding it is never useful — and a device that flaps out of
+    # ``/device/all_status`` and back (which the endpoint does on its own) is
+    # rediscovered routinely. Without this it would be re-added on every such
+    # flap and Home Assistant would log a duplicate-unique-ID error each time.
+    reporting_created: set[str] = set()
 
     def create_binary_sensors(device_id: str) -> list[BinarySensorEntity]:
         """Create binary sensor entities for a device."""
@@ -51,7 +59,7 @@ async def async_setup_entry(
         # created before the status check below — a device whose status we
         # cannot read yet is exactly one worth watching.
         entities.extend(
-            _create_reporting_sensor(device_id, created_entities, coordinator)
+            _create_reporting_sensor(device_id, reporting_created, coordinator)
         )
 
         if not status:

--- a/tests/test_offline_reporting.py
+++ b/tests/test_offline_reporting.py
@@ -477,3 +477,53 @@ def test_a_device_with_no_readable_status_still_gets_one() -> None:
     """It is created ahead of the status check on purpose: a device we cannot
     classify is if anything more worth watching, not less."""
     assert _create_reporting_sensor(BLE_ID, set(), _EntityCoordinator({})) != []
+
+
+# ── Rediscovery: the flap the cloud produces on its own ───────────────
+
+
+class _SetupCoordinator(_EntityCoordinator):
+    """Adds the bits ``async_setup_entry`` touches on top of the entity stub."""
+
+    def is_enabled(self, device_id: str) -> bool:
+        return True
+
+
+def test_a_rediscovered_device_does_not_get_a_second_reporting_sensor(monkeypatch) -> None:
+    """``/device/all_status`` drops devices on its own, so a device is
+    rediscovered routinely. ``async_add_device`` deliberately forgets a
+    rediscovered device's component entities so they can be rebuilt from a
+    fresher status — but the reporting sensor derives nothing from status, and
+    re-adding it makes Home Assistant log a duplicate-unique-ID error.
+
+    Found by a live run against a real Home Assistant, not by the unit tests:
+    the coordinator dispatches ``SIGNAL_NEW_DEVICE`` *before* it commits the
+    new snapshot, so the rediscovery path sees an empty status and every
+    status-derived builder bows out — leaving this one to collide alone.
+    """
+    from custom_components.shelly_cloud_diy import binary_sensor as mod
+
+    record = CheckinRecord(marker=(1,), last_checkin=time.monotonic(),
+                           base_window_s=DEFAULT_WINDOW_S, widest_gap_s=60.0)
+    coordinator = _SetupCoordinator({MAINS_ID: record}, devices={MAINS_ID: {"status": {}}})
+
+    handlers: list[Any] = []
+    monkeypatch.setattr(
+        mod, "async_dispatcher_connect",
+        lambda hass, signal, cb: handlers.append(cb) or (lambda: None),
+    )
+
+    added: list[Any] = []
+    hass = SimpleNamespace(data={"shelly_cloud_diy": {"e1": coordinator}})
+    entry = SimpleNamespace(entry_id="e1", async_on_unload=lambda cb: None)
+
+    asyncio.run(mod.async_setup_entry(hass, entry, lambda ents: added.extend(ents)))
+    first = [e for e in added if e.unique_id.endswith("_reporting")]
+    assert len(first) == 1, "one reporting sensor at setup"
+
+    # The device drops out of a poll and comes back — the coordinator fires
+    # SIGNAL_NEW_DEVICE again.
+    handlers[0](MAINS_ID)
+
+    again = [e for e in added if e.unique_id.endswith("_reporting")]
+    assert len(again) == 1, "rediscovery must not add a second one"


### PR DESCRIPTION
Follow-up to #28, found by a live run against a real Home Assistant — the unit tests could not see it.

`/device/all_status` drops devices spontaneously (the very behaviour the reporting sensor debounces), so a device is rediscovered routinely. Each rediscovery logged:

```
Platform shelly_cloud_diy does not generate unique IDs.
ID <device>_reporting already exists - ignoring binary_sensor...._reporting
```

`async_add_device` deliberately forgets a rediscovered device's entities so component entities can be rebuilt from a fresher status. The reporting sensor derives nothing from status, so rebuilding it is never useful — and re-adding it collides with the entity already registered.

It surfaced **alone** because the coordinator dispatches `SIGNAL_NEW_DEVICE` *before* it commits the new snapshot, so the rediscovery path sees an empty status and every status-derived builder bows out.

**Fix:** the reporting sensor gets its own guard set, which rediscovery does not clear.

**Verification**
- Regression test drives `async_setup_entry` and fires the rediscovery callback. Control run confirms it fails when the guard sets are swapped back.
- Live: same device flapped out and back, two rediscoveries logged, **zero** collisions.
- 158 passed / 1 skipped on HA 2025.1.4 · 159 passed on HA 2026.7.2.

**Noted, not fixed here:** the dispatch-before-commit ordering in `coordinator.py` means a device that has *never* been materialised and appears mid-run gets only this sensor and no component entities, with no second chance until restart. Narrow in practice — the entity registry covers any device seen before, and the options flow will not let you enable a device the cloud is not currently listing — so it mainly affects `create_all_initially` users gaining a brand-new device. Left for a separate change since it touches shared behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxqg751CivULXbU63q5WDZ
