### PR TITLE
feat(binary_sensor): warn when a relay contact no longer opens

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -106,6 +106,7 @@ Lücke schließt dieses Projekt.
 | ☁️ **Cloud-Polling** | Liest den Status jedes Geräts, das dein Shelly-Account sieht — eigene, geteilte, entfernte und BLE-überbrückte (Shelly-BLU-Familie über ein BLU-Gateway). | ✅ ausgeliefert |
 | 🔌 **Opt-in-Entities** | Schalter, Lampen, Rollladen, Sensoren, Binary Sensors, Buttons — nur für die Geräte angelegt, die du auswählst, damit es keine Doppler mit der LAN-Integration gibt. | ✅ ausgeliefert |
 | 📡 **Ausfall-Erkennung** | Ein **Reporting**-Sensor je Gerät, der abfällt, sobald sich ein Gerät nicht mehr meldet — das Signal, das `cloud.connected` nicht liefern kann (siehe unten). | ✅ ausgeliefert |
+| ⚡ **Warnung bei klebendem Kontakt** | Meldet, wenn ein Relais sich als offen meldet, während die geräteeigene Messung weiter eine Last sieht — ein verschweißter Kontakt (siehe unten). | ✅ ausgeliefert |
 | 📈 **Energie-Verlaufsimport** | Importiert historische Energiedaten in die Home-Assistant-Langzeitstatistik. | ✅ ausgeliefert |
 | ⚙️ **Config- + Options-Flow** | `auth_key` einfügen; Poll-Intervall und Geräte-Auswahl später anpassen. | ✅ ausgeliefert |
 | 🌍 **Lokalisierte UI** | Englische und deutsche Übersetzungen für jeden sichtbaren Text. | ✅ ausgeliefert |
@@ -161,6 +162,50 @@ an der Gefriertruhe — ohne die stillen Geräte zu Fehlalarmen zu machen.
 
 Bricht das Abfragen selbst weg (Cloud-Ausfall, abgelehnter `auth_key`), wird der
 Sensor **nicht verfügbar**, statt die ganze Flotte für tot zu erklären.
+
+### Mitbekommen, wenn ein Relais nicht mehr abschaltet
+
+Ein schaltender Shelly meldet im selben Payload, was er *befohlen* hat und was
+er *misst*. Sagt das Relais „offen", während die Messung weiter eine Last sieht,
+ist der Kontakt verschweißt — der Aktor nimmt weiter Befehle an und meldet
+weiter *aus*, die Last schaltet aber nie wirklich ab. Alles, was auf dem
+Abschalten beruht (eine Automation, ein Zeitplan, ein Bewegungsmelder), hört
+damit unbemerkt auf zu funktionieren, und Home Assistant sagt kein Wort.
+
+Jeder Schaltkanal, der seinen eigenen Ausgang misst, bekommt deshalb einen
+Binärsensor **Relay fault** (Diagnose, Klasse `problem`), und beim Auslösen
+erscheint eine Reparatur-Meldung. Die gemessene Leistung steht als Attribut
+daneben — diese Zahl ist das ganze Argument.
+
+Gebaut wurde das an einem Gerät, das genau so ausgefallen ist: ein Shelly 1PM
+Mini Gen3 meldete gleichzeitig `output: false` und 85,2 W, so lange wie
+beobachtet wurde, bei sichtbar brennender Lampe, per Software nicht mehr
+abschaltbar. Zwei Dinge hat dieser Lauf gelehrt, beide stecken im Detektor:
+
+- **Der Moment direkt nach einem Schaltbefehl lügt.** Ein Ausschalten lieferte
+  rund 45 Sekunden lang 0 W, obwohl die Last nachweislich weiterlief. Der
+  Widerspruch muss deshalb anhalten — fünf Meldungen *und* zwei Minuten —, bevor
+  überhaupt etwas gesagt wird, und ein einzelner unauffälliger Messwert nimmt
+  eine stehende Warnung **nicht** zurück. Zum Löschen braucht es fünf ruhige
+  Minuten.
+- **Der Energiezähler ist zu grob, um zu helfen.** Er stand 80 Sekunden still
+  und sprang dann auf einmal um 1,0 Wh. Er geht nicht in das Urteil ein.
+
+Gezählt werden die Meldungen des Geräts, nicht unsere Abfragen: ein
+eingefrorenes Gerät liefert seinen letzten Payload immer wieder aus, und würden
+Abfragen zählen, ließe sich aus einem einzigen alten Schnappschuss ein Vorwurf
+zusammenzählen. Eine bereits ausgesprochene Warnung bleibt dagegen bestehen,
+wenn ein Gerät verstummt — ein verschweißter Kontakt löst sich nicht dadurch,
+dass das Gerät aus der Cloud fällt.
+
+Bewusst zurückhaltend: unter 5 W wird nichts gemeldet (Snubber, LED-Treiber und
+Messrauschen legen immer etwas auf einen offenen Kontakt), Geräte mit
+Klemmwandler werden nie beurteilt, weil ihre Messung in keinem definierten
+Verhältnis zu irgendeinem Kontakt daneben steht, und Gen1-Rollladengeräte
+bleiben ganz außen vor — dort ist „Relais aus, Strom fließt" einfach ein
+fahrender Rollladen. Sitzt ein Shelly in einer Wechselschaltung, wo der andere
+Schalter Strom durch die Messung schicken kann, obwohl das Relais wirklich offen
+ist, lässt sich der Detektor in den Optionen abschalten.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Gen2 / BLE-gateway coverage** in one package. That is the gap this project close
 | ☁️ **Cloud polling** | Reads device state for every device visible to your Shelly account — owned, shared, remote, and BLE-bridged (Shelly BLU family via a BLU Gateway). | ✅ shipped |
 | 🔌 **Opt-in entities** | Switches, lights, covers, sensors, binary sensors, buttons — materialised only for the devices you choose, so you avoid duplicates with the LAN integration. | ✅ shipped |
 | 📡 **Offline detection** | A per-device **Reporting** sensor that turns off when a device stops checking in — the signal `cloud.connected` cannot give you (see below). | ✅ shipped |
+| ⚡ **Stuck-contact warning** | Warns when a relay reports itself as open while the device's own meter still sees a load — a welded contact (see below). | ✅ shipped |
 | 📈 **Energy history import** | Imports historical energy data into Home Assistant long-term statistics. | ✅ shipped |
 | ⚙️ **Config + options flow** | Paste your `auth_key`; tune the poll interval and per-device enablement later. | ✅ shipped |
 | 🌍 **Localised UI** | English and German translations for every user-visible string. | ✅ shipped |
@@ -154,6 +155,47 @@ without turning your quiet devices into false alarms.
 
 If polling itself breaks (cloud outage, rejected `auth_key`), the sensor goes
 **unavailable** rather than reporting your whole fleet as dead.
+
+### Knowing when a relay stops switching off
+
+A switching Shelly reports what it *commanded* and what it *measures* in the
+same payload. When the relay says open while the meter still sees a load, the
+contact has welded shut — the actuator keeps accepting commands and keeps
+reporting *off*, but the load never actually switches off. Anything built on
+switching it off (an automation, a schedule, a motion sensor) silently stops
+working, and nothing in Home Assistant says so.
+
+Every switching channel that meters its own output therefore gets a **Relay
+fault** binary sensor (diagnostic, `problem` class), and a repair notification
+appears when one trips. The measured wattage rides along as an attribute,
+because that number is the whole argument.
+
+This was built against a unit that actually failed this way — a Shelly 1PM Mini
+Gen3 reporting `output: false` and 85.2 W at the same time, for as long as it
+was watched, with the lamp visibly on and unswitchable from software. Two things
+that run taught, both of which are in the detector:
+
+- **The moment right after a command lies.** One switch-off produced a reading
+  of 0 W for about 45 seconds while the load was demonstrably still running. So
+  the disagreement has to persist — five check-ins *and* two minutes — before
+  anything is said, and a single agreeing reading does **not** retract a
+  standing warning. Clearing needs five quiet minutes.
+- **The energy counter is too coarse to help.** It stood still for 80 seconds
+  and then jumped by 1.0 Wh at once. It is not part of the verdict.
+
+Counted are the device's own check-ins, not our polls: a device that freezes
+keeps re-serving its last payload, and counting polls would let one stale
+snapshot be repeated into an accusation. A warning already raised is kept when a
+device goes quiet — a welded contact does not unweld because the device dropped
+off the cloud.
+
+Deliberately conservative: anything under 5 W is ignored (snubbers, LED drivers
+and meter noise all put a trickle on an open contact), clamp-metering devices
+are never judged because their measurement has no defined relationship to any
+contact next to it, and Gen1 roller-shutter devices are skipped entirely — there
+"relay off, power flowing" is just a moving shutter. If a Shelly of yours sits in
+a two-way circuit, where the other switch can push current through the meter
+while the relay is genuinely open, switch the detector off in the options.
 
 ---
 

--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -26,6 +26,7 @@ from .entities.descriptions import (
     BlockBinarySensorDescription,
     RpcBinarySensorDescription,
 )
