### PR TITLE
fix: build entities for a device that first appears mid-run

### DIFF
--- a/custom_components/shelly_cloud_diy/__init__.py
+++ b/custom_components/shelly_cloud_diy/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .api.cloud_control import ShellyCloudControl
 from .const import (
@@ -34,6 +35,7 @@ from .const import (
     CONF_SERVER_URI,
     DOMAIN,
     PLATFORMS,
+    SIGNAL_DEVICE_REMOVED,
 )
 from .coordinator import ShellyCloudCoordinator
 from .services.fleet_map import async_handle_fleet_map
@@ -232,6 +234,10 @@ async def async_remove_config_entry_device(
         return False
 
     _purge_device_entities(hass, config_entry.entry_id, device_entry.id, device_id)
+    # Tell the platforms to forget their entity bookkeeping for this device.
+    # Without it they would still consider every entity "already created" and
+    # a later rediscovery would silently produce nothing.
+    async_dispatcher_send(hass, SIGNAL_DEVICE_REMOVED, device_id)
     return True
 
 

--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, device_gen, is_gen2_status
+from .const import DOMAIN, SIGNAL_DEVICE_REMOVED, device_gen, is_gen2_status
 from .coordinator import ShellyCloudCoordinator, SIGNAL_NEW_DEVICE
 from .entities.base import ShellyBaseEntity
 from .entities.descriptions import (
@@ -38,13 +38,10 @@ async def async_setup_entry(
     """Set up Shelly Cloud DIY binary sensors."""
     coordinator: ShellyCloudCoordinator = hass.data[DOMAIN][entry.entry_id]
     created_entities: set[str] = set()
-    # Kept apart from ``created_entities`` because ``async_add_device`` clears
-    # that set for a rediscovered device so component entities can be rebuilt
-    # from a fresher status. The reporting sensor derives nothing from status,
-    # so rebuilding it is never useful — and a device that flaps out of
-    # ``/device/all_status`` and back (which the endpoint does on its own) is
-    # rediscovered routinely. Without this it would be re-added on every such
-    # flap and Home Assistant would log a duplicate-unique-ID error each time.
+    # Tracked separately from ``created_entities`` because the reporting sensor
+    # derives nothing from the device status: it exists for every device, even
+    # one whose status we cannot read, so it has no per-component key to live
+    # under. Both sets are forgotten together when the device is deleted.
     reporting_created: set[str] = set()
 
     def create_binary_sensors(device_id: str) -> list[BinarySensorEntity]:
@@ -87,12 +84,16 @@ async def async_setup_entry(
     @callback
     def async_add_device(device_id: str) -> None:
         """Add entities for newly discovered device."""
-        stale = [k for k in created_entities if k.startswith(device_id)]
-        for k in stale:
-            created_entities.discard(k)
         entities = create_binary_sensors(device_id)
         if entities:
             async_add_entities(entities)
+
+    @callback
+    def async_forget_device(device_id: str) -> None:
+        """Forget a deleted device so a later rediscovery rebuilds it."""
+        for tracked in (created_entities, reporting_created):
+            for k in [k for k in tracked if k.startswith(device_id)]:
+                tracked.discard(k)
 
     # Add existing devices
     entities: list[BinarySensorEntity] = []
@@ -105,6 +106,9 @@ async def async_setup_entry(
     # Listen for new devices
     entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_NEW_DEVICE, async_add_device)
+    )
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_DEVICE_REMOVED, async_forget_device)
     )
 
 

--- a/custom_components/shelly_cloud_diy/button.py
+++ b/custom_components/shelly_cloud_diy/button.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_DEVICE_REMOVED
 from .coordinator import ShellyCloudCoordinator, SIGNAL_NEW_DEVICE
 from .entities.base import ShellyBaseEntity
 
@@ -80,12 +80,15 @@ async def async_setup_entry(
     @callback
     def async_add_device(device_id: str) -> None:
         """Add entities for newly discovered device."""
-        stale = [k for k in created_entities if k.startswith(device_id)]
-        for k in stale:
-            created_entities.discard(k)
         entities = create_buttons(device_id)
         if entities:
             async_add_entities(entities)
+
+    @callback
+    def async_forget_device(device_id: str) -> None:
+        """Forget a deleted device so a later rediscovery rebuilds it."""
+        for k in [k for k in created_entities if k.startswith(device_id)]:
+            created_entities.discard(k)
 
     # Add existing devices
     entities: list[ButtonEntity] = []
@@ -98,6 +101,9 @@ async def async_setup_entry(
     # Listen for new devices
     entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_NEW_DEVICE, async_add_device)
+    )
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_DEVICE_REMOVED, async_forget_device)
     )
 
 

