### PR TITLE
fix(sensor): keep waking H&T devices available on USB power (#32)

### DIFF
--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -152,6 +152,37 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def still_deep_sleeping(status: dict[str, Any], period: int) -> bool:
+    """Return whether ``status`` was pushed by a device that just woke up.
+
+    Needed only to tell two externally powered devices apart (#32): one that
+    stopped sleeping when it got permanent power, and one that kept its
+    wakeup schedule regardless. Only the first makes the transport flag
+    meaningful again.
+
+    Two independent signals, either of which is enough:
+
+    * the cloud's own ``_sleeping`` marker, and
+    * a boot out of deep sleep whose uptime has not yet outlived one wakeup
+      period — a device that stays awake pushes later snapshots, so its
+      uptime grows past the period and the evidence expires by itself.
+    """
+    if status.get("_sleeping") is True:
+        return True
+
+    sys_block = status.get("sys")
+    if not isinstance(sys_block, dict):
+        return False
+    reason = sys_block.get("wakeup_reason")
+    if not isinstance(reason, dict) or reason.get("boot") != "deepsleep_wake":
+        return False
+
+    uptime = sys_block.get("uptime")
+    if not isinstance(uptime, (int, float)) or isinstance(uptime, bool):
+        return False
+    return 0 <= uptime < period
+
+
 def sleep_period_s(status: dict[str, Any]) -> int:
     """Return the deep-sleep period of ``status`` in seconds, 0 if not sleeping.
 
@@ -160,24 +191,31 @@ def sleep_period_s(status: dict[str, Any]) -> int:
     publish ``sys.wakeup_period``; devices that only carry the cloud's
     ``_sleeping`` marker fall back to :data:`SLEEP_ASSUMED_PERIOD_S`.
 
-    A device running off external power is never treated as sleeping, even
-    when it still carries a ``wakeup_period`` from its battery days — it is
-    permanently connected, so the transport flag is meaningful again and an
-    offline reading means the device really is gone. (#13)
+    External power alone does not end deep sleep. An H&T Gen3 running off
+    USB-C with the batteries removed keeps waking on its old schedule, so its
+    cached snapshot still shows ``cloud.connected: false`` for a live device
+    and the entities flapped between available and unavailable (#32). The
+    device is therefore only demoted to "mains, transport flag is honest
+    again" (#13) when nothing in the snapshot says it is still sleeping.
     """
     if not isinstance(status, dict):
+        return 0
+
+    sys_block = status.get("sys")
+    raw = sys_block.get("wakeup_period") if isinstance(sys_block, dict) else None
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool) and raw > 0:
+        period = int(raw)
+    elif status.get("_sleeping") is True:
+        period = SLEEP_ASSUMED_PERIOD_S
+    else:
         return 0
 
     power = status.get("devicepower:0")
     external = power.get("external") if isinstance(power, dict) else None
     if isinstance(external, dict) and external.get("present") is True:
-        return 0
+        return period if still_deep_sleeping(status, period) else 0
 
-    sys_block = status.get("sys")
-    period = sys_block.get("wakeup_period") if isinstance(sys_block, dict) else None
-    if isinstance(period, (int, float)) and not isinstance(period, bool) and period > 0:
-        return int(period)
-    return SLEEP_ASSUMED_PERIOD_S if status.get("_sleeping") is True else 0
+    return period
 
 
 def sleep_window_s(status: dict[str, Any]) -> float:

--- a/tests/test_sleeping_availability.py
+++ b/tests/test_sleeping_availability.py
@@ -68,6 +68,48 @@ HT_GEN3_STATUS: dict[str, Any] = {
     "_sleeping": True,
 }
 
