### PR TITLE
fix: pass the config entry to the coordinator explicitly

### DIFF
--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -297,8 +297,17 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(seconds=interval_s),
+            # Passed explicitly rather than left to the ContextVar the base
+            # class falls back on: Home Assistant reports that fallback as
+            # deprecated and removes it in 2026.8. The parameter exists in
+            # every version this integration supports (checked against the
+            # 2025.1.4 floor), so no version gate is needed.
+            config_entry=entry,
         )
 
+        # The base class now also exposes this as ``self.config_entry``.
+        # Kept under its own name because the whole module and the test
+        # harnesses address it as ``_entry``; renaming is a separate change.
         self._entry = entry
         self._api = api
         self.devices: dict[str, dict[str, Any]] = {}


### PR DESCRIPTION
Home Assistant reports the ContextVar fallback `DataUpdateCoordinator` uses when no config entry is passed as deprecated, with `breaks_in_ha_version="2026.8"`:

```
relies on ContextVar, but should pass the config entry explicitly.
```

The `config_entry` parameter exists in every version this integration supports — verified against the 2025.1.4 floor as well as 2026.7.2 — so no version gate is needed.

`self._entry` stays as it is: the base class now also exposes the same object as `self.config_entry`, but the whole module and all three test harnesses address it as `_entry`, and renaming that is a separate change with no behaviour benefit.

**Verified against a running Home Assistant** (2026.7.2, fed by the recorded 64-device snapshot): the warning appeared once per start before the change and not at all after, with the integration still loading all 64 devices.

Test matrix unchanged and green: 220 passed + 2 skipped (HA 2025.1.4 / py3.12), 221 + 1 skipped (HA 2026.7.2 / py3.14).