--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -68,6 +68,14 @@ HISTORICAL_SYNC_INTERVAL = 24 * 60 * 60  # daily
 
 SIGNAL_NEW_DEVICE = f"{DOMAIN}_new_device"
 
+# Fired when the user deletes a single device from the HA UI. Platforms use
+# it to forget which entities they already built for that device, so that a
+# later rediscovery starts from scratch. Rediscovery on its own must NOT
+# reset that bookkeeping: ``/device/all_status`` omits devices spontaneously,
+# so a healthy device is "rediscovered" routinely and rebuilding its entities
+# would collide with the ones still live.
+SIGNAL_DEVICE_REMOVED = f"{DOMAIN}_device_removed"
+
 # ── Fleet-Map overlay (Stage 1) ────────────────────────────────────
 
 # Domain of Home Assistant Core's native (local/LAN) Shelly integration.

--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -570,16 +570,9 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 "virtual_config": self.virtual_configs.get(device_id),
             }
 
-        # Fire SIGNAL_NEW_DEVICE only for devices the user has actually
-        # enabled — if they've opted out of a device we still poll it (so
-        # commands and data stay consistent) but we never materialise
-        # entities for it.
         newly_seen = set(new_devices) - self._known_device_ids
         if newly_seen:
             _LOGGER.info("Cloud Control API: discovered %d new device(s)", len(newly_seen))
-        for device_id in newly_seen:
-            if self.is_enabled(device_id):
-                async_dispatcher_send(self.hass, SIGNAL_NEW_DEVICE, device_id)
         self._known_device_ids = set(new_devices)
 
         # Forget check-in history for devices that have been absent from the
@@ -602,6 +595,22 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             self.checkins[gone_id].absent = True
 
         self.devices = new_devices
+
+        # Fire SIGNAL_NEW_DEVICE only for devices the user has actually
+        # enabled — if they've opted out of a device we still poll it (so
+        # commands and data stay consistent) but we never materialise
+        # entities for it.
+        #
+        # This runs AFTER ``self.devices`` has been replaced, and that order
+        # matters: the platform builders read the device's status straight out
+        # of ``coordinator.devices``. Dispatching first meant a device seen for
+        # the very first time was looked up in the PREVIOUS snapshot, where it
+        # does not exist — the builders then saw an empty status and created no
+        # component entities, and the device never got a second chance because
+        # ``_known_device_ids`` had already been updated.
+        for device_id in newly_seen:
+            if self.is_enabled(device_id):
+                async_dispatcher_send(self.hass, SIGNAL_NEW_DEVICE, device_id)
 
         # Schedule a name lookup for any device we haven't resolved yet.
         # Sleeping devices are included: the lookup hits the account-wide v1

--- a/custom_components/shelly_cloud_diy/cover.py
+++ b/custom_components/shelly_cloud_diy/cover.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_DEVICE_REMOVED
 from .coordinator import ShellyCloudCoordinator, SIGNAL_NEW_DEVICE
 from .entities.base import ShellyBaseEntity
 
@@ -70,12 +70,15 @@ async def async_setup_entry(
     @callback
     def async_add_device(device_id: str) -> None:
         """Add entities for newly discovered device."""
-        stale = [k for k in created_entities if k.startswith(device_id)]
-        for k in stale:
-            created_entities.discard(k)
         entities = create_covers(device_id)
         if entities:
             async_add_entities(entities)
+
+    @callback
+    def async_forget_device(device_id: str) -> None:
+        """Forget a deleted device so a later rediscovery rebuilds it."""
+        for k in [k for k in created_entities if k.startswith(device_id)]:
+            created_entities.discard(k)
 
     # Add existing devices
     entities: list[CoverEntity] = []
@@ -88,6 +91,9 @@ async def async_setup_entry(
     # Listen for new devices
     entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_NEW_DEVICE, async_add_device)
+    )
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_DEVICE_REMOVED, async_forget_device)
     )
 
 