+from .relay_fault import iter_relay_readings
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,6 +62,12 @@ async def async_setup_entry(
 
         if not status:
             return entities
+
+        entities.extend(
+            _create_relay_fault_sensors(
+                device_id, status, created_entities, coordinator
+            )
+        )
 
         gen = device_gen(status)
         if gen == "GBLE":
@@ -199,6 +206,88 @@ class ShellyReportingBinarySensor(ShellyBaseEntity, BinarySensorEntity):
         if record is None:
             return None
         return {"stale_after_s": int(record.stale_after_s)}
+
+
+def _create_relay_fault_sensors(
+    device_id: str,
+    status: dict[str, Any],
+    created: set[str],
+    coordinator: ShellyCloudCoordinator,
+) -> list[BinarySensorEntity]:
+    """Create one "Relay fault" sensor per metered switching channel.
+
+    Built from the status rather than from the generation, because the
+    thing that decides whether the question is answerable is not what kind
+    of device this is but whether the payload carries a relay *and* the
+    meter for that same relay — which is exactly what
+    :func:`iter_relay_readings` looks for.
+
+    Created even while the detector is switched off, so that turning the
+    option back on does not require a reload to get the entities back. The
+    verdict is then simply always ``off``.
+    """
+    entities: list[BinarySensorEntity] = []
+    for reading in iter_relay_readings(status):
+        uid = f"{device_id}_relay_fault_{reading.channel}"
+        if uid in created:
+            continue
+        created.add(uid)
+        entities.append(
+            ShellyRelayFaultBinarySensor(coordinator, device_id, reading.channel)
+        )
+    return entities
+
+
+class ShellyRelayFaultBinarySensor(ShellyBaseEntity, BinarySensorEntity):
+    """Whether a switching channel's contact has stopped opening.
+
+    ``on`` means the device reported its relay as *open* while its own
+    meter reported a real load flowing through it, for longer than any
+    post-command settling could explain. In practice that is a welded
+    contact: the actuator still accepts commands and still reports ``off``,
+    but the load never switches off. See ``relay_fault.py`` for the
+    thresholds and the hardware run they came from.
+
+    Availability is the ordinary device availability on purpose. While the
+    device is unreachable nobody can observe current flowing through it, so
+    claiming a live verdict would be an assertion about a device we cannot
+    see. A verdict already raised is retained and reappears with the
+    device.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: ShellyCloudCoordinator,
+        device_id: str,
+        channel: int,
+    ) -> None:
+        """Initialize the relay fault sensor."""
+        super().__init__(coordinator, device_id, channel)
+        self._attr_unique_id = f"{device_id}_relay_fault_{channel}"
+        self._attr_name = (
+            "Relay fault" if channel == 0 else f"Relay fault {channel + 1}"
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True while this channel is judged to be stuck closed."""
+        return self.coordinator.has_relay_fault(self._device_id, self._channel)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose the measured load behind the verdict.
+
+        Only while the channel reports *off*: with the relay closed the
+        number is just the ordinary consumption and would invite the reader
+        to compare it against a threshold it has nothing to do with.
+        """
+        power = self.coordinator.relay_fault_power(self._device_id, self._channel)
+        if power is None:
+            return None
+        return {"power_while_off_w": power}
 
 
 def _create_block_sensors(

--- a/custom_components/shelly_cloud_diy/config_flow.py
+++ b/custom_components/shelly_cloud_diy/config_flow.py
@@ -49,6 +49,7 @@ from .const import (
     CONF_LOCAL_GATEWAY_URL,
     CONF_OFFLINE_AFTER,
     CONF_POLL_INTERVAL,
+    CONF_RELAY_FAULT_DETECTION,
     CONF_SERVER_URI,
     DOMAIN,
     OFFLINE_AFTER_DEFAULT,
@@ -57,6 +58,7 @@ from .const import (
     POLL_INTERVAL_DEFAULT,
     POLL_INTERVAL_MAX,
     POLL_INTERVAL_MIN,
+    RELAY_FAULT_DETECTION_DEFAULT,
 )
 from .entities.descriptions import get_model_name
 from .utils import validate_gateway_url
@@ -440,6 +442,12 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                     CONF_OFFLINE_AFTER: int(
                         user_input.get(CONF_OFFLINE_AFTER, OFFLINE_AFTER_DEFAULT)
                     ),
+                    CONF_RELAY_FAULT_DETECTION: bool(
+                        user_input.get(
+                            CONF_RELAY_FAULT_DETECTION,
+                            RELAY_FAULT_DETECTION_DEFAULT,
+                        )
+                    ),
                 }
 
                 # Fetch the current fleet + names so the device-selection
@@ -473,6 +481,11 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
         current_offline = int(
             self.config_entry.options.get(CONF_OFFLINE_AFTER, OFFLINE_AFTER_DEFAULT)
         )
+        current_relay_fault = bool(
+            self.config_entry.options.get(
+                CONF_RELAY_FAULT_DETECTION, RELAY_FAULT_DETECTION_DEFAULT
+            )
+        )
 
         schema = vol.Schema(
             {
@@ -484,6 +497,9 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                 ): vol.All(
                     int, vol.Range(min=OFFLINE_AFTER_MIN, max=OFFLINE_AFTER_MAX)
                 ),
+                vol.Required(
+                    CONF_RELAY_FAULT_DETECTION, default=current_relay_fault
+                ): bool,
                 vol.Optional(
                     CONF_LOCAL_GATEWAY_URL, default=current_gw
                 ): str,

--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -60,6 +60,21 @@ OFFLINE_AFTER_DEFAULT = 30
 OFFLINE_AFTER_MIN = 2
 OFFLINE_AFTER_MAX = 24 * 60
 
+# ── Relay fault detection ("Relay fault" binary sensor) ────────────
+#
+# Watch every metered switching channel for the contradiction "relay
+# reports open, meter reports a load" — a welded contact. On by default:
+# the thresholds in ``relay_fault.py`` are deliberately conservative, and
+# an actuator that can no longer switch off is worth an unsolicited word.
+#
+# The escape hatch exists for wiring the detector cannot see. A Shelly
+# sitting in one leg of a two-way circuit can have current pushed through
+# its meter by the *other* switch while its own relay is genuinely open,
+# which looks identical from the payload. Whoever wired that knows; the
+# integration cannot.
+CONF_RELAY_FAULT_DETECTION = "relay_fault_detection"
+RELAY_FAULT_DETECTION_DEFAULT = True
+
 # ── Historical sync (unchanged from pre-pivot) ─────────────────────
 
 HISTORICAL_SYNC_INTERVAL = 24 * 60 * 60  # daily

--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -40,15 +40,23 @@ from .const import (
     CONF_ENABLED_DEVICES,
     CONF_OFFLINE_AFTER,
     CONF_POLL_INTERVAL,
+    CONF_RELAY_FAULT_DETECTION,
     DOMAIN,
     OFFLINE_AFTER_DEFAULT,
     POLL_INTERVAL_DEFAULT,
+    RELAY_FAULT_DETECTION_DEFAULT,
     SIGNAL_NEW_DEVICE,
     device_gen,
+)
+from .relay_fault import (
+    iter_relay_readings,
+    relay_clear_verdict,
+    relay_fault_verdict,
 )
 from .repair_issues import (
     async_manage_missing_devices_issue,
     async_manage_rate_limit_issue,
+    async_manage_relay_fault_issue,
     compute_missing_devices,
     is_mass_absence,
     missing_devices_verdict,
@@ -395,6 +403,19 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         # existing card for a full day and destroy the user's "Ignore".
         self._missing_streak: dict[str, int] = {}
         self._missing_since: dict[str, float] = {}
+        # Relay-fault bookkeeping, keyed per (device_id, channel) because a
+        # 2PM can have one welded contact and one healthy one. Streaks count
+        # consecutive polls where the channel reported "open, but drawing
+        # power"; ``_relay_healthy_since`` runs the other way and drives the
+        # deliberately slower clear (see relay_fault.STUCK_CLEAR_SECONDS).
+        self._relay_fault_streak: dict[tuple[str, int], int] = {}
+        self._relay_fault_since: dict[tuple[str, int], float | None] = {}
+        self._relay_healthy_since: dict[tuple[str, int], float | None] = {}
+        # The published verdicts. Read by the "Relay fault" binary sensors
+        # and by the repair card; entries survive a device's absence from a
+        # poll, since a device that dies with a welded contact is still
+        # welded shut.
+        self.relay_faults: set[tuple[str, int]] = set()
 
     # ── Offline detection bookkeeping ─────────────────────────────────
 
@@ -475,6 +496,106 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         except (TypeError, ValueError):
             minutes = OFFLINE_AFTER_DEFAULT
         return max(minutes, 1.0) * 60.0
+
+    @property
+    def relay_fault_detection(self) -> bool:
+        """Whether the welded-contact detector is switched on."""
+        return bool(
+            self._options.get(
+                CONF_RELAY_FAULT_DETECTION, RELAY_FAULT_DETECTION_DEFAULT
+            )
+        )
+
+    # ── Relay-fault bookkeeping ───────────────────────────────────────
+
+    def _evaluate_relay_faults(self, now: float) -> None:
+        """Judge every metered switching channel in the current snapshot.
+
+        Only devices that checked in on THIS poll are judged — evidence has
+        to be fresh in both directions. A device that freezes keeps
+        re-serving its last payload for as long as the cloud caches it, so
+        counting polls would let one stale snapshot be repeated into a
+        verdict; and by the same token a repeated agreeing payload must not
+        be allowed to clear one.
+
+        Standing verdicts therefore survive a device going quiet, which is
+        the correct behaviour rather than a side effect: a welded contact
+        does not unweld when the device drops off the cloud, and the load
+        it is feeding keeps running.
+        """
+        if not self.relay_fault_detection:
+            if self.relay_faults:
+                self.relay_faults.clear()
+                self._relay_fault_streak.clear()
+                self._relay_fault_since.clear()
+                self._relay_healthy_since.clear()
+            async_manage_relay_fault_issue(
+                self.hass, self._entry, active=False, faults=set(), names={}
+            )
+            return
+
+        for device_id, info in self.devices.items():
+            if not self.is_enabled(device_id):
+                continue
+            # ``_record_checkin`` stamps this poll's ``now`` on the record
+            # exactly when the payload fingerprint changed, so equality here
+            # IS "the device reported something new this time round".
+            record = self.checkins.get(device_id)
+            if record is None or record.last_checkin != now:
+                continue
+            for reading in iter_relay_readings(info.get("status", {})):
+                key = (device_id, reading.channel)
+                if reading.disagrees:
+                    self._relay_fault_streak[key] = (
+                        self._relay_fault_streak.get(key, 0) + 1
+                    )
+                    if self._relay_fault_since.get(key) is None:
+                        self._relay_fault_since[key] = now
+                    self._relay_healthy_since[key] = None
+                    if relay_fault_verdict(
+                        self._relay_fault_streak[key],
+                        self._relay_fault_since.get(key),
+                        now,
+                    ):
+                        self.relay_faults.add(key)
+                    continue
+
+                # Agreement. The streak restarts immediately — a raised
+                # verdict does NOT, because a single spurious zero-watt
+                # sample must not retract a standing warning.
+                self._relay_fault_streak[key] = 0
+                self._relay_fault_since[key] = None
+                if self._relay_healthy_since.get(key) is None:
+                    self._relay_healthy_since[key] = now
+                if key in self.relay_faults and relay_clear_verdict(
+                    self._relay_healthy_since.get(key), now
+                ):
+                    self.relay_faults.discard(key)
+
+        async_manage_relay_fault_issue(
+            self.hass,
+            self._entry,
+            active=bool(self.relay_faults),
+            faults=set(self.relay_faults),
+            names=self._display_names({d for d, _ in self.relay_faults}),
+        )
+
+    def has_relay_fault(self, device_id: str, channel: int) -> bool:
+        """Whether this channel is currently judged to have a stuck contact."""
+        return (device_id, channel) in self.relay_faults
+
+    def relay_fault_power(self, device_id: str, channel: int) -> float | None:
+        """Return the load currently measured on a channel reporting *off*.
+
+        Surfaced on the entity because the number is the whole argument: it
+        is the difference between "something is drawing 85 W through a relay
+        that says it is open" and an unexplained warning.
+        """
+        status = self.devices.get(device_id, {}).get("status", {})
+        for reading in iter_relay_readings(status):
+            if reading.channel == channel:
+                return reading.power if not reading.output else None
+        return None
 
     # ── Deep-sleep freshness bookkeeping (#13) ────────────────────────
 
@@ -736,6 +857,8 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         # not a sustained rate limit.
         self._note_poll_not_rate_limited()
         self._evaluate_missing_devices(set(new_devices))
+        # Reads ``self.devices``, so it must stay below the assignment above.
+        self._evaluate_relay_faults(now)
 
         return new_devices
 

--- a/custom_components/shelly_cloud_diy/relay_fault.py
+++ b/custom_components/shelly_cloud_diy/relay_fault.py
@@ -1,0 +1,174 @@
+"""Detection of a relay whose contact no longer opens ("stuck contact").
+
+A switching Shelly reports what it *commanded* (``output``) and what it
+*measures* (``apower``) in the same status payload. When the two disagree —
+the relay says open, the meter says a load is running — the contact has
+welded shut. The device keeps accepting commands and keeps reporting
+``off``; only the meter gives it away.
+
+Measured on real failing hardware (Shelly 1PM Mini Gen3, 2026-08-17). With
+the load switched off through Home Assistant::
+
+    A) no command, just observing   output=false   apower=85.2 W
+    B) turn_on                      output=true    apower=85.2 W
+    C) turn_off                     output=false   apower=85.2 W  (80 s)
+
+The lamp never went dark and could not be switched off in software at all.
+That run also produced the two design constraints encoded below:
+
+* **The moment right after a command lies.** In one of two turn_off runs the
+  device reported ``apower = 0`` for ~45 s while the load was demonstrably
+  still running. A detector that trusts a single sample would therefore have
+  announced "all clear" precisely while the fault was present, so the verdict
+  needs both a streak and a wall-clock floor, and clearing needs its own,
+  longer floor (see :data:`STUCK_CLEAR_SECONDS`).
+* **The energy counter is not a fast second opinion.** Over the same run it
+  stood still for 80 s and then jumped by 1.0 Wh at once, so it resolves
+  minutes, not seconds. Only ``apower`` is read here.
+
+Deliberately *no* learned per-device threshold, unlike the offline detector
+in ``coordinator.py``. Learning what "off" normally draws would be poisoned
+by exactly the situation this detects: a contact that is already welded when
+Home Assistant starts would teach the device that 85 W is its idle draw, and
+the fault would then be unreportable forever. A fixed floor cannot be taught
+anything.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# Below this, never accuse anything. An open relay is not necessarily a
+# zero-watt reading: snubber/RC networks across the contact, electronic LED
+# drivers and the meter's own noise floor all put a trickle on the line. The
+# floor is set well above that band rather than at the smallest load we could
+# theoretically catch — the cost of missing a 3 W night light is a missed
+# nicety, the cost of a false accusation is a user pulling a working actuator
+# out of a wall.
+STUCK_MIN_POWER_W = 5.0
+
+# Both gates must hold before the fault is announced, mirroring the
+# rate-limit gate in ``repair_issues.py``.
+#
+# The count is in CHECK-INS, not polls — five times the device itself said
+# so, not five times we asked. That distinction is the whole defence against
+# stale data: a device that freezes keeps re-serving its last payload for as
+# long as the cloud caches it, and counting polls would let one snapshot be
+# repeated into a verdict. Counting check-ins makes the number mean five
+# independent reports.
+#
+# Cost of that choice: on a device reporting once a minute the warning
+# arrives after ~5 minutes rather than ~2. For "your actuator is broken"
+# that is the right trade.
+STUCK_MIN_STREAK = 5
+STUCK_MIN_SECONDS = 120.0
+
+# Clearing is deliberately slower than raising, because the failure mode is
+# asymmetric: a single spurious ``apower = 0`` sample (which the hardware run
+# produced) must not retract a standing warning about a welded contact, while
+# a genuinely repaired or replaced actuator only costs the user five minutes
+# of a stale card. Never make this shorter than the ~45 s blind window.
+STUCK_CLEAR_SECONDS = 300.0
+
+_SWITCH_KEY_RE = re.compile(r"^switch:(\d+)$")
+
+
+@dataclass(frozen=True)
+class RelayReading:
+    """One switching channel's commanded state next to its measured load."""
+
+    channel: int
+    output: bool
+    power: float
+
+    @property
+    def disagrees(self) -> bool:
+        """True when the relay claims open while a real load is flowing."""
+        return not self.output and self.power >= STUCK_MIN_POWER_W
+
+
+def _as_power(value: Any) -> float | None:
+    """Return ``value`` as watts, or None if it is not a usable number."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def iter_relay_readings(status: dict[str, Any]) -> list[RelayReading]:
+    """Return every channel of ``status`` that can be judged at all.
+
+    Only channels that both switch a relay *and* meter that same relay's
+    output qualify. That requirement is what keeps clamp-metering devices
+    (Gen2 ``em:0``, Gen1 ``emeters``) out on its own: their measurement has
+    no defined relationship to any contact in the same housing, so a
+    disagreement there would mean nothing.
+    """
+    if not isinstance(status, dict):
+        return []
+
+    readings: list[RelayReading] = []
+
+    # Gen2/Gen3 — ``switch:N`` carries both fields. A non-metering switch
+    # (Shelly Plus 1) simply has no ``apower`` and drops out here.
+    for key, payload in status.items():
+        match = _SWITCH_KEY_RE.match(key) if isinstance(key, str) else None
+        if match is None or not isinstance(payload, dict):
+            continue
+        output = payload.get("output")
+        power = _as_power(payload.get("apower"))
+        if not isinstance(output, bool) or power is None:
+            continue
+        readings.append(RelayReading(int(match.group(1)), output, power))
+
+    if readings:
+        return sorted(readings, key=lambda r: r.channel)
+
+    # Gen1 — parallel ``relays`` / ``meters`` lists.
+    #
+    # Roller-shutter devices are skipped wholesale: in that mode the two
+    # relays drive motor directions, and the meter reads the motor while the
+    # shutter travels. "Relay off, power flowing" is then the normal picture
+    # for a moving cover, not a fault.
+    #
+    # Unit-tested only — the account this was developed against has no Gen1
+    # hardware, so unlike the Gen2 path above this shape has never been seen
+    # in a live payload.
+    if status.get("rollers"):
+        return []
+    relays = status.get("relays")
+    meters = status.get("meters")
+    if not isinstance(relays, list) or not isinstance(meters, list):
+        return []
+    for idx, relay in enumerate(relays):
+        if idx >= len(meters):
+            break
+        meter = meters[idx]
+        if not isinstance(relay, dict) or not isinstance(meter, dict):
+            continue
+        output = relay.get("ison")
+        power = _as_power(meter.get("power"))
+        if not isinstance(output, bool) or power is None:
+            continue
+        readings.append(RelayReading(idx, output, power))
+
+    return readings
+
+
+def relay_fault_verdict(
+    streak: int, streak_started: float | None, now: float
+) -> bool:
+    """True when the disagreement has lasted long enough to report."""
+    return (
+        streak >= STUCK_MIN_STREAK
+        and streak_started is not None
+        and (now - streak_started) >= STUCK_MIN_SECONDS
+    )
+
+
+def relay_clear_verdict(healthy_since: float | None, now: float) -> bool:
+    """True when a standing fault has been contradicted for long enough."""
+    return (
+        healthy_since is not None
+        and (now - healthy_since) >= STUCK_CLEAR_SECONDS
+    )

--- a/custom_components/shelly_cloud_diy/repair_issues.py
+++ b/custom_components/shelly_cloud_diy/repair_issues.py
@@ -16,13 +16,14 @@ non-reserved filename sidesteps the platform contract entirely at zero
 cost; if a real fix flow is ever wanted, add a proper ``repairs.py``
 exposing ``async_create_fix_flow`` at that point.
 
-All three issues are informational and non-persistent. None of them can
+All four issues are informational and non-persistent. None of them can
 be resolved by an in-process button press — a sustained rate limit, a
-device that vanished from the Shelly account, and an unreachable local
-gateway are all resolved outside Home Assistant — so a confirm-only Fix
-button would lie to the user and the card would simply reappear on the
-next poll. Every condition is re-derived from live polling (or the next
-sync cycle) after a restart, so nothing needs to be persisted.
+device that vanished from the Shelly account, an unreachable local
+gateway and a welded relay contact are all resolved outside Home
+Assistant — so a confirm-only Fix button would lie to the user and the
+card would simply reappear on the next poll. Every condition is
+re-derived from live polling (or the next sync cycle) after a restart,
+so nothing needs to be persisted.
 
 Issue ids are suffixed with the config entry id: the issue registry keys
 on ``(domain, issue_id)`` alone, so a second Shelly account would
@@ -86,9 +87,14 @@ HISTORY_IMPORT_MIN_FAILURES = 2
 # inside the same Home Assistant session rather than a day later.
 HISTORY_IMPORT_RETRY_S = 900.0
 
+# Same bound and the same reason as MISSING_DEVICE_MAX_LISTED: a fleet-wide
+# condition must not render a card made of a hundred device ids.
+RELAY_FAULT_MAX_LISTED = 5
+
 ISSUE_RATE_LIMITED = "rate_limited"
 ISSUE_MISSING_DEVICES = "missing_devices"
 ISSUE_HISTORY_IMPORT_FAILED = "history_import_failed"
+ISSUE_RELAY_FAULT = "relay_fault"
 
 
 # ── Pure verdict helpers (no hass — unit-testable) ────────────────────
@@ -267,6 +273,65 @@ def async_manage_missing_devices_issue(
         ir.async_delete_issue(hass, DOMAIN, iid)
 
 
+def format_relay_fault_list(
+    faults: set[tuple[str, int]], names: dict[str, str]
+) -> str:
+    """Render the affected switching channels for the card.
+
+    The channel is only spelled out from the second one onwards: on a
+    single-channel device "channel 1" is noise, on a 2PM it is the whole
+    point of the line.
+    """
+    parts = []
+    for device_id, channel in sorted(faults)[:RELAY_FAULT_MAX_LISTED]:
+        label = (
+            f"{_clamp_name(names[device_id])} ({device_id})"
+            if names.get(device_id)
+            else device_id
+        )
+        parts.append(label if channel == 0 else f"{label} channel {channel + 1}")
+    text = ", ".join(parts)
+    if len(faults) > len(parts):
+        text += f", … (+{len(faults) - len(parts)})"
+    return text
+
+
+@callback
+def async_manage_relay_fault_issue(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    *,
+    active: bool,
+    faults: set[tuple[str, int]],
+    names: dict[str, str],
+) -> None:
+    """Create or clear the stuck-contact issue for ``entry``.
+
+    Upserts rather than delete-then-create for the same reason as the
+    missing-devices card: a second failing actuator must not silently
+    un-ignore the first one.
+    """
+    iid = issue_id(ISSUE_RELAY_FAULT, entry.entry_id)
+    if active:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            iid,
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_RELAY_FAULT,
+            translation_placeholders={
+                "entry_title": entry.title,
+                "count": str(len(faults)),
+                "devices": format_relay_fault_list(faults, names),
+            },
+        )
+    else:
+        # A no-op when the id was never raised, so no existence probe.
+        ir.async_delete_issue(hass, DOMAIN, iid)
+
+
 @callback
 def async_manage_history_import_issue(
     hass: HomeAssistant, entry: ConfigEntry, *, active: bool
@@ -298,6 +363,7 @@ def async_clear_entry_issues(
         ISSUE_RATE_LIMITED,
         ISSUE_MISSING_DEVICES,
         ISSUE_HISTORY_IMPORT_FAILED,
+        ISSUE_RELAY_FAULT,
     ):
         # ``async_delete_issue`` on a non-existent id is an explicit no-op.
         ir.async_delete_issue(hass, DOMAIN, issue_id(kind, entry.entry_id))

--- a/custom_components/shelly_cloud_diy/strings.json
+++ b/custom_components/shelly_cloud_diy/strings.json
@@ -58,11 +58,13 @@
         "data": {
           "poll_interval": "Poll interval (seconds)",
           "offline_after_minutes": "Report a device as offline after (minutes)",
+          "relay_fault_detection": "Warn about a relay that no longer opens",
           "local_gateway_url": "Local gateway URL (optional, for EM historical data)"
         },
         "data_description": {
           "poll_interval": "3–60 s. Lower values feel snappier but consume more of Shelly's 1 req/s rate-limit budget.",
           "offline_after_minutes": "2–1440 min, default 30. Each device's \"Reporting\" sensor turns off once the device has been silent this long. It is only a base value: a device that is naturally quieter earns a wider window on its own, and battery or BLE devices are handled separately. Lowering it therefore mainly speeds up detection on devices that report continuously, such as power-metering plugs.",
+          "relay_fault_detection": "On by default. Watches every switching channel that meters its own output and warns when the relay reports itself as open while a real load is still flowing through it — a contact that has welded shut. Turn this off if a Shelly of yours sits in a two-way circuit, where the other switch can push current through the meter while the relay is genuinely open.",
           "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data."
         }
       },
@@ -156,6 +158,10 @@
     "history_import_failed": {
       "title": "Historical energy data could not be imported",
       "description": "The historical-data sync for {entry_title} has run twice without importing anything. Live device data is unaffected — only the import of past energy readings into long-term statistics.\n\nMost often the local gateway URL is wrong, or the gateway is not reachable from Home Assistant.\n\nWhat to do:\n\n1. Open Settings → Devices & services → Shelly Cloud DIY → Configure and check the local gateway URL, including the scheme and port (for example `http://192.168.1.50:8080`).\n2. Confirm the gateway is running and reachable from Home Assistant.\n3. If you no longer use it, clear the field to switch the import off.\n\nThe sync runs once at startup and then daily. To check a correction right away, run the **Download and convert historical energy data** action from Developer tools → Actions instead of waiting."
+    },
+    "relay_fault": {
+      "title": "A Shelly relay is no longer switching off",
+      "description": "{count} switching channel(s) on {entry_title} reported the relay as **open** while the device's own power meter reported a load still flowing through it, for at least two minutes.\n\nDevice(s): {devices}\n\nThis is what a welded relay contact looks like. The actuator still accepts commands and still reports *off*, but the load never actually switches off — so anything that relies on switching it off (an automation, a schedule, a motion sensor) silently stops working, and the load keeps consuming power.\n\nWhat to do:\n\n1. Check whether the load really is still running. The \"Relay fault\" diagnostic sensor on the device carries the measured wattage as an attribute.\n2. If it is, treat the actuator as defective and plan to replace it. A contact that welds once tends to do it again, and it cannot be switched off in software — only at the breaker.\n3. If the load is genuinely not running, the wiring may be feeding current past this relay (for example a two-way circuit). You can switch this warning off in the integration options.\n\nThe warning clears on its own once the channel has agreed with its own meter again for five minutes."
     }
   }
 }

--- a/custom_components/shelly_cloud_diy/translations/de.json
+++ b/custom_components/shelly_cloud_diy/translations/de.json
@@ -58,11 +58,13 @@
         "data": {
           "poll_interval": "Abfrageintervall (Sekunden)",
           "offline_after_minutes": "Gerät als offline melden nach (Minuten)",
+          "relay_fault_detection": "Vor einem Relais warnen, das nicht mehr öffnet",
           "local_gateway_url": "Lokale Gateway-URL (optional, für historische EM-Daten)"
         },
         "data_description": {
           "poll_interval": "3–60 s. Kleinere Werte fühlen sich flotter an, verbrauchen aber mehr von Shellys 1-req/s-Budget.",
           "offline_after_minutes": "2–1440 min, Standard 30. Der Sensor „Reporting“ eines Geräts fällt ab, sobald das Gerät so lange nichts mehr gemeldet hat. Das ist nur ein Basiswert: ein von Natur aus stilleres Gerät bekommt automatisch ein weiteres Fenster, Batterie- und BLE-Geräte werden getrennt behandelt. Ein kleinerer Wert beschleunigt die Erkennung deshalb vor allem bei Geräten, die durchgehend melden — etwa Zwischenstecker mit Leistungsmessung.",
+          "relay_fault_detection": "Standardmäßig an. Beobachtet jeden Schaltkanal, der seinen eigenen Ausgang misst, und warnt, wenn das Relais sich als offen meldet, während weiterhin eine echte Last durch es fließt — ein verschweißter Kontakt. Abschalten, wenn ein Shelly in einer Wechselschaltung sitzt, wo der andere Schalter Strom durch die Messung schicken kann, obwohl das Relais wirklich offen ist.",
           "local_gateway_url": "Nur nötig, wenn ein lokales Shelly-Gateway für historische Energiedaten genutzt wird."
         }
       },
@@ -174,6 +176,10 @@
     "history_import_failed": {
       "title": "Historische Energiedaten konnten nicht importiert werden",
       "description": "Der Abgleich der historischen Energiedaten für {entry_title} ist zweimal gelaufen, ohne etwas zu importieren. Die Live-Daten deiner Geräte sind davon nicht betroffen — nur der Import früherer Energiewerte in die Langzeitstatistik.\n\nMeistens ist die URL des lokalen Gateways falsch oder das Gateway ist von Home Assistant aus nicht erreichbar.\n\nSo gehst du vor:\n\n1. Öffne Einstellungen → Geräte & Dienste → Shelly Cloud DIY → Konfigurieren und prüfe die URL des lokalen Gateways inklusive Schema und Port (z. B. `http://192.168.1.50:8080`).\n2. Stelle sicher, dass das Gateway läuft und von Home Assistant aus erreichbar ist.\n3. Nutzt du es nicht mehr, leere das Feld — damit ist der Import aus.\n\nDer Abgleich läuft einmal beim Start und danach täglich. Willst du eine Korrektur sofort prüfen, führe die Aktion **Historische Energiedaten herunterladen und konvertieren** unter Entwicklerwerkzeuge → Aktionen aus, statt zu warten."
+    },
+    "relay_fault": {
+      "title": "Ein Shelly-Relais schaltet nicht mehr ab",
+      "description": "{count} Schaltkanal/-kanäle von {entry_title} haben das Relais als **offen** gemeldet, während die geräteeigene Leistungsmessung weiterhin eine Last gemessen hat — mindestens zwei Minuten lang.\n\nGerät(e): {devices}\n\nSo sieht ein verschweißter Relaiskontakt aus. Der Aktor nimmt weiter Befehle an und meldet weiter *aus*, die Last schaltet aber nie wirklich ab — alles, was auf dem Abschalten beruht (eine Automation, ein Zeitplan, ein Bewegungsmelder), hört damit unbemerkt auf zu funktionieren, und die Last verbraucht weiter Strom.\n\nWas zu tun ist:\n\n1. Prüfen, ob die Last tatsächlich noch läuft. Der Diagnose-Sensor „Relay fault“ am Gerät führt die gemessene Leistung als Attribut mit.\n2. Wenn ja: den Aktor als defekt behandeln und den Austausch einplanen. Ein Kontakt, der einmal verschweißt, tut es wieder — und per Software ist er nicht mehr abzuschalten, nur noch über die Sicherung.\n3. Läuft die Last wirklich nicht, führt die Verdrahtung womöglich Strom an diesem Relais vorbei (etwa eine Wechselschaltung). Diese Warnung lässt sich in den Optionen der Integration abschalten.\n\nDie Warnung verschwindet von selbst, sobald der Kanal fünf Minuten lang wieder mit seiner eigenen Messung übereinstimmt."
     }
   }
 }

--- a/custom_components/shelly_cloud_diy/translations/en.json
+++ b/custom_components/shelly_cloud_diy/translations/en.json
@@ -58,11 +58,13 @@
         "data": {
           "poll_interval": "Poll interval (seconds)",
           "offline_after_minutes": "Report a device as offline after (minutes)",
+          "relay_fault_detection": "Warn about a relay that no longer opens",
           "local_gateway_url": "Local gateway URL (optional, for EM historical data)"
         },
         "data_description": {
           "poll_interval": "3–60 s. Lower values feel snappier but consume more of Shelly's 1 req/s rate-limit budget.",
           "offline_after_minutes": "2–1440 min, default 30. Each device's \"Reporting\" sensor turns off once the device has been silent this long. It is only a base value: a device that is naturally quieter earns a wider window on its own, and battery or BLE devices are handled separately. Lowering it therefore mainly speeds up detection on devices that report continuously, such as power-metering plugs.",
+          "relay_fault_detection": "On by default. Watches every switching channel that meters its own output and warns when the relay reports itself as open while a real load is still flowing through it — a contact that has welded shut. Turn this off if a Shelly of yours sits in a two-way circuit, where the other switch can push current through the meter while the relay is genuinely open.",
           "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data."
         }
       },
@@ -174,6 +176,10 @@
     "history_import_failed": {
       "title": "Historical energy data could not be imported",
       "description": "The historical-data sync for {entry_title} has run twice without importing anything. Live device data is unaffected — only the import of past energy readings into long-term statistics.\n\nMost often the local gateway URL is wrong, or the gateway is not reachable from Home Assistant.\n\nWhat to do:\n\n1. Open Settings → Devices & services → Shelly Cloud DIY → Configure and check the local gateway URL, including the scheme and port (for example `http://192.168.1.50:8080`).\n2. Confirm the gateway is running and reachable from Home Assistant.\n3. If you no longer use it, clear the field to switch the import off.\n\nThe sync runs once at startup and then daily. To check a correction right away, run the **Download and convert historical energy data** action from Developer tools → Actions instead of waiting."
+    },
+    "relay_fault": {
+      "title": "A Shelly relay is no longer switching off",
+      "description": "{count} switching channel(s) on {entry_title} reported the relay as **open** while the device's own power meter reported a load still flowing through it, for at least two minutes.\n\nDevice(s): {devices}\n\nThis is what a welded relay contact looks like. The actuator still accepts commands and still reports *off*, but the load never actually switches off — so anything that relies on switching it off (an automation, a schedule, a motion sensor) silently stops working, and the load keeps consuming power.\n\nWhat to do:\n\n1. Check whether the load really is still running. The \"Relay fault\" diagnostic sensor on the device carries the measured wattage as an attribute.\n2. If it is, treat the actuator as defective and plan to replace it. A contact that welds once tends to do it again, and it cannot be switched off in software — only at the breaker.\n3. If the load is genuinely not running, the wiring may be feeding current past this relay (for example a two-way circuit). You can switch this warning off in the integration options.\n\nThe warning clears on its own once the channel has agreed with its own meter again for five minutes."
     }
   }
 }

--- a/tests/test_coordinator_init.py
+++ b/tests/test_coordinator_init.py
@@ -44,6 +44,10 @@ REQUIRED = {
     "_rate_limit_reported",
     "_missing_streak",
     "_missing_since",
+    "_relay_fault_streak",
+    "_relay_fault_since",
+    "_relay_healthy_since",
+    "relay_faults",
 }
 
 

--- a/tests/test_offline_reporting.py
+++ b/tests/test_offline_reporting.py
@@ -73,6 +73,10 @@ def _inert_repair_issues(monkeypatch):
         coordinator_mod, "async_manage_missing_devices_issue",
         lambda hass, entry, *, active, missing, names: None,
     )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_relay_fault_issue",
+        lambda hass, entry, *, active, faults, names: None,
+    )
 
 MAINS_ID = "ecda3bc59ec8"
 BLE_ID = "XB106582483818186"
@@ -156,6 +160,10 @@ def _coordinator(devices_status: dict[str, Any] | None = None, **options: Any) -
     coord._rate_limit_reported = False
     coord._missing_streak = {}
     coord._missing_since = {}
+    coord._relay_fault_streak = {}
+    coord._relay_fault_since = {}
+    coord._relay_healthy_since = {}
+    coord.relay_faults = set()
     return coord
 
 

--- a/tests/test_rediscovery.py
+++ b/tests/test_rediscovery.py
@@ -67,6 +67,10 @@ def _inert_repair_issues(monkeypatch):
         coordinator_mod, "async_manage_missing_devices_issue",
         lambda hass, entry, *, active, missing, names: None,
     )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_relay_fault_issue",
+        lambda hass, entry, *, active, faults, names: None,
+    )
 
 DEVICE_ID = "ecda3bc59ec8"
 OTHER_ID = "d0ef76c7a454"
@@ -130,6 +134,10 @@ def _coordinator(devices_status: dict[str, Any]) -> ShellyCloudCoordinator:
     coord._rate_limit_reported = False
     coord._missing_streak = {}
     coord._missing_since = {}
+    coord._relay_fault_streak = {}
+    coord._relay_fault_since = {}
+    coord._relay_healthy_since = {}
+    coord.relay_faults = set()
     return coord
 
 

--- a/tests/test_relay_fault.py
+++ b/tests/test_relay_fault.py
@@ -1,0 +1,453 @@
+"""Unit tests for the welded-contact detector ("Relay fault" sensor).
+
+The contract these pin comes from a run against genuinely failing hardware
+(Shelly 1PM Mini Gen3, 2026-08-17): the device reported ``output: false``
+while its own meter reported 85.2 W, continuously, and the load could not be
+switched off in software at all. Two observations from that run drive most of
+the tests below:
+
+* one turn_off produced ``apower = 0`` for ~45 s while the load was
+  demonstrably still running — so a single agreeing sample proves nothing and
+  must not retract a standing verdict;
+* the energy counter stood still for 80 s and then jumped by 1.0 Wh — so it
+  resolves minutes, not seconds, and is deliberately not part of the verdict.
+
+Driven through the real production code with the same lightweight fake
+coordinator the other coordinator tests use.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.shelly_cloud_diy import coordinator as coordinator_mod
+from custom_components.shelly_cloud_diy.binary_sensor import (
+    ShellyRelayFaultBinarySensor,
+    _create_relay_fault_sensors,
+)
+from custom_components.shelly_cloud_diy.const import CONF_RELAY_FAULT_DETECTION
+from custom_components.shelly_cloud_diy.coordinator import ShellyCloudCoordinator
+from custom_components.shelly_cloud_diy.relay_fault import (
+    STUCK_CLEAR_SECONDS,
+    STUCK_MIN_POWER_W,
+    STUCK_MIN_SECONDS,
+    STUCK_MIN_STREAK,
+    RelayReading,
+    iter_relay_readings,
+    relay_clear_verdict,
+    relay_fault_verdict,
+)
+from custom_components.shelly_cloud_diy.repair_issues import (
+    format_relay_fault_list,
+)
+
+DEVICE = "5432044e9768"
+STUCK_W = 85.2  # the wattage the real failing unit reported
+
+
+@pytest.fixture(autouse=True)
+def _inert_repair_issues(monkeypatch):
+    """Neutralise the repair-issue wrappers except the one under test.
+
+    ``_evaluate_relay_faults`` ends by upserting a repair card, which reaches
+    into the real issue registry; the stub ``hass`` here has none. The relay
+    wrapper is replaced by a recorder rather than a no-op so the tests can
+    assert what the card was told.
+    """
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_rate_limit_issue",
+        lambda hass, entry, *, active: None,
+    )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_missing_devices_issue",
+        lambda hass, entry, *, active, missing, names: None,
+    )
+    # Every device here is enabled (``create_all_initially``) so that the
+    # relay evaluation sees it at all, which also makes the poll dispatch
+    # SIGNAL_NEW_DEVICE into a Home Assistant that does not exist.
+    monkeypatch.setattr(
+        coordinator_mod, "async_dispatcher_send", lambda *args, **kwargs: None
+    )
+
+
+# ── Payload shapes: what can be judged at all ─────────────────────────
+
+
+def _gen2(output: bool, apower: float, channel: int = 0) -> dict[str, Any]:
+    return {
+        f"switch:{channel}": {"id": channel, "output": output, "apower": apower},
+        "cloud": {"connected": True},
+    }
+
+
+def test_a_metered_gen2_switch_is_readable() -> None:
+    assert iter_relay_readings(_gen2(False, STUCK_W)) == [
+        RelayReading(channel=0, output=False, power=STUCK_W)
+    ]
+
+
+def test_a_switch_without_metering_is_not_judged() -> None:
+    """A Shelly Plus 1 has a relay but nothing to contradict it with, so it
+    must produce no reading rather than a reading of zero — the latter would
+    render a "Relay fault" sensor that can never be anything but off."""
+    assert iter_relay_readings({"switch:0": {"id": 0, "output": False}}) == []
+
+
+def test_clamp_metering_is_not_judged() -> None:
+    """An EM measures a circuit, not the contact next to it. A disagreement
+    there says nothing about any relay, so the device must stay out."""
+    status = {"em:0": {"total_act_power": 812.0}, "cloud": {"connected": True}}
+    assert iter_relay_readings(status) == []
+
+
+def test_both_channels_of_a_two_channel_device_are_read() -> None:
+    status = {**_gen2(False, STUCK_W, 0), **_gen2(True, 12.0, 1)}
+    assert [r.channel for r in iter_relay_readings(status)] == [0, 1]
+
+
+def test_gen1_relay_and_meter_pair_up_by_index() -> None:
+    status = {
+        "relays": [{"ison": False}, {"ison": True}],
+        "meters": [{"power": STUCK_W}, {"power": 0.0}],
+    }
+    assert iter_relay_readings(status) == [
+        RelayReading(0, False, STUCK_W),
+        RelayReading(1, True, 0.0),
+    ]
+
+
+def test_gen1_roller_mode_is_skipped_entirely() -> None:
+    """In roller mode the two relays drive motor directions and the meter
+    reads the motor. "Relay off, power flowing" is then simply a moving
+    shutter — the single most obvious false positive available."""
+    status = {
+        "rollers": [{"state": "open"}],
+        "relays": [{"ison": False}],
+        "meters": [{"power": 120.0}],
+    }
+    assert iter_relay_readings(status) == []
+
+
+def test_a_boolean_apower_is_not_mistaken_for_a_wattage() -> None:
+    status = {"switch:0": {"output": False, "apower": True}}
+    assert iter_relay_readings(status) == []
+
+
+def test_a_non_dict_status_is_survivable() -> None:
+    assert iter_relay_readings(None) == []  # type: ignore[arg-type]
+
+
+# ── The disagreement itself ───────────────────────────────────────────
+
+
+def test_trickle_current_is_not_a_fault() -> None:
+    """Snubbers, LED drivers and meter noise put a couple of watts on an open
+    contact. Anything under the floor must be silence, not a warning."""
+    assert not RelayReading(0, False, STUCK_MIN_POWER_W - 0.1).disagrees
+
+
+def test_a_real_load_on_an_open_relay_is_a_fault() -> None:
+    assert RelayReading(0, False, STUCK_W).disagrees
+
+
+def test_a_closed_relay_drawing_power_is_the_normal_case() -> None:
+    assert not RelayReading(0, True, STUCK_W).disagrees
+
+
+# ── The gates ─────────────────────────────────────────────────────────
+
+
+def test_neither_gate_alone_is_enough() -> None:
+    assert not relay_fault_verdict(STUCK_MIN_STREAK, 0.0, STUCK_MIN_SECONDS - 1)
+    assert not relay_fault_verdict(STUCK_MIN_STREAK - 1, 0.0, STUCK_MIN_SECONDS + 1)
+    assert relay_fault_verdict(STUCK_MIN_STREAK, 0.0, STUCK_MIN_SECONDS)
+
+
+def test_clearing_is_slower_than_raising() -> None:
+    """The asymmetry is the point: the hardware run produced a 45 s window of
+    agreeing samples in the middle of a live fault."""
+    assert STUCK_CLEAR_SECONDS > STUCK_MIN_SECONDS
+    assert not relay_clear_verdict(0.0, STUCK_CLEAR_SECONDS - 1)
+    assert relay_clear_verdict(0.0, STUCK_CLEAR_SECONDS)
+    assert not relay_clear_verdict(None, 10_000.0)
+
+
+# ── Driven through the coordinator ────────────────────────────────────
+
+
+class _FakeApi:
+    def __init__(self, devices_status: dict[str, Any]) -> None:
+        self.devices_status = devices_status
+
+    async def get_all_status(self) -> dict[str, Any]:
+        return {"devices_status": self.devices_status}
+
+
+class _StubHass:
+    def async_create_task(self, coro: Any) -> None:
+        coro.close()
+
+
+def _coordinator(devices_status: dict[str, Any], **options: Any) -> ShellyCloudCoordinator:
+    """A coordinator with only the polling wiring in place.
+
+    ``__init__`` wants a HomeAssistant instance and a ConfigEntry; none of the
+    relay-fault logic does. ``test_coordinator_init.py`` is the guard that
+    keeps this shortcut from hiding a missing assignment.
+    """
+    coord = object.__new__(ShellyCloudCoordinator)
+    coord._api = _FakeApi(devices_status)
+    coord.hass = _StubHass()
+    coord._entry = SimpleNamespace(
+        entry_id="entry", title="Shelly Cloud DIY",
+        options={"enabled_devices": [], "create_all_initially": True, **options},
+    )
+    coord.devices = {}
+    coord._known_device_ids = set()
+    coord.device_names = {}
+    coord._names_attempted = set()
+    coord._name_lookup_in_flight = False
+    coord.virtual_configs = {}
+    coord._vcomp_config_in_flight = False
+    coord._sleep_seen = {}
+    coord.checkins = {}
+    coord._rate_limit_streak = 0
+    coord._rate_limit_since = None
+    coord._rate_limit_reported = False
+    coord._missing_streak = {}
+    coord._missing_since = {}
+    coord._relay_fault_streak = {}
+    coord._relay_fault_since = {}
+    coord._relay_healthy_since = {}
+    coord.relay_faults = set()
+    # The real one reaches into the HA device registry for a fallback label.
+    # Its behaviour belongs to the missing-devices card and is covered there.
+    coord._display_names = lambda ids: {
+        d: coord.device_names[d] for d in ids if d in coord.device_names
+    }
+    return coord
+
+
+class _CardRecorder:
+    """Captures what the repair card was last told."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[bool, set, dict]] = []
+
+    def __call__(self, hass, entry, *, active, faults, names) -> None:
+        self.calls.append((active, set(faults), dict(names)))
+
+    @property
+    def last_active(self) -> bool:
+        return self.calls[-1][0]
+
+
+@pytest.fixture
+def card(monkeypatch) -> _CardRecorder:
+    recorder = _CardRecorder()
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_relay_fault_issue", recorder
+    )
+    return recorder
+
+
+def _poll(coord: ShellyCloudCoordinator, status: dict[str, Any], at: float) -> None:
+    """Run one full poll with ``time.monotonic`` pinned to ``at``.
+
+    Patched rather than slept through: the gates are measured in minutes and
+    the clear in five of them, so a real-time test would take longer than the
+    rest of the suite combined.
+    """
+    coord._api.devices_status = {DEVICE: status}
+    original = time.monotonic
+    time.monotonic = lambda: at  # type: ignore[assignment]
+    try:
+        asyncio.run(coord._async_update_data())
+    finally:
+        time.monotonic = original  # type: ignore[assignment]
+
+
+def _drive(coord, status, *, start=0.0, polls=30, step=5.0) -> None:
+    for i in range(polls):
+        # Vary the fingerprint so the device counts as checking in.
+        fresh = {**status, "serial": int(start) + i, "_updated": f"t{i}"}
+        _poll(coord, fresh, start + i * step)
+
+
+def test_a_healthy_device_is_never_accused(card) -> None:
+    coord = _coordinator({})
+    _drive(coord, _gen2(False, 0.0))
+    assert coord.relay_faults == set()
+    assert card.last_active is False
+
+
+def test_a_load_running_through_an_open_relay_is_reported(card) -> None:
+    """The office-light case, replayed: relay reports off, meter reports 85 W,
+    and it never stops."""
+    coord = _coordinator({})
+    _drive(coord, _gen2(False, STUCK_W))
+    assert coord.relay_faults == {(DEVICE, 0)}
+    assert card.last_active is True
+    assert coord.has_relay_fault(DEVICE, 0)
+
+
+def test_nothing_is_said_before_both_gates_are_served(card) -> None:
+    """Two minutes of disagreement is the floor. At the 5 s default interval
+    that is ~24 polls, so five polls in the detector must still be silent —
+    this is what keeps the post-command settling window out of the verdict."""
+    coord = _coordinator({})
+    _drive(coord, _gen2(False, STUCK_W), polls=STUCK_MIN_STREAK + 1, step=5.0)
+    assert coord.relay_faults == set()
+    assert card.last_active is False
+
+
+def test_one_agreeing_sample_does_not_retract_a_standing_warning(card) -> None:
+    """The measured failure mode: 45 s of ``apower = 0`` in the middle of a
+    live fault. Retracting on that would have announced all-clear precisely
+    while the contact was welded."""
+    coord = _coordinator({})
+    _drive(coord, _gen2(False, STUCK_W))
+    assert coord.relay_faults == {(DEVICE, 0)}
+
+    # Nine agreeing polls — the full 45 s window the hardware produced.
+    _drive(coord, _gen2(False, 0.0), start=1000.0, polls=9, step=5.0)
+    assert coord.relay_faults == {(DEVICE, 0)}, "warning retracted too early"
+
+
+def test_a_repaired_actuator_clears_the_warning_on_its_own(card) -> None:
+    coord = _coordinator({})
+    _drive(coord, _gen2(False, STUCK_W))
+    assert coord.relay_faults == {(DEVICE, 0)}
+
+    _drive(coord, _gen2(False, 0.0), start=1000.0, polls=80, step=5.0)
+    assert coord.relay_faults == set()
+    assert card.last_active is False
+
+
+def test_a_frozen_device_cannot_earn_a_new_accusation(card) -> None:
+    """A device that stops reporting keeps re-serving its last payload. If
+    polls counted instead of check-ins, one stale snapshot repeated often
+    enough would manufacture a fault out of nothing — three hours of it
+    here, against gates measured in minutes."""
+    coord = _coordinator({})
+    stuck = _gen2(False, STUCK_W)
+    # Same fingerprint every time: the device is not checking in.
+    for i in range(200):
+        _poll(coord, {**stuck, "serial": 1, "_updated": "frozen"}, i * 60.0)
+    assert coord.relay_faults == set()
+
+
+def test_a_frozen_agreeing_payload_cannot_clear_a_warning(card) -> None:
+    """The same rule in the other direction. A device that goes quiet while
+    its last payload happened to read zero watts must not talk itself out of
+    a standing warning by having that payload re-served."""
+    coord = _coordinator({})
+    _drive(coord, _gen2(False, STUCK_W))
+    assert coord.relay_faults == {(DEVICE, 0)}
+
+    healthy = _gen2(False, 0.0)
+    for i in range(200):
+        _poll(coord, {**healthy, "serial": 7, "_updated": "frozen"},
+              10_000.0 + i * 60.0)
+    assert coord.relay_faults == {(DEVICE, 0)}
+
+
+def test_a_standing_warning_survives_the_device_going_quiet(card) -> None:
+    """The other half of the same rule: a device that dies with a welded
+    contact is still welded shut, so the verdict is retained."""
+    coord = _coordinator({})
+    _drive(coord, _gen2(False, STUCK_W))
+    assert coord.relay_faults == {(DEVICE, 0)}
+
+    for i in range(200):
+        _poll(coord, {**_gen2(False, STUCK_W), "serial": 1, "_updated": "frozen"},
+              10_000.0 + i * 60.0)
+    assert coord.relay_faults == {(DEVICE, 0)}
+
+
+def test_the_option_switches_the_detector_off_and_drops_its_verdicts(card) -> None:
+    coord = _coordinator({}, **{CONF_RELAY_FAULT_DETECTION: False})
+    _drive(coord, _gen2(False, STUCK_W))
+    assert coord.relay_faults == set()
+    assert card.last_active is False
+
+
+def test_channels_are_judged_independently(card) -> None:
+    """A 2PM can have one welded contact and one healthy one; accusing the
+    device as a whole would send the user to the wrong terminal."""
+    coord = _coordinator({})
+    _drive(coord, {**_gen2(False, STUCK_W, 0), **_gen2(False, 0.0, 1)})
+    assert coord.relay_faults == {(DEVICE, 0)}
+
+
+# ── The entity ────────────────────────────────────────────────────────
+
+
+def test_one_sensor_is_built_per_metered_channel() -> None:
+    coord = _coordinator({})
+    created: set[str] = set()
+    status = {**_gen2(False, 0.0, 0), **_gen2(False, 0.0, 1)}
+    entities = _create_relay_fault_sensors(DEVICE, status, created, coord)
+    assert [e.unique_id for e in entities] == [
+        f"{DEVICE}_relay_fault_0",
+        f"{DEVICE}_relay_fault_1",
+    ]
+    assert [e.name for e in entities] == ["Relay fault", "Relay fault 2"]
+
+
+def test_a_rediscovered_device_does_not_get_a_second_set() -> None:
+    coord = _coordinator({})
+    created: set[str] = set()
+    status = _gen2(False, 0.0)
+    assert _create_relay_fault_sensors(DEVICE, status, created, coord)
+    assert _create_relay_fault_sensors(DEVICE, status, created, coord) == []
+
+
+def test_the_sensor_reports_the_coordinator_verdict() -> None:
+    coord = _coordinator({})
+    coord.devices = {DEVICE: {"status": _gen2(False, STUCK_W), "online": True}}
+    sensor = ShellyRelayFaultBinarySensor(coord, DEVICE, 0)
+    assert sensor.is_on is False
+    coord.relay_faults.add((DEVICE, 0))
+    assert sensor.is_on is True
+
+
+def test_the_sensor_carries_the_wattage_behind_the_verdict() -> None:
+    """Without the number the warning is unarguable in both directions."""
+    coord = _coordinator({})
+    coord.devices = {DEVICE: {"status": _gen2(False, STUCK_W), "online": True}}
+    sensor = ShellyRelayFaultBinarySensor(coord, DEVICE, 0)
+    assert sensor.extra_state_attributes == {"power_while_off_w": STUCK_W}
+
+
+def test_no_wattage_is_shown_while_the_relay_is_closed() -> None:
+    """With the contact closed the reading is ordinary consumption, and
+    showing it would invite comparison against a threshold it has nothing to
+    do with."""
+    coord = _coordinator({})
+    coord.devices = {DEVICE: {"status": _gen2(True, STUCK_W), "online": True}}
+    sensor = ShellyRelayFaultBinarySensor(coord, DEVICE, 0)
+    assert sensor.extra_state_attributes is None
+
+
+# ── The card's rendering ──────────────────────────────────────────────
+
+
+def test_the_card_names_the_device_and_omits_a_pointless_channel() -> None:
+    text = format_relay_fault_list({(DEVICE, 0)}, {DEVICE: "Büro Licht"})
+    assert text == f"Büro Licht ({DEVICE})"
+
+
+def test_the_card_spells_out_the_channel_from_the_second_one() -> None:
+    text = format_relay_fault_list({(DEVICE, 1)}, {})
+    assert text == f"{DEVICE} channel 2"
+
+
+def test_the_card_stays_bounded_on_a_fleet_wide_condition() -> None:
+    faults = {(f"dev{i:02d}", 0) for i in range(12)}
+    text = format_relay_fault_list(faults, {})
+    assert text.endswith("… (+7)")

--- a/tests/test_repair_issues.py
+++ b/tests/test_repair_issues.py
@@ -58,10 +58,11 @@ _EXPECTED_ISSUE_KEYS = {
     "rate_limited",
     "missing_devices",
     "history_import_failed",
+    "relay_fault",
 }
 
 # Everything the async_manage_* wrappers actually supply as placeholders.
-_SUPPLIED_PLACEHOLDERS = {"entry_title", "count", "device_ids"}
+_SUPPLIED_PLACEHOLDERS = {"entry_title", "count", "device_ids", "devices"}
 
 
 # ── Part A: issue id scoping ──────────────────────────────────────────
@@ -365,6 +366,10 @@ class _RealCoordinatorDriver:
         coord._rate_limit_reported = False
         coord._missing_streak = {}
         coord._missing_since = {}
+        coord._relay_fault_streak = {}
+        coord._relay_fault_since = {}
+        coord._relay_healthy_since = {}
+        coord.relay_faults = set()
         self.coord = coord
 
         sink = self.sink

--- a/tests/test_repair_issues_harness.py
+++ b/tests/test_repair_issues_harness.py
@@ -64,11 +64,14 @@ from custom_components.shelly_cloud_diy.repair_issues import (  # noqa: E402
     ISSUE_HISTORY_IMPORT_FAILED,
     ISSUE_MISSING_DEVICES,
     ISSUE_RATE_LIMITED,
+    ISSUE_RELAY_FAULT,
     async_clear_entry_issues,
     async_manage_history_import_issue,
     async_manage_missing_devices_issue,
     async_manage_rate_limit_issue,
+    async_manage_relay_fault_issue,
     format_device_list,
+    format_relay_fault_list,
     issue_id,
 )
 
@@ -482,6 +485,9 @@ async def test_clear_entry_issues_removes_only_this_entry(
             hass, target, active=True, missing={"aaaa"}, names={}
         )
         async_manage_history_import_issue(hass, target, active=True)
+        async_manage_relay_fault_issue(
+            hass, target, active=True, faults={("aaaa", 0)}, names={}
+        )
     await hass.async_block_till_done()
 
     reg = ir.async_get(hass)
@@ -489,8 +495,9 @@ async def test_clear_entry_issues_removes_only_this_entry(
         ISSUE_RATE_LIMITED,
         ISSUE_MISSING_DEVICES,
         ISSUE_HISTORY_IMPORT_FAILED,
+        ISSUE_RELAY_FAULT,
     )
-    assert len(reg.issues) == 6
+    assert len(reg.issues) == 8
 
     async_clear_entry_issues(hass, entry)
     await hass.async_block_till_done()
@@ -504,7 +511,7 @@ async def test_clear_entry_issues_removes_only_this_entry(
             reg.async_get_issue(DOMAIN, issue_id(kind, other_entry.entry_id))
             is not None
         )
-    assert len(reg.issues) == 3
+    assert len(reg.issues) == 4
 
 
 async def test_clear_entry_issues_on_a_clean_entry_is_a_noop(
@@ -516,3 +523,69 @@ async def test_clear_entry_issues_on_a_clean_entry_is_a_noop(
 
     assert ir.async_get(hass).issues == {}
     assert _actions(events) == []
+
+
+async def test_relay_fault_wrapper_creates_expected_issue(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    """The stuck-contact wrapper renders the affected channels.
+
+    Worth running against the real registry rather than only as a pure
+    function: this card is the one surface a user sees without having gone
+    looking for a diagnostic entity first, so a placeholder the registry
+    refuses to render would make the whole feature silent.
+    """
+    faults = {("5432044e9768", 0), ("3494546e1f2a", 1)}
+    names = {"5432044e9768": "Büro Licht"}
+
+    async_manage_relay_fault_issue(
+        hass, entry, active=True, faults=faults, names=names
+    )
+    await hass.async_block_till_done()
+
+    reg = ir.async_get(hass)
+    issue = reg.async_get_issue(
+        DOMAIN, issue_id(ISSUE_RELAY_FAULT, entry.entry_id)
+    )
+
+    assert issue is not None
+    assert issue.translation_key == ISSUE_RELAY_FAULT
+    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.is_fixable is False
+    assert issue.is_persistent is False
+    assert issue.translation_placeholders == {
+        "entry_title": "Shelly Cloud",
+        "count": "2",
+        "devices": format_relay_fault_list(faults, names),
+    }
+    rendered = issue.translation_placeholders["devices"]
+    assert "Büro Licht (5432044e9768)" in rendered
+    assert "3494546e1f2a channel 2" in rendered
+
+
+async def test_relay_fault_card_survives_a_second_failing_actuator(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    """Upsert, not delete-then-create: a user who dismissed the card for one
+    welded relay must not have it reappear un-ignored because a second one
+    joined the list."""
+    reg = ir.async_get(hass)
+    iid = issue_id(ISSUE_RELAY_FAULT, entry.entry_id)
+
+    async_manage_relay_fault_issue(
+        hass, entry, active=True, faults={("aaaa", 0)}, names={}
+    )
+    await hass.async_block_till_done()
+    ir.async_ignore_issue(hass, DOMAIN, iid, True)
+    await hass.async_block_till_done()
+    dismissed = reg.async_get_issue(DOMAIN, iid).dismissed_version
+    assert dismissed is not None
+
+    async_manage_relay_fault_issue(
+        hass, entry, active=True, faults={("aaaa", 0), ("bbbb", 0)}, names={}
+    )
+    await hass.async_block_till_done()
+
+    issue = reg.async_get_issue(DOMAIN, iid)
+    assert issue.dismissed_version == dismissed, "the Ignore was destroyed"
+    assert issue.translation_placeholders["count"] == "2"

--- a/tests/test_sleeping_availability.py
+++ b/tests/test_sleeping_availability.py
@@ -401,6 +401,10 @@ def _inert_repair_issues(monkeypatch):
         coordinator_mod, "async_manage_missing_devices_issue",
         lambda hass, entry, *, active, missing, names: None,
     )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_relay_fault_issue",
+        lambda hass, entry, *, active, faults, names: None,
+    )
 
 
 def _live_coordinator(devices_status: dict[str, Any]) -> ShellyCloudCoordinator:
@@ -426,6 +430,10 @@ def _live_coordinator(devices_status: dict[str, Any]) -> ShellyCloudCoordinator:
     coord._rate_limit_reported = False
     coord._missing_streak = {}
     coord._missing_since = {}
+    coord._relay_fault_streak = {}
+    coord._relay_fault_since = {}
+    coord._relay_healthy_since = {}
+    coord.relay_faults = set()
     return coord
 
 


### PR DESCRIPTION
## What it does

A switching Shelly reports what it *commanded* (`output`) and what it *measures*
(`apower`) in the same payload. When the relay says open while the meter still
sees a load, the contact has welded shut: the actuator keeps accepting commands
and keeps reporting *off*, the load never switches off, and everything built on
switching it off silently stops working. Nothing in Home Assistant says so today.

Adds a per-channel **Relay fault** binary sensor (diagnostic, `problem`) for
every switching channel that meters its own output, a repair card, and an option
to switch the whole detector off.

## Built against hardware that actually failed

Shelly 1PM Mini Gen3, measured 2026-08-17: `output: false` with 85.2 W flowing,
sustained, lamp visibly on and unswitchable from software. Two findings from
that run are encoded in the design:

* **The moment right after a command lies.** One `turn_off` produced `apower: 0`
  for ~45 s while the load was demonstrably still running. So the verdict needs
  five check-ins **and** 120 s, and a single agreeing sample does not retract a
  standing warning — clearing needs 300 s of its own. The asymmetry is deliberate.
* **The energy counter is not a fast second opinion.** It stood still for 80 s,
  then jumped 1.0 Wh at once. It resolves minutes, not seconds, and is not part
  of the verdict.

That same unit still reads `switch = off` at 74.4 W today, so the failure mode
is not a one-off glitch.

## Three decisions worth reviewing

1. **Check-ins are counted, not polls.** A frozen device re-serves its last
   payload for as long as the cloud caches it; counting polls would let one
   stale snapshot be repeated into an accusation. A raised verdict survives a
   device going quiet — a welded contact does not unweld because the device
   dropped off the cloud.
2. **No learned threshold**, unlike offline detection. Learning what "off"
   normally draws would be poisoned by the very fault this detects: a contact
   already welded at startup would teach the device that 85 W is its idle draw.
   A fixed 5 W floor cannot be taught anything, and sits above the
   snubber / LED-driver / meter-noise band.
3. **Out of scope by construction:** clamp-metering devices (no defined relation
   between measurement and contact), Gen1 roller mode ("relay off, power
   flowing" is a moving shutter), and channels without metering (no entity).
   The one false positive the payload cannot see is a two-way circuit — hence
   the option, and it is named in both READMEs.

## Verification

* 31 new unit tests in `tests/test_relay_fault.py`; full matrix green
  (260 / 261 passed on py3.12+HA 2025.1.4 and py3.14+HA latest), 21 harness tests green.
* Live-tested against the mock cloud on a real HA instance: the sensor is built
  only where metering exists, tripped at 130 s, the repair card rendered with the
  resolved device name, cleared at 320 s against the 300 s floor, no errors.
* Control runs: removing the check-in guard turns 2 tests red, making the clear
  symmetric turns 2 others red.
* Gen1 is unit-tested only — there is no Gen1 device in the account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLJigzBTVmXLDz9x6ERKjs