### PR TITLE
fix(binary_sensor): create the alarm entity on Gen1 flood and smoke sensors

### DIFF
--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -334,6 +334,24 @@ def _create_block_sensors(
                     coordinator, device_id, desc, 0, "sensor", "state"
                 ))
 
+    # Flood / Smoke — Gen1 leaf sensors carry a bare top-level flag:
+    # Shelly Flood (``SHWT-1``) reports ``"flood": false`` and Shelly Smoke
+    # (``SHSM-01``) reports ``"smoke": false``, both alongside ``is_valid``
+    # and a ``tmp`` block (vendor Gen1 API docs, /status). Both descriptions
+    # have existed since the first release but were never wired to a status
+    # key, so these devices arrived with their diagnostics and without the one
+    # reading they exist for — the same gap the Gen4 flood had in #41.
+    for flag in ("flood", "smoke"):
+        if flag in status:
+            desc = BLOCK_BINARY_SENSORS.get(flag)
+            if desc:
+                uid = f"{device_id}_{flag}"
+                if uid not in created:
+                    created.add(uid)
+                    entities.append(BlockBinarySensor(
+                        coordinator, device_id, desc, 0, None, flag
+                    ))
+
     # Gas alarm
     gas = status.get("gas_sensor", {})
     if gas and "alarm_state" in gas:

