### PR TITLE
fix(repairs): clamp device names on a word boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,16 @@ rename / version-bump commits.
 
 Quick scan (run from repo root):
 
+⚠ Use `origin/main..HEAD`, **never `origin/HEAD..HEAD`**. `origin/HEAD` is unset
+in this clone, so `git diff origin/HEAD..HEAD` aborts with `bad revision`; the
+`grep` behind the pipe then reads an empty stream, matches nothing and prints
+`diff clean` — **without having checked anything**. Always print the diff size
+first so a scan that saw zero lines is visible.
+
 ```bash
-git diff origin/HEAD..HEAD -- '**' | grep -E -i \
+git diff origin/main..HEAD -- '**' | wc -l   # 0 = nothing was scanned, investigate
+
+git diff origin/main..HEAD -- '**' | grep -E -i \
   'auth_key|integrator_token|access_token|bearer[[:space:]]+[A-Za-z0-9]|ghp_|gho_|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]+\.eyJ' \
   && echo "SECRET SUSPECTED — ABORT" || echo "diff clean"
 

--- a/custom_components/shelly_cloud_diy/repair_issues.py
+++ b/custom_components/shelly_cloud_diy/repair_issues.py
@@ -74,6 +74,12 @@ MISSING_DEVICE_MAX_LISTED = 5
 # exists to enforce.
 MISSING_DEVICE_MAX_NAME_LEN = 24
 
+# When the clamp has to cut, it prefers the last word boundary at or after
+# this offset, so "KG-SY-PSW-Licht-Buero-Dirk" ends on "…-Buero…" instead of
+# mid-word "…-Di…". Below the floor the boundary is too early to be worth the
+# characters it costs, and the hard cut is used instead.
+MISSING_DEVICE_NAME_MIN_KEEP = 16
+
 # Two unproductive syncs. Because the daily interval is 24 h and this counter
 # is instance state on a service that async_setup_entry rebuilds on every
 # reload, a naive "wait for the next daily run" would mean the repair never
@@ -180,10 +186,22 @@ def history_import_verdict(
 
 
 def _clamp_name(name: str) -> str:
-    """Trim a device name to keep the rendered card bounded."""
+    """Trim a device name to keep the rendered card bounded.
+
+    The cut lands on a word boundary where one sits late enough in the
+    budget to be worth it, because the truncated half of a name is what the
+    reader uses to recognise their device: a live card read
+    "KG-SY-PSW-Licht-Buero-Di…", which looks like a rendering bug rather
+    than a shortened name. Names without a usable separator still get the
+    hard cut — the bound, not the prettiness, is what this function owes.
+    """
     if len(name) <= MISSING_DEVICE_MAX_NAME_LEN:
         return name
-    return name[: MISSING_DEVICE_MAX_NAME_LEN - 1].rstrip() + "…"
+    head = name[: MISSING_DEVICE_MAX_NAME_LEN - 1]
+    cut = max(head.rfind(" "), head.rfind("-"), head.rfind("_"))
+    if cut >= MISSING_DEVICE_NAME_MIN_KEEP:
+        head = head[:cut]
+    return head.rstrip(" -_") + "…"
 
 
 def format_device_list(missing: set[str], names: dict[str, str]) -> str:

--- a/tests/test_repair_issues.py
+++ b/tests/test_repair_issues.py
@@ -35,6 +35,7 @@ from custom_components.shelly_cloud_diy.repair_issues import (
     HISTORY_IMPORT_MIN_FAILURES,
     HISTORY_IMPORT_RETRY_S,
     MISSING_DEVICE_MAX_LISTED,
+    MISSING_DEVICE_MAX_NAME_LEN,
     MISSING_DEVICE_MIN_SECONDS,
     MISSING_DEVICE_MIN_STREAK,
     RATE_LIMIT_MIN_SECONDS,
@@ -287,6 +288,40 @@ def test_format_clamps_a_single_long_name() -> None:
     text = format_device_list({"abc123"}, {"abc123": "x" * 100})
     assert text.endswith("(abc123)")
     assert len(text) < 100
+
+
+def test_format_clamps_on_a_word_boundary() -> None:
+    """A cut name must still read like a name.
+
+    The live relay-fault card rendered Dirk's switch as
+    "KG-SY-PSW-Licht-Buero-Di…", which reads as a rendering fault rather
+    than a shortened label.
+    """
+    text = format_device_list(
+        {"abc123"}, {"abc123": "KG-SY-PSW-Licht-Buero-Dirk"}
+    )
+    assert text == "KG-SY-PSW-Licht-Buero… (abc123)"
+
+
+def test_format_clamp_falls_back_to_a_hard_cut() -> None:
+    """No separator late enough in the budget means the hard cut stands."""
+    text = format_device_list({"abc123"}, {"abc123": "Wohnzimmer" + "x" * 40})
+    assert text.startswith("Wohnzimmerxxx")
+    assert text.endswith("… (abc123)")
+
+
+def test_format_clamp_never_exceeds_the_bound() -> None:
+    """Whichever branch runs, the clamp still owes the caller its bound."""
+    for name in (
+        "KG-SY-PSW-Licht-Buero-Dirk",
+        "Wohnzimmer Deckenlampe hinten links",
+        "a" * 100,
+        "-" * 30,
+        "kurz-" + "y" * 30,
+    ):
+        text = format_device_list({"abc123"}, {"abc123": name})
+        rendered = text.split(" (abc123)")[0]
+        assert len(rendered) <= MISSING_DEVICE_MAX_NAME_LEN, name
 
 
 def test_format_is_deterministic() -> None:


### PR DESCRIPTION
## What

Two small fixes, both fallout from the live relay-fault confirmation on 2026-08-18.

### 1. Repair-card device name cut mid-word

The card that appeared on the real defective switch rendered it as
`KG-SY-PSW-Licht-Buero-Di…`. That reads as a rendering fault rather than a
shortened name — and the truncated half is exactly what the reader uses to
recognise which device the card is about.

`_clamp_name` now prefers the last space / hyphen / underscore at or after
`MISSING_DEVICE_NAME_MIN_KEEP` (16). A name with no usable separator that late
still gets the hard cut, so the bound the function owes its caller is unchanged
— that bound, not prettiness, is the reason the clamp exists.

Three tests: the boundary case, the hard-cut fallback, and a guard that *every*
branch stays inside `MISSING_DEVICE_MAX_NAME_LEN`.
**Control run against the old clamp: the boundary test is red.**

### 2. The pre-push secret scan never checked anything

`git diff origin/HEAD..HEAD` aborts with `bad revision` in this clone —
`origin/HEAD` is unset. The `grep` behind the pipe then read an empty stream,
matched nothing, and printed `diff clean`. The HARD RULE in `CLAUDE.md` has been
silently passing on every push.

Switched to `origin/main..HEAD` and added a diff-size line first, so a scan that
saw zero lines is *visible* rather than reassuring.

## Testing

- `ALL ENVIRONMENTS GREEN` — 291 passed / 2 skipped (HA 2025.1.4 / py3.12) and
  292 passed / 1 skipped (HA 2026.7.2 / py3.14)
- 21 harness tests green (`--asyncio-mode=auto`)
- No user-visible strings changed, no new options, no translation impact.

## Not included

No manifest bump — v0.9.2 shipped hours ago and a cosmetic clamp does not
justify a release on its own. Happy to fold it into the next one.