--- a/custom_components/shelly_cloud_diy/light.py
+++ b/custom_components/shelly_cloud_diy/light.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_DEVICE_REMOVED
 from .coordinator import ShellyCloudCoordinator, SIGNAL_NEW_DEVICE
 from .entities.base import ShellyBaseEntity
 
@@ -71,12 +71,15 @@ async def async_setup_entry(
     @callback
     def async_add_device(device_id: str) -> None:
         """Add entities for newly discovered device."""
-        stale = [k for k in created_entities if k.startswith(device_id)]
-        for k in stale:
-            created_entities.discard(k)
         entities = create_lights(device_id)
         if entities:
             async_add_entities(entities)
+
+    @callback
+    def async_forget_device(device_id: str) -> None:
+        """Forget a deleted device so a later rediscovery rebuilds it."""
+        for k in [k for k in created_entities if k.startswith(device_id)]:
+            created_entities.discard(k)
 
     # Add existing devices
     entities: list[LightEntity] = []
@@ -89,6 +92,9 @@ async def async_setup_entry(
     # Listen for new devices
     entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_NEW_DEVICE, async_add_device)
+    )
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_DEVICE_REMOVED, async_forget_device)
     )
 
 

--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.const import PERCENTAGE, UnitOfElectricPotential, EntityCategory
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
-from .const import DOMAIN, device_gen, is_gen2_status
+from .const import DOMAIN, SIGNAL_DEVICE_REMOVED, device_gen, is_gen2_status
 from .coordinator import ShellyCloudCoordinator, SIGNAL_NEW_DEVICE
 from .entities.base import ShellyBaseEntity
 from .entities.descriptions import (
@@ -71,14 +71,15 @@ async def async_setup_entry(
     @callback
     def async_add_device(device_id: str) -> None:
         """Add entities for newly discovered device."""
-        # Clear stale tracking for this device so entities are
-        # recreated after a delete-then-rediscover cycle.
-        stale = [k for k in created_sensors if k.startswith(device_id)]
-        for k in stale:
-            created_sensors.discard(k)
         entities = create_sensors(device_id)
         if entities:
             async_add_entities(entities)
+
+    @callback
+    def async_forget_device(device_id: str) -> None:
+        """Forget a deleted device so a later rediscovery rebuilds it."""
+        for k in [k for k in created_sensors if k.startswith(device_id)]:
+            created_sensors.discard(k)
 
     # Add existing devices
     entities: list[SensorEntity] = []
@@ -91,6 +92,9 @@ async def async_setup_entry(
     # Listen for new devices
     entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_NEW_DEVICE, async_add_device)
+    )
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_DEVICE_REMOVED, async_forget_device)
     )
 
 

--- a/custom_components/shelly_cloud_diy/switch.py
+++ b/custom_components/shelly_cloud_diy/switch.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_DEVICE_REMOVED
 from .coordinator import ShellyCloudCoordinator, SIGNAL_NEW_DEVICE
 from .entities.base import ShellyBaseEntity
 
@@ -66,12 +66,15 @@ async def async_setup_entry(
     @callback
     def async_add_device(device_id: str) -> None:
         """Add entities for newly discovered device."""
-        stale = [k for k in created_entities if k.startswith(device_id)]
-        for k in stale:
-            created_entities.discard(k)
         entities = create_switches(device_id)
         if entities:
             async_add_entities(entities)
+
+    @callback
+    def async_forget_device(device_id: str) -> None:
+        """Forget a deleted device so a later rediscovery rebuilds it."""
+        for k in [k for k in created_entities if k.startswith(device_id)]:
+            created_entities.discard(k)
 
     # Add existing devices
     entities: list[SwitchEntity] = []
@@ -84,6 +87,9 @@ async def async_setup_entry(
     # Listen for new devices
     entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_NEW_DEVICE, async_add_device)
+    )
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_DEVICE_REMOVED, async_forget_device)
     )
 
 