--- a/tests/test_gen1_flood_smoke.py
+++ b/tests/test_gen1_flood_smoke.py
@@ -1,0 +1,124 @@
+"""Unit tests for the Gen1 flood and smoke alarms.
+
+Gen1 leaf sensors carry a bare top-level flag rather than a component. Per the
+vendor Gen1 API docs, a Shelly Flood (``SHWT-1``) ``/status`` reads
+``{"is_valid": true, "flood": false, "tmp": {...}, ...}`` and a Shelly Smoke
+(``SHSM-01``) the same with ``"smoke"``.
+
+Both descriptions existed in ``BLOCK_BINARY_SENSORS`` from the first release
+but were never wired to a status key, so these devices arrived with their
+diagnostics and no alarm entity — the Gen1 half of #41.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+from custom_components.shelly_cloud_diy.binary_sensor import (
+    BlockBinarySensor,
+    _create_block_sensors,
+)
+from custom_components.shelly_cloud_diy.const import is_gen2_status
+
+DEVICE_ID = "3494546a1b2c"
+
+
+class _FakeCoordinator:
+    """Minimal coordinator: entities only read ``.devices[id]['status']``."""
+
+    def __init__(self, device_id: str, status: dict[str, Any], code: str) -> None:
+        self.devices = {
+            device_id: {"status": status, "device_code": code, "online": True}
+        }
+        self.data = self.devices
+        self.last_update_success = True
+
+
+def _flood_status(flood: Any = False) -> dict[str, Any]:
+    """Shelly Flood ``SHWT-1`` /status, as documented by Shelly."""
+    return {
+        "is_valid": True,
+        "flood": flood,
+        "tmp": {"value": 20, "units": "C", "tC": 20, "tF": 68, "is_valid": True},
+        "bat": {"value": 88, "voltage": 2.9},
+        "cloud": {"enabled": True, "connected": True},
+        "wifi_sta": {"connected": True},
+    }
+
+
+def _smoke_status(smoke: Any = False) -> dict[str, Any]:
+    """Shelly Smoke ``SHSM-01`` /status, as documented by Shelly."""
+    status = _flood_status()
+    del status["flood"]
+    status["smoke"] = smoke
+    return status
+
+
+def _build(status: dict[str, Any], code: str = "SHWT-1", created: set[str] | None = None):
+    coord = _FakeCoordinator(DEVICE_ID, status, code)
+    entities = _create_block_sensors(
+        DEVICE_ID, status, set() if created is None else created, coord
+    )
+    return entities, {e.unique_id: e for e in entities}
+
+
+def test_gen1_leaf_sensors_stay_on_the_block_path():
+    """Guard the routing: neither status may be read as Gen2."""
+    assert is_gen2_status(_flood_status()) is False
+    assert is_gen2_status(_smoke_status()) is False
+
+
+def test_flood_alarm_entity_is_created():
+    entities, by_uid = _build(_flood_status())
+
+    uid = f"{DEVICE_ID}_flood_0"
+    assert uid in by_uid, [e.unique_id for e in entities]
+
+    entity = by_uid[uid]
+    assert isinstance(entity, BlockBinarySensor)
+    assert entity.device_class is BinarySensorDeviceClass.MOISTURE
+    assert entity.name == "Flood"
+
+
+def test_smoke_alarm_entity_is_created():
+    _, by_uid = _build(_smoke_status(), code="SHSM-01")
+
+    uid = f"{DEVICE_ID}_smoke_0"
+    assert uid in by_uid
+    assert by_uid[uid].device_class is BinarySensorDeviceClass.SMOKE
+    assert by_uid[uid].name == "Smoke"
+
+
+def test_alarm_values_are_mirrored():
+    _, dry = _build(_flood_status(flood=False))
+    assert dry[f"{DEVICE_ID}_flood_0"].is_on is False
+
+    _, wet = _build(_flood_status(flood=True))
+    assert wet[f"{DEVICE_ID}_flood_0"].is_on is True
+
+    _, smoking = _build(_smoke_status(smoke=True), code="SHSM-01")
+    assert smoking[f"{DEVICE_ID}_smoke_0"].is_on is True
+
+
+def test_a_device_without_the_flag_gets_no_alarm_entity():
+    """A Gen1 relay must not grow a flood or smoke sensor."""
+    relay = {
+        "relays": [{"ison": False}],
+        "meters": [{"power": 0.0, "total": 12}],
+        "cloud": {"enabled": True, "connected": True},
+    }
+    _, by_uid = _build(relay, code="SHSW-1")
+    assert not any(uid.endswith(("_flood_0", "_smoke_0")) for uid in by_uid)
+
+
+def test_already_created_uid_is_not_duplicated():
+    seen = {f"{DEVICE_ID}_flood"}
+    entities, _ = _build(_flood_status(), created=seen)
+    assert all(e.unique_id != f"{DEVICE_ID}_flood_0" for e in entities)
+
+
+def test_temperature_block_is_untouched():
+    """The flag sits next to ``tmp`` — creating it must not shadow anything."""
+    entities, _ = _build(_flood_status(flood=True))
+    assert len(entities) == 1


### PR DESCRIPTION
## What is broken

`BLOCK_BINARY_SENSORS` has carried a `flood` and a `smoke` description since the first release, but neither was ever wired to a status key in `_create_block_sensors()`. A **Shelly Flood (`SHWT-1`)** and a **Shelly Smoke (`SHSM-01`)** therefore arrive with their temperature, battery and cloud diagnostics and without the one reading they exist for.

Same class of dead-code gap as `("emeter", "energyReturned")` in #38: the description was written, the wiring never was.

## Why this is separate from #40

#40 fixed the Gen2+ shape — `flood:<id>.alarm` on a Flood S Gen4, reported in #41. Gen1 devices never reach that builder: they carry a bare top-level flag and go through the block path, which had no handling at all.

## The fix

Per the vendor Gen1 API docs, `/status` on both devices reads:

```json
{ "is_valid": true, "flood": false, "tmp": { "value": 20, ... } }
{ "is_valid": true, "smoke": false, "tmp": { "value": 22, ... } }
```

One entity per flag, with the device class its description already declared — `moisture` for flood, `smoke` for smoke.

**Not changed:** `is_valid` is not consulted. No other Gen1 sensor here gates on it, and no payload from a device in that state has been observed, so gating would be a guess rather than a fix.

## Verification

`tests/test_gen1_flood_smoke.py` — entity identity and device class for both, value mirroring, a Gen1 relay growing neither entity, dedup, and a routing guard that neither status is misread as Gen2.

311 passed / 2 skipped on HA 2025.1.4 (py3.12), 312 / 1 on HA 2026.7.2 (py3.14).

**Not hardware-confirmed** — I own neither device. The status shape is from the vendor documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XarCtwJ7JnsgAgaUytQhQs
