### PR TITLE
fix(sensor): create the returned-energy sensors on Gen1 energy meters (#38)

### DIFF
--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -124,14 +124,22 @@ def _create_block_sensors(
                         coordinator, device_id, desc, idx, "emeters", attr
                     ))
 
-        if "total" in emeter:
-            desc = BLOCK_SENSORS.get(("emeter", "energy"))
-            if desc:
+        # Cumulative counters. Gen1 energy meters report consumption as
+        # ``total`` and grid feed-in as ``total_returned`` (both watt-hours);
+        # a description for the latter existed from the start but was never
+        # instantiated, so PV owners on a Shelly 3EM got the consumption half
+        # only (#38).
+        for attr, key in [
+            ("total", ("emeter", "energy")),
+            ("total_returned", ("emeter", "energyReturned")),
+        ]:
+            if attr in emeter and key in BLOCK_SENSORS:
+                desc = BLOCK_SENSORS[key]
                 uid = f"{device_id}_{desc.key}_{idx}"
                 if uid not in created:
                     created.add(uid)
                     entities.append(BlockSensor(
-                        coordinator, device_id, desc, idx, "emeters", "total"
+                        coordinator, device_id, desc, idx, "emeters", attr
                     ))
 
     # Meters

--- a/tests/test_emeter_returned_energy.py
+++ b/tests/test_emeter_returned_energy.py
@@ -1,0 +1,127 @@
+"""Unit tests for Gen1 energy-meter counters (``emeters[].total_returned``).
+
+Reported as issue #38 (2026-08-25): on a Shelly 3EM the "energy returned"
+sensors never appeared. Cause: ``_create_block_sensors`` instantiated only
+``total`` (consumption); the ``("emeter", "energyReturned")`` description had
+existed since the initial port but was never wired to a status key, so anyone
+feeding PV back into the grid saw one half of the meter.
+
+These tests drive the real Block creation loop with a fake coordinator — no
+running HA required.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfEnergy
+
+from custom_components.shelly_cloud_diy.sensor import (
+    BlockSensor,
+    _create_block_sensors as create_block_sensors,
+)
+
+DEVICE_ID = "3em0a1b2c3d4"
+
+
+class _FakeCoordinator:
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {
+            device_id: {"status": status, "device_code": "SHEM-3", "online": True}
+        }
+        self.data = self.devices
+        self.last_update_success = True
+
+
+# Shape of a Gen1 Shelly 3EM: three clamp channels, each with its own pair of
+# cumulative counters. Phase B is exporting (negative power, rising
+# ``total_returned``), which is exactly the case the missing entity hid.
+_3EM_STATUS: dict[str, Any] = {
+    "mac": "AABBCCDDEEFF",
+    "emeters": [
+        {
+            "power": 250.7,
+            "pf": 0.88,
+            "current": 1.09,
+            "voltage": 230.1,
+            "is_valid": True,
+            "total": 12345.6,
+            "total_returned": 0.0,
+        },
+        {
+            "power": -410.2,
+            "pf": -0.96,
+            "current": 1.79,
+            "voltage": 229.8,
+            "is_valid": True,
+            "total": 500.0,
+            "total_returned": 4200.5,
+        },
+        {
+            "power": 12.0,
+            "pf": 0.5,
+            "current": 0.1,
+            "voltage": 230.0,
+            "is_valid": True,
+            "total": 77.7,
+            "total_returned": 1.25,
+        },
+    ],
+}
+
+
+def _build(status: dict[str, Any]):
+    coord = _FakeCoordinator(DEVICE_ID, status)
+    sensors = create_block_sensors(DEVICE_ID, status, set(), coord)
+    return sensors, {e.unique_id: e for e in sensors}
+
+
+def test_every_phase_gets_a_returned_energy_entity():
+    _, by_uid = _build(_3EM_STATUS)
+    for idx in range(3):
+        assert f"{DEVICE_ID}_emeter|energyReturned_{idx}" in by_uid
+        # The consumption counter must survive the change.
+        assert f"{DEVICE_ID}_emeter|energy_{idx}" in by_uid
+
+
+def test_returned_energy_reads_the_right_phase():
+    _, by_uid = _build(_3EM_STATUS)
+    assert by_uid[f"{DEVICE_ID}_emeter|energyReturned_0"].native_value == 0.0
+    assert by_uid[f"{DEVICE_ID}_emeter|energyReturned_1"].native_value == 4200.5
+    assert by_uid[f"{DEVICE_ID}_emeter|energyReturned_2"].native_value == 1.25
+    # Consumption still points at ``total``, not at the new key.
+    assert by_uid[f"{DEVICE_ID}_emeter|energy_1"].native_value == 500.0
+
+
+def test_returned_energy_is_a_statistics_grade_energy_sensor():
+    _, by_uid = _build(_3EM_STATUS)
+    entity = by_uid[f"{DEVICE_ID}_emeter|energyReturned_0"]
+    assert isinstance(entity, BlockSensor)
+    assert entity.device_class is SensorDeviceClass.ENERGY
+    assert entity.state_class is SensorStateClass.TOTAL_INCREASING
+    assert entity.native_unit_of_measurement == UnitOfEnergy.WATT_HOUR
+
+
+def test_names_follow_the_existing_channel_convention():
+    _, by_uid = _build(_3EM_STATUS)
+    assert by_uid[f"{DEVICE_ID}_emeter|energyReturned_0"].name == "Energy Returned"
+    assert by_uid[f"{DEVICE_ID}_emeter|energyReturned_1"].name == "Energy Returned 2"
+    assert by_uid[f"{DEVICE_ID}_emeter|energyReturned_2"].name == "Energy Returned 3"
+
+
+def test_meter_without_the_key_creates_nothing_extra():
+    """A Gen1 EM firmware that omits ``total_returned`` must not gain a
+    permanently ``None`` entity."""
+    status = {"emeters": [{"power": 1.0, "voltage": 230.0, "total": 10.0}]}
+    _, by_uid = _build(status)
+    assert f"{DEVICE_ID}_emeter|energy_0" in by_uid
+    assert f"{DEVICE_ID}_emeter|energyReturned_0" not in by_uid
+
+
+def test_created_set_prevents_duplicates_across_calls():
+    coord = _FakeCoordinator(DEVICE_ID, _3EM_STATUS)
+    created: set[str] = set()
+    first = create_block_sensors(DEVICE_ID, _3EM_STATUS, created, coord)
+    second = create_block_sensors(DEVICE_ID, _3EM_STATUS, created, coord)
+    assert any("energyReturned" in e.unique_id for e in first)
+    assert second == []


### PR DESCRIPTION
## Problem

Reported in #38: on a Shelly 3EM (Gen1), no "energy returned" sensors are created.

Gen1 energy meters report two cumulative counters per clamp channel:

```json
"emeters": [{"power": …, "pf": …, "current": …, "voltage": …,
             "is_valid": true, "total": 12345.6, "total_returned": 4200.5}]
```

`_create_block_sensors()` only ever instantiated `total`. Anyone feeding PV back
into the grid therefore got the consumption half of their meter and nothing else.

The `("emeter", "energyReturned")` description has existed in
`entities/descriptions.py` since the initial port (`4880f9c`) but was never wired
to a status key — dead code from day one.

## Fix

`total` and `total_returned` now go through one presence-guarded loop, so
firmware that omits `total_returned` still creates no permanently-empty entity.

New entities (one per clamp channel, `Wh` / `total_increasing` / `device_class:
energy`, so they are usable in the Energy dashboard):

- `Energy Returned`, `Energy Returned 2`, `Energy Returned 3`
- unique IDs `<device_id>_emeter|energyReturned_<channel>`

Existing `Energy` sensors are untouched — no unique-ID or unit changes.

## Scope

Gen1 only. The Gen2 Pro 3EM already surfaces its returned counters via
`emdata:<idx>` (`*_total_act_ret_energy`, `total_act_ret`), and the Pro EM-50 via
`em1data:<idx>` — both verified unaffected.

## Tests

New `tests/test_emeter_returned_energy.py` (6 cases) drives the real Block
creation loop against a 3-channel 3EM status: per-phase entity creation, correct
per-phase value, energy/statistics metadata, channel naming convention, the
key-absent case, and duplicate suppression via the `created` set.

Full matrix green: 297 passed (HA 2025.1.4 / py3.12) and 298 passed
(HA 2026.7.2 / py3.14).

Fixes #38