--- a/tests/test_rediscovery.py
+++ b/tests/test_rediscovery.py
@@ -1,0 +1,240 @@
+"""Unit tests for device discovery and rediscovery.
+
+Two behaviours meet here, and getting either one alone wrong is a bug that
+only shows up on a live account:
+
+1. ``_async_update_data`` must replace ``self.devices`` BEFORE it fires
+   ``SIGNAL_NEW_DEVICE``. The platform builders read the device's status out
+   of ``coordinator.devices``; dispatching first meant a device seen for the
+   first time was looked up in the *previous* snapshot, where it does not
+   exist. The builders then saw an empty status, created no component
+   entities, and the device never got a second chance because
+   ``_known_device_ids`` had already been updated.
+
+2. A rediscovered device must NOT have its entity bookkeeping reset.
+   ``/device/all_status`` omits healthy devices spontaneously (see the
+   debounce note in ``_async_update_data``), so ``SIGNAL_NEW_DEVICE`` fires
+   for a perfectly healthy device as a matter of routine. Rebuilding its
+   entities then collides with the ones still live — Home Assistant logs
+   "does not generate unique IDs" and drops the duplicate. Only an actual
+   deletion from the UI may reset that bookkeeping, which is what
+   ``SIGNAL_DEVICE_REMOVED`` is for.
+
+The two pull in opposite directions: fixing (1) on its own is what makes (2)
+bite, because the clearing that used to be harmless suddenly has a populated
+snapshot to work with.
+
+Driven through the real production code with a lightweight fake coordinator,
+so no running Home Assistant instance is required.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+from custom_components.shelly_cloud_diy import binary_sensor as binary_sensor_mod
+from custom_components.shelly_cloud_diy import coordinator as coordinator_mod
+from custom_components.shelly_cloud_diy.const import (
+    DOMAIN,
+    SIGNAL_DEVICE_REMOVED,
+    SIGNAL_NEW_DEVICE,
+)
+from custom_components.shelly_cloud_diy.coordinator import ShellyCloudCoordinator
+
+DEVICE_ID = "ecda3bc59ec8"
+OTHER_ID = "d0ef76c7a454"
+
+
+def _gen3_status(updated: str = "2026-08-16 14:20:06") -> dict[str, Any]:
+    """A Gen3 mains device with an input and a cloud block, so the RPC
+    builder has something to build (one input sensor + one cloud sensor)."""
+    return {
+        "_updated": updated,
+        "sys": {"mac": DEVICE_ID.upper(), "uptime": 545909},
+        "cloud": {"connected": True},
+        "input:0": {"id": 0, "state": False},
+        "switch:0": {"id": 0, "output": True, "apower": 12.3},
+    }
+
+
+class _FakeApi:
+    def __init__(self, devices_status: dict[str, Any]) -> None:
+        self._devices_status = devices_status
+
+    async def get_all_status(self) -> dict[str, Any]:
+        return {"devices_status": self._devices_status}
+
+
+class _StubHass:
+    """Enough of HomeAssistant for the poll path; ``data`` carries the
+    coordinator the way the real integration hands it to a platform."""
+
+    def __init__(self) -> None:
+        self.data: dict[str, Any] = {}
+
+    def async_create_task(self, coro: Any) -> None:
+        coro.close()
+
+
+def _coordinator(devices_status: dict[str, Any]) -> ShellyCloudCoordinator:
+    """A coordinator whose real ``_async_update_data`` can be driven.
+
+    ``__init__`` wants a HomeAssistant instance and a ConfigEntry; the poll
+    path does not, so bypass it rather than mock all of HA.
+    """
+    coord = object.__new__(ShellyCloudCoordinator)
+    coord._api = _FakeApi(devices_status)
+    coord.hass = _StubHass()
+    # ``create_all_initially`` so every discovered device is dispatched —
+    # otherwise ``is_enabled`` gates the signal we are testing.
+    coord._entry = SimpleNamespace(options={"create_all_initially": True})
+    coord.devices = {}
+    coord._known_device_ids = set()
+    coord.device_names = {}
+    coord._names_attempted = set()
+    coord._name_lookup_in_flight = False
+    coord.virtual_configs = {}
+    coord._vcomp_config_in_flight = False
+    coord._sleep_seen = {}
+    coord.checkins = {}
+    return coord
+
+
+def _setup_binary_sensor_platform(
+    coord: ShellyCloudCoordinator, monkeypatch: Any
+) -> tuple[list[Any], dict[str, Any]]:
+    """Run the real ``binary_sensor.async_setup_entry`` and hand back the
+    entities it added plus the dispatcher callbacks it registered."""
+    added: list[Any] = []
+    callbacks: dict[str, Any] = {}
+
+    def fake_connect(hass: Any, signal: str, target: Any) -> Any:
+        callbacks[signal] = target
+        return lambda: None
+
+    monkeypatch.setattr(binary_sensor_mod, "async_dispatcher_connect", fake_connect)
+
+    entry = SimpleNamespace(entry_id="entry", async_on_unload=lambda _cb: None)
+    coord.hass.data = {DOMAIN: {"entry": coord}}
+
+    asyncio.run(
+        binary_sensor_mod.async_setup_entry(
+            coord.hass, entry, lambda entities: added.extend(entities)
+        )
+    )
+    return added, callbacks
+
+
+# ── 1. The dispatch order ─────────────────────────────────────────────
+
+
+def test_a_new_device_is_dispatched_against_the_snapshot_it_appeared_in(
+    monkeypatch: Any,
+) -> None:
+    """The bug this pins: the signal used to fire while ``coordinator.devices``
+    still held the previous poll, so the builders looked the brand-new device
+    up in a snapshot that could not contain it."""
+    coord = _coordinator({DEVICE_ID: _gen3_status()})
+    seen_at_dispatch: dict[str, Any] = {}
+
+    def record(hass: Any, signal: str, device_id: str) -> None:
+        seen_at_dispatch[device_id] = coord.devices.get(device_id, {}).get("status", {})
+
+    monkeypatch.setattr(coordinator_mod, "async_dispatcher_send", record)
+    asyncio.run(coord._async_update_data())
+
+    assert DEVICE_ID in seen_at_dispatch, "no signal fired for the new device"
+    assert seen_at_dispatch[DEVICE_ID].get("input:0") == {"id": 0, "state": False}
+
+
+def test_a_device_appearing_mid_run_gets_its_component_entities(
+    monkeypatch: Any,
+) -> None:
+    """End-to-end over the real platform: a device that shows up while the
+    integration is already running must get its component entities, not just
+    the device-wide reporting sensor."""
+    devices_status: dict[str, Any] = {}
+    coord = _coordinator(devices_status)
+    added, callbacks = _setup_binary_sensor_platform(coord, monkeypatch)
+    assert added == [], "no devices yet, so nothing to build"
+
+    # Wire the coordinator's signal to the platform listener, as HA would.
+    monkeypatch.setattr(
+        coordinator_mod,
+        "async_dispatcher_send",
+        lambda hass, signal, device_id: callbacks[signal](device_id),
+    )
+
+    devices_status[DEVICE_ID] = _gen3_status()
+    asyncio.run(coord._async_update_data())
+
+    uids = {e.unique_id for e in added}
+    assert f"{DEVICE_ID}_reporting" in uids
+    assert f"{DEVICE_ID}_input:0_state" in uids, "component entities were not built"
+    assert f"{DEVICE_ID}_cloud_connected" in uids
+
+
+# ── 2. Rediscovery must not rebuild what is still live ────────────────
+
+
+def test_rediscovery_does_not_rebuild_entities_that_still_exist(
+    monkeypatch: Any,
+) -> None:
+    """``/device/all_status`` drops healthy devices on its own, so this path
+    runs in normal operation. Rebuilding here is what produced the duplicate
+    unique-ID errors."""
+    coord = _coordinator({DEVICE_ID: _gen3_status()})
+    coord.devices = {DEVICE_ID: {"status": _gen3_status(), "online": True}}
+    added, callbacks = _setup_binary_sensor_platform(coord, monkeypatch)
+
+    first_round = {e.unique_id for e in added}
+    assert f"{DEVICE_ID}_input:0_state" in first_round
+
+    added.clear()
+    callbacks[SIGNAL_NEW_DEVICE](DEVICE_ID)
+    assert added == [], "a rediscovered device must not be rebuilt"
+
+
+def test_rediscovery_of_one_device_leaves_the_others_alone(
+    monkeypatch: Any,
+) -> None:
+    """The bookkeeping is keyed by device, so a signal for one device must
+    not resurrect or duplicate anything belonging to another."""
+    coord = _coordinator({})
+    coord.devices = {
+        DEVICE_ID: {"status": _gen3_status(), "online": True},
+        OTHER_ID: {"status": _gen3_status(), "online": True},
+    }
+    added, callbacks = _setup_binary_sensor_platform(coord, monkeypatch)
+    assert {e.unique_id for e in added} >= {
+        f"{DEVICE_ID}_input:0_state",
+        f"{OTHER_ID}_input:0_state",
+    }
+
+    added.clear()
+    callbacks[SIGNAL_DEVICE_REMOVED](DEVICE_ID)
+    callbacks[SIGNAL_NEW_DEVICE](OTHER_ID)
+    assert added == [], "the untouched device was rebuilt"
+
+
+# ── 3. …but a real deletion must reset it ─────────────────────────────
+
+
+def test_a_deleted_device_is_rebuilt_when_it_is_rediscovered(
+    monkeypatch: Any,
+) -> None:
+    """Deleting a device from the UI purges its entity-registry entries, so
+    the platform must forget it too — otherwise a later rediscovery finds
+    everything "already created" and silently produces nothing."""
+    coord = _coordinator({})
+    coord.devices = {DEVICE_ID: {"status": _gen3_status(), "online": True}}
+    added, callbacks = _setup_binary_sensor_platform(coord, monkeypatch)
+    original = {e.unique_id for e in added}
+    assert f"{DEVICE_ID}_reporting" in original
+
+    added.clear()
+    callbacks[SIGNAL_DEVICE_REMOVED](DEVICE_ID)
+    callbacks[SIGNAL_NEW_DEVICE](DEVICE_ID)
+
+    assert {e.unique_id for e in added} == original


### PR DESCRIPTION
## The bug

`_async_update_data` fired `SIGNAL_NEW_DEVICE` **before** replacing `self.devices`. The platform builders read the device's status out of `coordinator.devices`, so a device seen for the very first time was looked up in the *previous* snapshot — where it cannot exist. The builders saw an empty status, created no component entities, and the device never got a second chance, because `_known_device_ids` had already been updated.

Follow-up to the note left in #29.

## Why moving the dispatch is not enough on its own

`async_add_device` cleared the platform's created-entity bookkeeping for **every** rediscovered device. That was intended for a delete-then-rediscover cycle — but `/device/all_status` omits healthy devices spontaneously (the same behaviour the offline sensor debounces against), so a healthy device is "rediscovered" as a matter of routine.

Today that clearing is harmless only because the builders bail out on the stale snapshot. With the dispatch order corrected it would suddenly take effect and rebuild entities that are still live: the duplicate-unique-ID error #29 fixed for the reporting sensor, generalised to all six platforms.

So the clearing now hangs off a new `SIGNAL_DEVICE_REMOVED`, dispatched from `async_remove_config_entry_device` — the one place where the entity-registry entries really are gone.

## Verification

Unit tests: five new tests in `tests/test_rediscovery.py`. Both halves of the fix were reverted individually to confirm the tests bite (two tests fail per half). Full matrix green — 163 passed + 1 skipped on HA 2025.1.4 / py3.12, 164 on HA 2026.7.2 / py3.14.

Live, against a running Home Assistant fed by a recorded 64-device cloud snapshot so devices can be made to appear and vanish on command. Two identical Gen3 1PM devices Home Assistant had never seen before, one per branch:

| Scenario | without the fix | with the fix |
|---|---|---|
| device appears mid-run | **1 entity** (the reporting sensor alone — with a nameless entity id, because the status was empty) | **9 entities** |
| 3 rediscovery cycles | — | **0** duplicate unique IDs |
| dispatch move **only** | — | **7 errors from a single cycle**, across binary_sensor, sensor and switch |
| delete from the UI, then rediscover | — | all **9** entities restored |
| same, with `SIGNAL_DEVICE_REMOVED` suppressed | — | **0** restored — the signal is load-bearing |

## Scope

Narrow in practice: the entity registry restores anything that existed once, so this only bites when a device that has *never* been materialised shows up while Home Assistant is running. The second half of the change, however, protects every install from the moment the first half lands.