### PR TITLE
Device: Added moisture sensor for Shelly Flood devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ secrets.yaml
 # Local-only scratch: ad-hoc pure-function tests, MCP browser artifacts
 scratchpad/
 .playwright-mcp/
+/tests

--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -372,6 +372,20 @@ def _create_rpc_sensors(
                             coordinator, device_id, desc, idx, key, "state"
                         ))
 
+    # Flood alarms (for example Shelly Flood Gen4 / S4SN-0071Z)
+    for key, payload in status.items():
+        if match := re.fullmatch(r"flood:(\d+)", key):
+            idx = int(match.group(1))
+            if isinstance(payload, dict) and "alarm" in payload:
+                desc = RPC_BINARY_SENSORS.get("flood")
+                if desc:
+                    uid = f"{device_id}_{key}_alarm"
+                    if uid not in created:
+                        created.add(uid)
+                        entities.append(RpcBinarySensor(
+                            coordinator, device_id, desc, idx, key, "alarm"
+                        ))
+
     # Cloud
     if "connected" in status.get("cloud", {}):
         desc = RPC_BINARY_SENSORS.get("cloud")

--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -160,7 +160,7 @@ PLATFORMS: list[Platform] = [
 # They must not be re-added with an optional index either — a Gen1 status has
 # a bare ``cloud`` key too, which would classify every Gen1 device as Gen2.
 _GEN2_PATTERN = re.compile(
-    r"(switch|light|cover|input|temperature|humidity"
+    r"(switch|light|cover|input|temperature|humidity|flood"
     r"|devicepower|voltmeter|em1data|em1|emdata|em|pm1"
     r"|boolean|number|enum|text|button):\d+"
 )

--- a/custom_components/shelly_cloud_diy/entities/descriptions.py
+++ b/custom_components/shelly_cloud_diy/entities/descriptions.py
@@ -985,6 +985,12 @@ RPC_BINARY_SENSORS: Final[dict[str, RpcBinarySensorDescription]] = {
         name="Input",
         device_class=BinarySensorDeviceClass.POWER,
     ),
+    "flood": RpcBinarySensorDescription(
+        key="flood",
+        sub_key="alarm",
+        name="Flood",
+        device_class=BinarySensorDeviceClass.MOISTURE,
+    ),
     # Disabled by default, matching HA core's native Shelly integration. On a
     # deep-sleep device this flag is a boot-timing artifact rather than a state:
     # the cached snapshot is captured seconds after wake, before the cloud


### PR DESCRIPTION
Added moisture sensor and mapped "flood" from Shelly API payload.  Should work with older sensors as well assuming they are mapped the same in the API payload, but tested with Shelly Flood S Gen4.