+# Redacted status of the H&T Gen3 from issue #32: batteries removed, running
+# off USB-C — and *still* waking out of deep sleep every 600 s, which is why
+# the cached snapshot keeps reporting a dead cloud session for a live device.
+USB_SLEEPER_STATUS: dict[str, Any] = {
+    "id": "84fce63f8338",
+    "code": "S3SN-0U12A",
+    "cloud": {"connected": False},
+    "ws": {"connected": False},
+    "mqtt": {"connected": False},
+    "wifi": {"status": "got ip", "rssi": -51},
+    "temperature:0": {"id": 0, "tC": 25.8, "tF": 78.5},
+    "humidity:0": {"id": 0, "rh": 43.7},
+    "devicepower:0": {
+        "id": 0,
+        "battery": {"V": 0, "percent": 0},
+        "external": {"present": True},
+    },
+    "sys": {
+        "unixtime": 1786993324,
+        "uptime": 5,
+        "wakeup_period": 600,
+        "wakeup_reason": {"boot": "deepsleep_wake", "cause": "status_update"},
+    },
+    "serial": 1786993324,
+    "_updated": "2026-08-17 19:02:05",
+    "_sleeping": True,
+}
+
+# The counter-case #13 asked for: same hardware on permanent power, awake for
+# hours, only the wakeup_period left over from its battery days. Its transport
+# flag means something again, so it must not be excused by the sleep window.
+AWAKE_ON_USB_STATUS: dict[str, Any] = {
+    **USB_SLEEPER_STATUS,
+    "sys": {
+        "unixtime": 1786993324,
+        "uptime": 43200,
+        "wakeup_period": 600,
+        "wakeup_reason": {"boot": "poweron", "cause": None},
+    },
+}
+del AWAKE_ON_USB_STATUS["_sleeping"]
+
 # What a mains-powered device looks like while genuinely disconnected: no
 # wakeup period, no sleeping marker. Must stay unavailable.
 MAINS_OFFLINE_STATUS: dict[str, Any] = {
@@ -138,12 +180,44 @@ def test_sleep_period_falls_back_for_sleeping_marker_only() -> None:
     assert sleep_period_s(status) == SLEEP_ASSUMED_PERIOD_S
 
 
-def test_externally_powered_device_is_not_sleeping() -> None:
-    """A battery device on USB power stays connected — the flag is honest again."""
-    status = {
-        **HT_GEN3_STATUS,
-        "devicepower:0": {"battery": {"percent": 100}, "external": {"present": True}},
-    }
+def test_externally_powered_device_that_stopped_sleeping_is_not_sleeping() -> None:
+    """USB power *and* no sign of sleep — the transport flag is honest again."""
+    assert sleep_period_s(AWAKE_ON_USB_STATUS) == 0
+
+
+def test_externally_powered_device_that_keeps_sleeping_still_sleeps() -> None:
+    """Issue #32: an H&T Gen3 on USB-C keeps its wakeup schedule.
+
+    The reporter pulled the batteries and ran the device off USB-C. It still
+    woke every 600 s, so the cached snapshot still carried
+    ``cloud.connected: false`` — and treating external power as proof of
+    being awake flapped every entity of that device between available and
+    unavailable roughly every six minutes.
+    """
+    assert sleep_period_s(USB_SLEEPER_STATUS) == 600
+
+
+def test_deep_sleep_wake_alone_proves_sleep_on_external_power() -> None:
+    """Without the cloud marker, a fresh deep-sleep boot is evidence enough."""
+    status = {**USB_SLEEPER_STATUS}
+    del status["_sleeping"]
+    assert sleep_period_s(status) == 600
+
+
+def test_stale_deep_sleep_wake_expires_once_uptime_outgrows_the_period() -> None:
+    """A device that woke and then stayed awake must not look asleep forever."""
+    status = {**USB_SLEEPER_STATUS}
+    del status["_sleeping"]
+    status["sys"] = {**status["sys"], "uptime": 601}
+    assert sleep_period_s(status) == 0
+
+
+@pytest.mark.parametrize("uptime", [None, "5", True, -1, {"s": 5}])
+def test_unusable_uptime_is_not_read_as_a_fresh_wake(uptime: Any) -> None:
+    """Only a real, plausible uptime may keep a mains-fed device sleeping."""
+    status = {**USB_SLEEPER_STATUS}
+    del status["_sleeping"]
+    status["sys"] = {**status["sys"], "uptime": uptime}
     assert sleep_period_s(status) == 0
 
 
@@ -260,17 +334,26 @@ def test_mains_device_is_never_treated_as_sleeping() -> None:
 
 
 def test_history_is_dropped_when_a_device_stops_sleeping() -> None:
-    """A battery device switched to external power must not keep stale history."""
+    """A battery device that stopped sleeping must not keep stale history."""
     coord = _coordinator()
     coord._evaluate_sleep_state(DEVICE_ID, HT_GEN3_STATUS, 0.0)
     assert DEVICE_ID in coord._sleep_seen
 
-    powered = {
-        **HT_GEN3_STATUS,
-        "devicepower:0": {"battery": {"percent": 100}, "external": {"present": True}},
-    }
-    assert coord._evaluate_sleep_state(DEVICE_ID, powered, 1.0) == (False, None)
+    assert coord._evaluate_sleep_state(DEVICE_ID, AWAKE_ON_USB_STATUS, 1.0) == (
+        False,
+        None,
+    )
     assert DEVICE_ID not in coord._sleep_seen
+
+
+def test_usb_powered_sleeper_keeps_its_check_in_window() -> None:
+    """Issue #32: the window survives the switch to external power."""
+    coord = _coordinator()
+    sleeping, stale_at = coord._evaluate_sleep_state(DEVICE_ID, USB_SLEEPER_STATUS, 0.0)
+    assert sleeping is True
+    # 600 s period is below the floor, so the floor decides the window.
+    assert stale_at == SLEEP_STALE_FLOOR_S
+    assert DEVICE_ID in coord._sleep_seen
 
 
 # ── _async_update_data: the record the entities actually read ─────────


### PR DESCRIPTION
Fixes #32.

## What the reporter sees

A Shelly H&T Gen3 with the batteries pulled and USB-C attached flaps between
available and unavailable about every six minutes — the *Cloud* entity
alternates "Verbunden" / "Nicht verfügbar" all day, while temperature and
humidity in that same snapshot are current.

## Cause

The device does **not** stop deep-sleeping when it gets permanent power. Its
diagnostics show all of:

```
sys.wakeup_period      600
sys.uptime             5
sys.wakeup_reason      {boot: deepsleep_wake, cause: status_update}
_sleeping              true
devicepower:0.external.present  true
```

Since #13, `devicepower:0.external.present == true` short-circuited
`sleep_period_s()` to `0` — "permanently connected, the transport flag is
meaningful again". That assumption was made from reasoning, never from a
dump of such a device. For this hardware it is wrong: the snapshot Shelly
Cloud caches is still captured seconds after a deep-sleep wake, so
`cloud.connected` is false about half the time, and availability followed it.

## Fix

External power alone is no longer proof of being awake. It only demotes a
device to "mains" when nothing in the snapshot says it is still sleeping:

* no `_sleeping` marker from the cloud, **and**
* no `deepsleep_wake` boot whose `uptime` is still inside one wakeup period.

The second condition is what keeps #13's counter-case intact: a device that
woke once and then stayed awake outgrows its period and loses the excuse by
itself, without needing a separate flag.

## Intended side effect

Such a device now also uses the deep-sleep window (4 h floor) instead of the
user's mains window for the "reporting" sensor, so both features agree again
on what "still checking in" means for it.

## Tests

`tests/test_sleeping_availability.py` gains the real #32 payload plus the
awake-on-USB counter-case; `sleep_period_s()` on the reporter's unmodified
diagnostics returns `600` (window 14400 s) instead of `0`.
Full matrix green: 230 passed on py3.12/HA 2025.1.4 and py3.14/HA latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLJigzBTVmXLDz9x6ERKjs