### PR TITLE
feat(health): device health checks, plus the Wi-Fi signal sensors that were never wired up

### DIFF
--- a/custom_components/shelly_cloud_diy/config_flow.py
+++ b/custom_components/shelly_cloud_diy/config_flow.py
@@ -45,12 +45,16 @@ from .api.cloud_control import (
 from .const import (
     CONF_AUTH_KEY,
     CONF_CREATE_ALL_INITIALLY,
+    CONF_DEVICE_HEALTH_DETECTION,
+    CONF_DEVICE_HEALTH_FIRMWARE,
     CONF_ENABLED_DEVICES,
     CONF_LOCAL_GATEWAY_URL,
     CONF_OFFLINE_AFTER,
     CONF_POLL_INTERVAL,
     CONF_RELAY_FAULT_DETECTION,
     CONF_SERVER_URI,
+    DEVICE_HEALTH_DETECTION_DEFAULT,
+    DEVICE_HEALTH_FIRMWARE_DEFAULT,
     DOMAIN,
     OFFLINE_AFTER_DEFAULT,
     OFFLINE_AFTER_MAX,
@@ -478,6 +482,18 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                             RELAY_FAULT_DETECTION_DEFAULT,
                         )
                     ),
+                    CONF_DEVICE_HEALTH_DETECTION: bool(
+                        user_input.get(
+                            CONF_DEVICE_HEALTH_DETECTION,
+                            DEVICE_HEALTH_DETECTION_DEFAULT,
+                        )
+                    ),
+                    CONF_DEVICE_HEALTH_FIRMWARE: bool(
+                        user_input.get(
+                            CONF_DEVICE_HEALTH_FIRMWARE,
+                            DEVICE_HEALTH_FIRMWARE_DEFAULT,
+                        )
+                    ),
                 }
 
                 # Fetch the current fleet + names so the device-selection
@@ -516,6 +532,16 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                 CONF_RELAY_FAULT_DETECTION, RELAY_FAULT_DETECTION_DEFAULT
             )
         )
+        current_device_health = bool(
+            self.config_entry.options.get(
+                CONF_DEVICE_HEALTH_DETECTION, DEVICE_HEALTH_DETECTION_DEFAULT
+            )
+        )
+        current_health_firmware = bool(
+            self.config_entry.options.get(
+                CONF_DEVICE_HEALTH_FIRMWARE, DEVICE_HEALTH_FIRMWARE_DEFAULT
+            )
+        )
 
         schema = vol.Schema(
             {
@@ -529,6 +555,12 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                 ),
                 vol.Required(
                     CONF_RELAY_FAULT_DETECTION, default=current_relay_fault
+                ): bool,
+                vol.Required(
+                    CONF_DEVICE_HEALTH_DETECTION, default=current_device_health
+                ): bool,
+                vol.Required(
+                    CONF_DEVICE_HEALTH_FIRMWARE, default=current_health_firmware
                 ): bool,
                 vol.Optional(
                     CONF_LOCAL_GATEWAY_URL, default=current_gw

--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -75,6 +75,30 @@ OFFLINE_AFTER_MAX = 24 * 60
 CONF_RELAY_FAULT_DETECTION = "relay_fault_detection"
 RELAY_FAULT_DETECTION_DEFAULT = True
 
+# ── Device health checks ("Doctor") ────────────────────────────────
+#
+# Threshold checks on fields the poll already returns: Wi-Fi signal,
+# device temperature, free RAM and filesystem, a pending restart and any
+# component reporting its own errors. No extra request, no extra
+# credential — see ``device_health.py`` for the thresholds and for why
+# Gen1 devices are not judged at all.
+#
+# On by default. Only a component's own heat is judged, never an external
+# add-on probe — a sensor in a boiler flow pipe is hot by design and the
+# payload cannot be told apart from an overheating device. The off switch
+# stays for the cases no payload can reveal, the way the relay detector
+# keeps one for two-way circuits.
+CONF_DEVICE_HEALTH_DETECTION = "device_health_detection"
+DEVICE_HEALTH_DETECTION_DEFAULT = True
+
+# Firmware findings are OFF by default, and that is a measurement, not a
+# preference: 24 of the 35 Gen2 devices on the account this was developed
+# against had an update pending. A card that is permanently lit on two
+# thirds of a fleet teaches the user to ignore the card — including the
+# time it is reporting a device cooking at 85 °C.
+CONF_DEVICE_HEALTH_FIRMWARE = "device_health_firmware"
+DEVICE_HEALTH_FIRMWARE_DEFAULT = False
+
 # ── Historical sync (unchanged from pre-pivot) ─────────────────────
 
 HISTORICAL_SYNC_INTERVAL = 24 * 60 * 60  # daily

--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -37,10 +37,14 @@ from .api.cloud_control import (
 )
 from .const import (
     CONF_CREATE_ALL_INITIALLY,
+    CONF_DEVICE_HEALTH_DETECTION,
+    CONF_DEVICE_HEALTH_FIRMWARE,
     CONF_ENABLED_DEVICES,
     CONF_OFFLINE_AFTER,
     CONF_POLL_INTERVAL,
     CONF_RELAY_FAULT_DETECTION,
+    DEVICE_HEALTH_DETECTION_DEFAULT,
+    DEVICE_HEALTH_FIRMWARE_DEFAULT,
     DOMAIN,
     OFFLINE_AFTER_DEFAULT,
     POLL_INTERVAL_DEFAULT,
@@ -48,12 +52,19 @@ from .const import (
     SIGNAL_NEW_DEVICE,
     device_gen,
 )
+from .device_health import (
+    HealthFinding,
+    evaluate_device_health,
+    finding_key,
+    health_verdict,
+)
 from .relay_fault import (
     iter_relay_readings,
     relay_clear_verdict,
     relay_fault_verdict,
 )
 from .repair_issues import (
+    async_manage_device_health_issue,
     async_manage_missing_devices_issue,
     async_manage_rate_limit_issue,
     async_manage_relay_fault_issue,
@@ -416,6 +427,17 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         # poll, since a device that dies with a welded contact is still
         # welded shut.
         self.relay_faults: set[tuple[str, int]] = set()
+        # Device-health bookkeeping, keyed per (device_id, check, component)
+        # so a device can complete the streak for its Wi-Fi signal while its
+        # temperature finding is still too young to mention. Same reason as
+        # the relay maps above: the count is in CHECK-INS, not polls.
+        self._health_streak: dict[tuple[str, str, str], int] = {}
+        self._health_since: dict[tuple[str, str, str], float] = {}
+        # The published verdicts, device_id -> confirmed findings. Read by
+        # the aggregated repair card. Entries survive a device going quiet:
+        # a device that dropped off the cloud at 84 °C is not cooler for
+        # having stopped talking about it.
+        self.device_health: dict[str, tuple[HealthFinding, ...]] = {}
 
     # ── Offline detection bookkeeping ─────────────────────────────────
 
@@ -596,6 +618,126 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             if reading.channel == channel:
                 return reading.power if not reading.output else None
         return None
+
+    # ── Device-health bookkeeping ("Doctor") ──────────────────────────
+
+    @property
+    def device_health_detection(self) -> bool:
+        """Whether the threshold health checks are switched on."""
+        return bool(
+            self._options.get(
+                CONF_DEVICE_HEALTH_DETECTION, DEVICE_HEALTH_DETECTION_DEFAULT
+            )
+        )
+
+    @property
+    def device_health_firmware(self) -> bool:
+        """Whether a pending firmware update counts as a finding."""
+        return bool(
+            self._options.get(
+                CONF_DEVICE_HEALTH_FIRMWARE, DEVICE_HEALTH_FIRMWARE_DEFAULT
+            )
+        )
+
+    def _evaluate_device_health(self, now: float) -> None:
+        """Re-judge the health thresholds against the current snapshot.
+
+        Only devices that checked in on THIS poll are judged, for the same
+        reason ``_evaluate_relay_faults`` does it: a device that freezes
+        keeps re-serving its last payload for as long as the cloud caches
+        it, so counting polls would let one stale snapshot be repeated into
+        a verdict — and by the same token a repeated payload must not be
+        allowed to clear one either.
+
+        Unlike the relay detector, clearing is immediate on the first
+        contradicting check-in rather than delayed. The asymmetry there
+        exists because a welded contact can produce an innocent-looking
+        sample in the middle of a live fault; nothing here can. A device
+        that now reports 45 °C is not hiding a hot chip, so holding the
+        finding open for another five minutes would only mean showing the
+        user something that has stopped being true.
+        """
+        if not self.device_health_detection:
+            if self.device_health:
+                self.device_health.clear()
+                self._health_streak.clear()
+                self._health_since.clear()
+            async_manage_device_health_issue(
+                self.hass, self._entry, active=False, findings={}, names={}
+            )
+            return
+
+        include_firmware = self.device_health_firmware
+
+        for device_id, info in self.devices.items():
+            if not self.is_enabled(device_id):
+                continue
+            # ``_record_checkin`` stamps this poll's ``now`` on the record
+            # exactly when the payload fingerprint changed, so equality here
+            # IS "the device reported something new this time round".
+            record = self.checkins.get(device_id)
+            if record is None or record.last_checkin != now:
+                continue
+
+            findings = evaluate_device_health(
+                info.get("status", {}), include_firmware=include_firmware
+            )
+            present = {finding_key(device_id, f): f for f in findings}
+
+            # Findings that vanished on a fresh check-in lose their history
+            # outright, so a flapping value has to serve both gates again
+            # from scratch rather than accumulating a streak over an hour.
+            for key in [
+                k for k in self._health_streak if k[0] == device_id
+            ]:
+                if key not in present:
+                    del self._health_streak[key]
+                    self._health_since.pop(key, None)
+
+            confirmed: list[HealthFinding] = []
+            for key, finding in present.items():
+                self._health_streak[key] = self._health_streak.get(key, 0) + 1
+                self._health_since.setdefault(key, now)
+                if health_verdict(
+                    self._health_streak[key], self._health_since[key], now
+                ):
+                    confirmed.append(finding)
+
+            if confirmed:
+                self.device_health[device_id] = tuple(sorted(confirmed))
+            else:
+                self.device_health.pop(device_id, None)
+
+        # Devices the user unticked (or that left the account) must not keep
+        # a card alive: the finding is about hardware we no longer look at.
+        # Their streak history goes with them — it is only ever pruned on a
+        # fresh check-in, and a device that has left will never file one, so
+        # without this the maps would keep every departed device forever.
+        # Derived from the streak map as well as the verdicts, because a
+        # device can leave while a finding of its own is still too young to
+        # have been published.
+        gone = {
+            device_id
+            for device_id in {*self.device_health, *(k[0] for k in self._health_streak)}
+            if device_id not in self.devices or not self.is_enabled(device_id)
+        }
+        for device_id in gone:
+            self.device_health.pop(device_id, None)
+        for key in [k for k in self._health_streak if k[0] in gone]:
+            del self._health_streak[key]
+            self._health_since.pop(key, None)
+
+        async_manage_device_health_issue(
+            self.hass,
+            self._entry,
+            active=bool(self.device_health),
+            findings=dict(self.device_health),
+            names=self._display_names(set(self.device_health)),
+        )
+
+    def health_findings(self, device_id: str) -> tuple[HealthFinding, ...]:
+        """Confirmed findings for one device, empty when it is healthy."""
+        return self.device_health.get(device_id, ())
 
     # ── Deep-sleep freshness bookkeeping (#13) ────────────────────────
 
@@ -859,6 +1001,7 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         self._evaluate_missing_devices(set(new_devices))
         # Reads ``self.devices``, so it must stay below the assignment above.
         self._evaluate_relay_faults(now)
+        self._evaluate_device_health(now)
 
         return new_devices
 

--- a/custom_components/shelly_cloud_diy/device_health.py
+++ b/custom_components/shelly_cloud_diy/device_health.py
@@ -1,0 +1,415 @@
+"""Threshold checks on the status snapshot we already poll ("Doctor").
+
+Every input below is a field the coordinator receives on each ordinary
+``/device/all_status`` poll and today throws away. Reading it costs **no
+extra request**, no extra credential and nothing from Shelly's 1 req/s
+budget — the only thing this module adds is an interpretation.
+
+The thresholds were chosen against a real 64-device account
+(``.planning/messungen/snapshot.json``, 2026-09-04), which is also why they
+are not hypothetical: that sample already contains a device at -82 dBm, a
+switch running at 78.5 °C and a component reporting ``errors: ["read"]``.
+
+**Which devices are judged, and why not the rest**
+
+* **Gen2+/RPC devices** get the full set. Every device-wide input (Wi-Fi
+  signal, free RAM, free filesystem, pending restart, pending firmware) is
+  present on 35/35 of them in the sample; component temperature and
+  component errors exist only where the device has such a component.
+* **BLE/gateway-bridged devices** (``_dev_info.gen == "GBLE"``) get exactly
+  one check: the RSSI their bridging gateway reports for them. They carry
+  none of the Gen2 fields, and judging a device against a field it does not
+  have would turn "unknown" into "unhealthy" — the one mistake a health
+  check must never make. Their ``devicepower:0.battery.V`` and ``.low`` are
+  ``null`` on 28/29 and 29/29 respectively, so neither is usable; the
+  battery *percent* is already a first-class entity and is not duplicated
+  here as a finding.
+* **Gen1 devices are skipped entirely.** No Gen1 device appears in any
+  payload ever recorded from this account, so every Gen1 threshold would
+  rest on vendor documentation rather than on something measured — the
+  mistake that produced issue #32. A check nobody can verify is worse than
+  no check.
+
+**Own heat only.** The temperature check reads a component's *nested*
+temperature (``switch:0.temperature.tC``) and deliberately ignores a
+standalone ``temperature:<id>`` component: that one is an external probe on
+a Shelly Add-on, measuring the world rather than the device. A probe in a
+boiler flow pipe or a sauna is above 70 °C by design and the payload offers
+no way to tell it apart from an overheating device. The check still has an
+off switch in the options, the same escape hatch the relay-fault detector
+offers for two-way circuits.
+
+Kept free of Home Assistant imports apart from the shared generation
+detection in ``const`` — duplicating that regex to buy import purity would
+mean two definitions of "is this a Gen2 device" that can drift apart.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from .const import device_gen
+
+# ── Wi-Fi signal ──────────────────────────────────────────────────────
+#
+# -70 dBm is the point where a 2.4 GHz link stops having headroom: it still
+# works, but retransmissions climb and a microwave oven or a neighbouring
+# AP is enough to drop it. -85 dBm is close to the noise floor, where the
+# link survives only because Shelly traffic is tiny and infrequent.
+# Measured range in the sample: -82 … -31 dBm, so the warning line already
+# fires on real hardware while the error line does not.
+RSSI_WARNING_DBM = -70
+RSSI_ERROR_DBM = -85
+
+# ── Device temperature ────────────────────────────────────────────────
+#
+# Shelly rates its Gen2 hardware for 40 °C ambient and its own components
+# well above 70 °C, so 70 is not "about to fail" — it is "this is running
+# hotter than the rest of the fleet and that is usually an installation
+# problem", typically a device buried in an insulated wall box next to a
+# dimmer. 85 °C is where the device's own overtemperature protection starts
+# to become relevant. Measured range: 36.6 … 78.5 °C.
+TEMPERATURE_WARNING_C = 70.0
+TEMPERATURE_ERROR_C = 85.0
+
+# ── Free memory and free filesystem ───────────────────────────────────
+#
+# Expressed as a fraction of the device's own total, because a Gen2 device
+# has ~256 KB of RAM and a Gen3 more: an absolute byte floor would mean a
+# different thing on each. Below 20 % free a device can still run but has
+# no room for a script, an OTA image or a burst of MQTT; below 10 % Shelly
+# firmware starts refusing work and rebooting. The whole sample sits
+# between 30.4 % and 54.2 % free RAM and 25.0 % and 50.4 % free filesystem,
+# so neither line fires on healthy hardware.
+FREE_WARNING_FRACTION = 0.20
+FREE_ERROR_FRACTION = 0.10
+
+# ── The two gates before anything is announced ────────────────────────
+#
+# Mirrors the relay-fault detector and the rate-limit gate: a streak AND a
+# wall-clock floor, both of which have to hold.
+#
+# The count is in CHECK-INS, not polls — three times the device itself said
+# so, not three times we asked. A device that freezes keeps re-serving its
+# last payload for as long as the cloud caches it, so counting polls would
+# let a single snapshot be repeated into a verdict.
+#
+# Three rather than the relay detector's five, because the evidence here is
+# not a contradiction that needs corroborating: a temperature reading is
+# self-contained, and the cost of being wrong is a card, not an accusation
+# that someone's actuator is defective. 300 s rather than 120 s for the
+# opposite reason — none of these findings is urgent, and the one thing
+# that would ruin the card is firing it at a device that is briefly warm
+# after a firmware flash or briefly short of RAM while a script starts. At
+# the 5 s default poll the streak is served in ~15 s, so the time floor is
+# the binding gate on every device that reports faster than once every
+# 100 s.
+HEALTH_MIN_STREAK = 3
+HEALTH_MIN_SECONDS = 300.0
+
+# Severities. Deliberately a plain string rather than an enum: these travel
+# into a repair-card placeholder and into diagnostics, and both want text.
+SEVERITY_INFO = "info"
+SEVERITY_WARNING = "warning"
+SEVERITY_ERROR = "error"
+
+CHECK_WIFI = "wifi_signal"
+CHECK_TEMPERATURE = "temperature"
+CHECK_RAM = "ram"
+CHECK_FILESYSTEM = "filesystem"
+CHECK_RESTART = "restart_required"
+CHECK_COMPONENT_ERROR = "component_error"
+CHECK_FIRMWARE = "firmware_update"
+
+# Short English labels for the aggregated repair card. They are rendered
+# inside a translated description as a placeholder, so they stay terse and
+# recognisable rather than trying to be a sentence.
+CHECK_LABELS: dict[str, str] = {
+    CHECK_WIFI: "Wi-Fi signal",
+    CHECK_TEMPERATURE: "Temperature",
+    CHECK_RAM: "Free memory",
+    CHECK_FILESYSTEM: "Free storage",
+    CHECK_RESTART: "Restart pending",
+    CHECK_COMPONENT_ERROR: "Component error",
+    CHECK_FIRMWARE: "Firmware update",
+}
+
+# ``<type>:<id>`` — the shape of every Gen2 component key. Anything without
+# the numeric suffix (``sys``, ``wifi``, ``cloud``, ``ws``) is a singleton
+# block, not a component, and is read by name where it is wanted.
+_COMPONENT_KEY_RE = re.compile(r"^([a-z_]+):(\d+)$")
+
+
+@dataclass(frozen=True, order=True)
+class HealthFinding:
+    """One threshold crossing on one device.
+
+    ``component`` is the status key the finding came from — a real
+    component (``switch:0``, ``temperature:100``) or the device-wide block
+    it was read out of (``sys``, ``wifi``, ``reporter``). ``detail`` carries the measured value, because the
+    number is the whole argument: "this device is warm" is an opinion,
+    "78.5 °C" is something the user can act on or dismiss.
+    """
+
+    check: str
+    component: str
+    severity: str
+    detail: str
+
+    @property
+    def label(self) -> str:
+        """Human name of the check, for the aggregated card."""
+        return CHECK_LABELS.get(self.check, self.check)
+
+
+def _as_number(value: Any) -> float | None:
+    """Return ``value`` as a float, or None if it is not a usable number.
+
+    ``bool`` is rejected explicitly: it is a subclass of ``int`` in Python,
+    and a device that reports ``tC: true`` would otherwise be measured at
+    one degree.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _rssi_finding(component: str, value: Any) -> HealthFinding | None:
+    """Judge one RSSI reading, whether Wi-Fi or gateway-reported."""
+    rssi = _as_number(value)
+    # A real RSSI is negative. Zero (and anything above it) is what a device
+    # reports when it has no measurement, not a perfect link, so it must not
+    # be read as "excellent" and must not be read as "unhealthy" either.
+    if rssi is None or rssi >= 0:
+        return None
+    if rssi <= RSSI_ERROR_DBM:
+        severity = SEVERITY_ERROR
+    elif rssi <= RSSI_WARNING_DBM:
+        severity = SEVERITY_WARNING
+    else:
+        return None
+    return HealthFinding(CHECK_WIFI, component, severity, f"{rssi:.0f} dBm")
+
+
+def _temperature_findings(status: dict[str, Any]) -> list[HealthFinding]:
+    """Every component that reports its OWN heat and runs hot.
+
+    Only the nested shape counts — ``switch:0.temperature.tC``,
+    ``light:0.temperature.tC`` — because that is a component measuring
+    itself. A standalone ``temperature:<id>`` component is the opposite: it
+    is an *external* probe on a Shelly Add-on, measuring the world. A sensor
+    in a boiler flow pipe or a sauna sits above 70 °C by design, and the
+    payload gives us nothing to tell that apart from an overheating device.
+
+    That exclusion costs nothing measurable: in the 64-device sample both
+    hot readings (71.3 °C and 78.5 °C) come from ``switch:0``, and every
+    standalone ``temperature:<id>`` present is either a BLU ambient sensor
+    around 25 °C or an add-on channel with ``errors: ["read"]`` — which is
+    still judged, by the component-error check where it belongs.
+    """
+    findings: list[HealthFinding] = []
+    for key, payload in status.items():
+        match = _COMPONENT_KEY_RE.match(key) if isinstance(key, str) else None
+        if match is None or not isinstance(payload, dict):
+            continue
+        if match.group(1) == "temperature":
+            continue
+        nested = payload.get("temperature")
+        raw = nested.get("tC") if isinstance(nested, dict) else None
+        celsius = _as_number(raw)
+        if celsius is None:
+            continue
+        if celsius >= TEMPERATURE_ERROR_C:
+            severity = SEVERITY_ERROR
+        elif celsius >= TEMPERATURE_WARNING_C:
+            severity = SEVERITY_WARNING
+        else:
+            continue
+        findings.append(
+            HealthFinding(
+                CHECK_TEMPERATURE, key, severity, f"{celsius:.1f} °C"
+            )
+        )
+    return findings
+
+
+def _free_finding(
+    check: str, component: str, free: Any, size: Any
+) -> HealthFinding | None:
+    """Judge a free/total pair as a fraction of the device's own capacity."""
+    free_value = _as_number(free)
+    size_value = _as_number(size)
+    if free_value is None or size_value is None or size_value <= 0:
+        return None
+    fraction = free_value / size_value
+    if fraction < FREE_ERROR_FRACTION:
+        severity = SEVERITY_ERROR
+    elif fraction < FREE_WARNING_FRACTION:
+        severity = SEVERITY_WARNING
+    else:
+        return None
+    return HealthFinding(
+        check, component, severity, f"{fraction * 100:.0f} % free"
+    )
+
+
+def _component_error_findings(status: dict[str, Any]) -> list[HealthFinding]:
+    """Components that are telling us themselves that something is wrong.
+
+    This is the one check with no threshold to argue about: the device has
+    already made the judgement and put it in an ``errors`` list. Measured
+    on real hardware as ``temperature:100 → ["read"]`` (an add-on probe
+    that is wired but not answering) and ``light:1 → ["cal_abort:no_load"]``.
+    """
+    findings: list[HealthFinding] = []
+    for key, payload in status.items():
+        match = _COMPONENT_KEY_RE.match(key) if isinstance(key, str) else None
+        if match is None or not isinstance(payload, dict):
+            continue
+        errors = payload.get("errors")
+        if not isinstance(errors, list) or not errors:
+            continue
+        detail = ", ".join(str(err) for err in errors)
+        findings.append(
+            HealthFinding(CHECK_COMPONENT_ERROR, key, SEVERITY_ERROR, detail)
+        )
+    return findings
+
+
+def _firmware_finding(sys_block: dict[str, Any]) -> HealthFinding | None:
+    """Report a pending firmware update as information, never as a fault.
+
+    24 of 35 Gen2 devices in the measured account had one pending. A finding
+    that fires on two thirds of a fleet is wallpaper, so this one is behind
+    its own opt-in and carries the lowest severity there is.
+    """
+    updates = sys_block.get("available_updates")
+    if not isinstance(updates, dict) or not updates:
+        return None
+    versions = []
+    for channel in ("stable", "beta"):
+        entry = updates.get(channel)
+        if isinstance(entry, dict) and entry.get("version"):
+            versions.append(f"{channel} {entry['version']}")
+    detail = ", ".join(versions) if versions else "available"
+    return HealthFinding(CHECK_FIRMWARE, "sys", SEVERITY_INFO, detail)
+
+
+def evaluate_device_health(
+    status: dict[str, Any], *, include_firmware: bool = False
+) -> list[HealthFinding]:
+    """Return every threshold crossing in one device's status snapshot.
+
+    Pure: same snapshot in, same findings out, no clock and no state. The
+    decision about whether a finding has lasted long enough to be worth
+    telling anyone about belongs to the caller (see the gates in
+    ``coordinator._evaluate_device_health``), because that decision needs a
+    history this function deliberately does not have.
+    """
+    if not isinstance(status, dict) or not status:
+        return []
+
+    gen = device_gen(status)
+
+    if gen == "GBLE":
+        # The reduced set, and it really is one check. ``reporter.rssi`` is
+        # the gateway's view of the beacon, so a finding here means "the
+        # bridge barely hears this sensor", which is the one actionable
+        # thing about a BLU device we can see from the cloud at all.
+        reporter = status.get("reporter")
+        if not isinstance(reporter, dict):
+            return []
+        finding = _rssi_finding("reporter", reporter.get("rssi"))
+        return [finding] if finding else []
+
+    if gen != "G2":
+        # Gen1 (and anything unrecognised). See the module docstring: no
+        # measured payload exists, so there is nothing honest to check.
+        return []
+
+    findings: list[HealthFinding] = []
+
+    wifi = status.get("wifi")
+    if isinstance(wifi, dict):
+        if finding := _rssi_finding("wifi", wifi.get("rssi")):
+            findings.append(finding)
+
+    findings.extend(_temperature_findings(status))
+    findings.extend(_component_error_findings(status))
+
+    sys_block = status.get("sys")
+    if isinstance(sys_block, dict):
+        if finding := _free_finding(
+            CHECK_RAM, "sys", sys_block.get("ram_free"), sys_block.get("ram_size")
+        ):
+            findings.append(finding)
+        if finding := _free_finding(
+            CHECK_FILESYSTEM, "sys",
+            sys_block.get("fs_free"), sys_block.get("fs_size"),
+        ):
+            findings.append(finding)
+        if sys_block.get("restart_required"):
+            # Never observed true in the measured sample — coded from the
+            # field's presence (35/35) and documented as untested rather
+            # than claimed as verified.
+            findings.append(
+                HealthFinding(
+                    CHECK_RESTART, "sys", SEVERITY_ERROR,
+                    "configuration change not applied yet",
+                )
+            )
+        if include_firmware and (finding := _firmware_finding(sys_block)):
+            findings.append(finding)
+
+    return sorted(findings)
+
+
+def health_verdict(
+    streak: int, first_seen: float | None, now: float
+) -> bool:
+    """True when one finding has persisted long enough to be worth saying.
+
+    There is no matching ``health_clear_verdict``. Clearing is immediate on
+    the first check-in that no longer carries the finding, which is
+    deliberately *not* slower than raising: a transient 71 °C reading that
+    falls back to 60 °C has stopped being true, and the relay detector's
+    asymmetry exists only because a welded contact can produce an innocent
+    sample mid-fault. Nothing measured here can.
+    """
+    return (
+        streak >= HEALTH_MIN_STREAK
+        and first_seen is not None
+        and (now - first_seen) >= HEALTH_MIN_SECONDS
+    )
+
+
+def finding_key(device_id: str, finding: HealthFinding) -> tuple[str, str, str]:
+    """Identity of a finding across polls, for the streak bookkeeping.
+
+    The severity and the measured value are deliberately NOT part of it: a
+    device drifting from -71 to -73 dBm is the same finding getting slightly
+    worse, and restarting its clock on every fluctuation would mean a
+    genuinely borderline link could never complete the streak.
+    """
+    return (device_id, finding.check, finding.component)
+
+
+def summarise_findings(
+    findings: dict[str, tuple[HealthFinding, ...]]
+) -> str:
+    """Render "which kinds of finding, how many" for the aggregated card.
+
+    Bounded by construction — there are seven checks — so unlike the device
+    list this needs no truncation. Counts findings, not devices: one device
+    with five dead add-on probes is five component errors, and collapsing
+    that to "1" would understate what the user is looking at.
+    """
+    counts: dict[str, int] = {}
+    for device_findings in findings.values():
+        for finding in device_findings:
+            counts[finding.check] = counts.get(finding.check, 0) + 1
+    ordered = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return ", ".join(
+        f"{CHECK_LABELS.get(check, check)} ({count})" for check, count in ordered
+    )

--- a/custom_components/shelly_cloud_diy/diagnostics.py
+++ b/custom_components/shelly_cloud_diy/diagnostics.py
@@ -27,6 +27,8 @@ from .const import (
     OFFLINE_AFTER_DEFAULT,
     POLL_INTERVAL_DEFAULT,
     RELAY_FAULT_DETECTION_DEFAULT,
+    device_gen,
+    is_gen2_status,
 )
 from .coordinator import sleep_period_s
 from .services.fleet_map import (
@@ -62,6 +64,25 @@ KNOWN_OPTION_KEYS = frozenset(
 # devices). The technical control fields (mode, white, gain, brightness,
 # rgb, output, …) are deliberately kept — they are the point of the dump.
 DEVICE_TO_REDACT = {"name", "cloud_name", "ssid", "sta_ip", "ip", "mac"}
+
+# Top-level status keys the coverage report never counts as a gap. Each was
+# judged on its own; the list is short on purpose, because every key excluded
+# here is a gap that can no longer be seen.
+#
+#   _updated, _dev_info   written by our own coordinator, not by the device
+#   serial, ts            the payload's revision counter and its timestamp
+#   id, code              the device's own component id and model code
+#
+# Deliberately NOT excluded, although both are tempting:
+#
+#   sys        carries uptime, RAM and filesystem headroom and the pending
+#              firmware version. None of it is an entity today, and that is
+#              a real gap the report should keep saying out loud.
+#   reporter   the bridging gateway's RSSI — on a BLU device it is the only
+#              signal figure there is, and it has no description at all.
+STRUCTURAL_STATUS_KEYS = frozenset(
+    {"_updated", "_dev_info", "serial", "ts", "id", "code"}
+)
 
 
 def _config_diagnostics(
@@ -237,8 +258,130 @@ async def async_get_device_diagnostics(
         "redacted_keys": sorted(DEVICE_TO_REDACT),
         "sleep": _sleep_diagnostics(record),
         "reporting": _reporting_diagnostics(coordinator, device_id),
+        "coverage": _coverage_diagnostics(
+            coordinator, device_id, record.get("status") or {}
+        ),
         "record": async_redact_data(record, DEVICE_TO_REDACT),
     }
+
+
+def _entity_source_keys(entity: Any, status: dict[str, Any]) -> set[str]:
+    """Return the top-level status keys one entity reads.
+
+    Every entity stores the key it was built from, but under a different
+    attribute name per class — ``_component_key`` on the RPC entities,
+    ``_status_key`` on the Block and BLE ones — and the Gen1 entities whose
+    reading is a bare top-level flag (``motion``, ``flood``) keep it in
+    ``_attr_key`` with no container at all. Reading all three and keeping
+    only what is actually a key of this payload covers every shape without
+    the report having to know the class hierarchy.
+    """
+    keys: set[str] = set()
+    for attribute in ("_component_key", "_status_key", "_attr_key"):
+        value = getattr(entity, attribute, None)
+        if isinstance(value, str) and value in status:
+            keys.add(value)
+    return keys
+
+
+def _coverage_diagnostics(
+    coordinator: Any, device_id: str, status: dict[str, Any]
+) -> dict[str, Any]:
+    """Report which parts of this device's payload produce no entity.
+
+    Derived from the builders, not from the description tables. That
+    distinction is the whole point: all four dead-description bugs (#38,
+    #41, #42 and the Wi-Fi RSSI) were entries that existed in a table while
+    no builder ever looked them up, so a table-derived report would have
+    called every one of them "covered" and found nothing.
+
+    So the real creation functions run here, against a throwaway ``created``
+    set, and the answer is assembled from the entities they actually return.
+    The two device-wide binary sensors (Reporting, Relay fault) are left out
+    because they derive from no single status key and would only blur the
+    picture.
+
+    Key NAMES only, never values — this block sits next to a redacted dump
+    and must not become a way around it.
+
+    Never raises. A user downloads this from the device page to attach to a
+    bug report; a coverage report that cannot be produced is worth far less
+    than the raw status next to it, so any failure degrades to an ``error``
+    string and the rest of the file survives.
+    """
+    try:
+        if not status:
+            return {"note": "no status in the current snapshot"}
+
+        # Imported here rather than at module scope: the platforms pull in
+        # the whole entity stack, and a diagnostics module has no business
+        # making that a hard import for every start.
+        from . import binary_sensor as binary_sensor_platform
+        from . import sensor as sensor_platform
+
+        # The same dispatch the two platforms make, so the report is judged
+        # against the builders that would really have run for this device.
+        # Labels are fixed here rather than read off the function, so a
+        # failure names the builder that was meant to run.
+        gen = device_gen(status)
+        if gen == "GBLE":
+            builders = (
+                ("sensor.ble", sensor_platform._create_ble_sensors),
+                (
+                    "binary_sensor.ble",
+                    binary_sensor_platform._create_ble_binary_sensors,
+                ),
+            )
+        elif is_gen2_status(status):
+            builders = (
+                ("sensor.rpc", sensor_platform._create_rpc_sensors),
+                ("binary_sensor.rpc", binary_sensor_platform._create_rpc_sensors),
+            )
+        else:
+            builders = (
+                ("sensor.block", sensor_platform._create_block_sensors),
+                ("binary_sensor.block", binary_sensor_platform._create_block_sensors),
+            )
+
+        covered: set[str] = set()
+        entity_count = 0
+        builder_errors: list[str] = []
+
+        for label, build in builders:
+            # A fresh throwaway set per builder, because that is what
+            # production does: the sensor and binary-sensor platforms each
+            # keep their own. Sharing one here could let a unique-id collision
+            # between the two swallow an entity and invent a gap.
+            try:
+                entities = build(device_id, status, set(), coordinator)
+            except Exception as err:  # noqa: BLE001 - see docstring
+                builder_errors.append(f"{label}: {type(err).__name__}")
+                continue
+            entity_count += len(entities)
+            for entity in entities:
+                covered |= _entity_source_keys(entity, status)
+
+        uncovered = sorted(
+            key
+            for key in status
+            if key not in covered and key not in STRUCTURAL_STATUS_KEYS
+        )
+
+        report: dict[str, Any] = {
+            "generation": gen,
+            "entities_built": entity_count,
+            "covered_keys": sorted(covered),
+            "uncovered_keys": uncovered,
+            "uncovered_count": len(uncovered),
+            "ignored_keys": sorted(
+                key for key in status if key in STRUCTURAL_STATUS_KEYS
+            ),
+        }
+        if builder_errors:
+            report["builder_errors"] = builder_errors
+        return report
+    except Exception as err:  # noqa: BLE001 - see docstring
+        return {"error": f"{type(err).__name__}: {err}"}
 
 
 def _reporting_diagnostics(

--- a/custom_components/shelly_cloud_diy/repair_issues.py
+++ b/custom_components/shelly_cloud_diy/repair_issues.py
@@ -16,14 +16,14 @@ non-reserved filename sidesteps the platform contract entirely at zero
 cost; if a real fix flow is ever wanted, add a proper ``repairs.py``
 exposing ``async_create_fix_flow`` at that point.
 
-All four issues are informational and non-persistent. None of them can
+All five issues are informational and non-persistent. None of them can
 be resolved by an in-process button press — a sustained rate limit, a
 device that vanished from the Shelly account, an unreachable local
-gateway and a welded relay contact are all resolved outside Home
-Assistant — so a confirm-only Fix button would lie to the user and the
-card would simply reappear on the next poll. Every condition is
-re-derived from live polling (or the next sync cycle) after a restart,
-so nothing needs to be persisted.
+gateway, a welded relay contact and a device running hot or short of
+memory are all resolved outside Home Assistant — so a confirm-only Fix
+button would lie to the user and the card would simply reappear on the
+next poll. Every condition is re-derived from live polling (or the next
+sync cycle) after a restart, so nothing needs to be persisted.
 
 Issue ids are suffixed with the config entry id: the issue registry keys
 on ``(domain, issue_id)`` alone, so a second Shelly account would
@@ -37,10 +37,13 @@ from homeassistant.core import callback
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN, ORPHAN_FLOOR_ABS, ORPHAN_FLOOR_FRAC
+from .device_health import summarise_findings
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
+
+    from .device_health import HealthFinding
 
 
 # Both gates must hold. At the 5 s default poll interval the TIME gate is the
@@ -101,6 +104,7 @@ ISSUE_RATE_LIMITED = "rate_limited"
 ISSUE_MISSING_DEVICES = "missing_devices"
 ISSUE_HISTORY_IMPORT_FAILED = "history_import_failed"
 ISSUE_RELAY_FAULT = "relay_fault"
+ISSUE_DEVICE_HEALTH = "device_health"
 
 
 # ── Pure verdict helpers (no hass — unit-testable) ────────────────────
@@ -351,6 +355,48 @@ def async_manage_relay_fault_issue(
 
 
 @callback
+def async_manage_device_health_issue(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    *,
+    active: bool,
+    findings: dict[str, tuple[HealthFinding, ...]],
+    names: dict[str, str],
+) -> None:
+    """Create or clear the aggregated device-health issue for ``entry``.
+
+    **One card for the whole account, never one per device.** The account
+    this was measured against would have produced 24 firmware cards alone;
+    a repair panel with two dozen rows from a single integration is not a
+    warning, it is a wall the user scrolls past.
+
+    Upserts for the same reason as the missing-devices and relay cards: a
+    second device going hot must not silently un-ignore the first one,
+    which a delete-then-create would do.
+    """
+    iid = issue_id(ISSUE_DEVICE_HEALTH, entry.entry_id)
+    if active:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            iid,
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_DEVICE_HEALTH,
+            translation_placeholders={
+                "entry_title": entry.title,
+                "count": str(len(findings)),
+                "summary": summarise_findings(findings),
+                "devices": format_device_list(set(findings), names),
+            },
+        )
+    else:
+        # A no-op when the id was never raised, so no existence probe.
+        ir.async_delete_issue(hass, DOMAIN, iid)
+
+
+@callback
 def async_manage_history_import_issue(
     hass: HomeAssistant, entry: ConfigEntry, *, active: bool
 ) -> None:
@@ -382,6 +428,7 @@ def async_clear_entry_issues(
         ISSUE_MISSING_DEVICES,
         ISSUE_HISTORY_IMPORT_FAILED,
         ISSUE_RELAY_FAULT,
+        ISSUE_DEVICE_HEALTH,
     ):
         # ``async_delete_issue`` on a non-existent id is an explicit no-op.
         ir.async_delete_issue(hass, DOMAIN, issue_id(kind, entry.entry_id))

--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -194,6 +194,27 @@ def _create_block_sensors(
                     coordinator, device_id, desc, 0, key, "tC"
                 ))
 
+    # Wi-Fi signal strength. The description has existed since the first
+    # release but no builder ever looked it up, so the reading never became an
+    # entity — the same dead-description gap as the returned energy in #38 and
+    # the flood/smoke flags in #41/#42.
+    #
+    # ⚠ Shape taken from the vendor Gen1 API documentation
+    # (https://shelly-api-docs.shelly.cloud/gen1/, /status), NOT measured: no
+    # Gen1 device appears in any payload recorded from a real account. The
+    # documented object is
+    # ``"wifi_sta": {"connected": true, "ssid": …, "ip": …, "rssi": -54}``.
+    wifi_sta = status.get("wifi_sta")
+    if isinstance(wifi_sta, dict) and wifi_sta.get("rssi") is not None:
+        desc = BLOCK_SENSORS.get(("wifi_sta", "rssi"))
+        if desc:
+            uid = f"{device_id}_wifi_sta_rssi"
+            if uid not in created:
+                created.add(uid)
+                entities.append(BlockSensor(
+                    coordinator, device_id, desc, 0, "wifi_sta", "rssi"
+                ))
+
     return entities
 
 
@@ -498,6 +519,31 @@ def _create_rpc_sensors(
                     entities.append(RpcVirtualSensor(
                         coordinator, device_id, comp_type, idx, key
                     ))
+
+    # Wi-Fi signal strength — ``wifi.rssi``. A top-level, non-indexed
+    # component, so it is read directly rather than through a
+    # ``<type>:<id>`` scan, the same way the Cloud binary sensor reads
+    # ``cloud.connected``.
+    #
+    # Present on 35 of 35 Gen2+ devices in the recorded account snapshot, and
+    # the description has existed since the first release — but no builder
+    # ever looked it up, so the reading never became an entity. Same
+    # dead-description gap as the returned energy in #38 and the flood alarms
+    # in #41/#42.
+    #
+    # Gated on a non-null value, not on the key: a device running without
+    # Wi-Fi (a Pro on Ethernet) still carries the component, and an entity
+    # that can only ever read "unknown" is worse than no entity.
+    wifi = status.get("wifi")
+    if isinstance(wifi, dict) and wifi.get("rssi") is not None:
+        desc = RPC_SENSORS.get("rssi")
+        if desc:
+            uid = f"{device_id}_wifi_rssi"
+            if uid not in created:
+                created.add(uid)
+                entities.append(RpcSensor(
+                    coordinator, device_id, desc, 0, "wifi", "rssi"
+                ))
 
     return entities
 
@@ -843,6 +889,11 @@ class BleBatteryPercentSensor(ShellyBaseEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    # Declared even though the reader below hard-codes it: this is the only
+    # way an outside caller can ask an entity which status key it consumes,
+    # which is how the diagnostics coverage report tells a surfaced part of
+    # the payload from an ignored one.
+    _status_key = "devicepower:0"
 
     def __init__(
         self,
@@ -873,6 +924,9 @@ class BleBatteryVoltageSensor(ShellyBaseEntity, SensorEntity):
     _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_suggested_display_precision = 2
+    # See BleBatteryPercentSensor: declared so the coverage report can see
+    # that this entity is what makes ``devicepower:0`` a surfaced key.
+    _status_key = "devicepower:0"
 
     def __init__(
         self,

--- a/custom_components/shelly_cloud_diy/strings.json
+++ b/custom_components/shelly_cloud_diy/strings.json
@@ -71,13 +71,17 @@
           "poll_interval": "Poll interval (seconds)",
           "offline_after_minutes": "Report a device as offline after (minutes)",
           "relay_fault_detection": "Warn about a relay that no longer opens",
-          "local_gateway_url": "Local gateway URL (optional, for EM historical data)"
+          "local_gateway_url": "Local gateway URL (optional, for EM historical data)",
+          "device_health_detection": "Warn about devices in poor health",
+          "device_health_firmware": "Count a pending firmware update as a finding"
         },
         "data_description": {
           "poll_interval": "3–60 s. Lower values feel snappier but consume more of Shelly's 1 req/s rate-limit budget.",
           "offline_after_minutes": "2–1440 min, default 30. Each device's \"Reporting\" sensor turns off once the device has been silent this long. It is only a base value: a device that is naturally quieter earns a wider window on its own, and battery or BLE devices are handled separately. Lowering it therefore mainly speeds up detection on devices that report continuously, such as power-metering plugs.",
           "relay_fault_detection": "On by default. Watches every switching channel that meters its own output and warns when the relay reports itself as open while a real load is still flowing through it — a contact that has welded shut. Turn this off if a Shelly of yours sits in a two-way circuit, where the other switch can push current through the meter while the relay is genuinely open.",
-          "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data."
+          "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data.",
+          "device_health_detection": "On by default. Interprets data every poll already returns: Wi-Fi signal (warning at -70 dBm, error at -85 dBm), component temperature (70 °C / 85 °C), free memory and free storage (under 20 % / 10 %), a restart the device is still waiting for, and any component reporting its own error. It costs no extra requests. Bluetooth (BLU) devices are judged only on the signal their gateway reports for them, and Gen1 devices are not judged at all. Only a component's own temperature counts, never an external Add-on probe.",
+          "device_health_firmware": "Off by default. Adds \"a firmware update is available\" as a finding. On a typical account most devices have one pending, so switching this on tends to keep the card permanently lit — which is exactly what stops you noticing the findings that matter."
         }
       },
       "devices": {
@@ -186,6 +190,10 @@
     "relay_fault": {
       "title": "A Shelly relay is no longer switching off",
       "description": "{count} switching channel(s) on {entry_title} reported the relay as **open** while the device's own power meter reported a load still flowing through it, for at least two minutes.\n\nDevice(s): {devices}\n\nThis is what a welded relay contact looks like. The actuator still accepts commands and still reports *off*, but the load never actually switches off — so anything that relies on switching it off (an automation, a schedule, a motion sensor) silently stops working, and the load keeps consuming power.\n\nWhat to do:\n\n1. Check whether the load really is still running. The \"Relay fault\" diagnostic sensor on the device carries the measured wattage as an attribute.\n2. If it is, treat the actuator as defective and plan to replace it. A contact that welds once tends to do it again, and it cannot be switched off in software — only at the breaker.\n3. If the load is genuinely not running, the wiring may be feeding current past this relay (for example a two-way circuit). You can switch this warning off in the integration options.\n\nThe warning clears on its own once the channel has agreed with its own meter again for five minutes."
+    },
+    "device_health": {
+      "title": "Some Shelly devices are reporting problems",
+      "description": "{count} device(s) on {entry_title} crossed a health threshold and stayed across it for at least five minutes.\n\nFindings: {summary}\n\nDevice(s): {devices}\n\nEverything behind this comes from the status data the integration already polls — nothing extra was requested from Shelly Cloud. What the individual findings mean:\n\n- **Wi-Fi signal** — the device sits at -70 dBm or worse. The link still works, but it retransmits a lot and the device will drop off the cloud more often than the rest of your fleet. Move the device, move the access point, or add one closer.\n- **Temperature** — a component reports 70 °C or more. Usually a device packed into an insulated wall box, or one switching more current than its installation allows for. Only a component's own temperature is judged; an external probe on a Shelly Add-on is not, because a sensor in a boiler pipe is hot by design.\n- **Free memory / Free storage** — under 20 % is left. Scripts, schedules and over-the-air updates need that room; below 10 % the firmware starts refusing work and rebooting.\n- **Restart pending** — a configuration change has not been applied yet. Restart the device from the Shelly app.\n- **Component error** — the device itself is reporting this one, most often a wired add-on sensor that no longer answers.\n- **Firmware update** — information only, and off by default. It appears here only if you switched it on in the options.\n\nThis is one card for the whole account, never one per device. It clears by itself as soon as every device is back below its thresholds, and the whole check can be switched off under Settings → Devices & services → Shelly Cloud DIY → Configure."
     }
   }
 }

--- a/custom_components/shelly_cloud_diy/translations/de.json
+++ b/custom_components/shelly_cloud_diy/translations/de.json
@@ -71,13 +71,17 @@
           "poll_interval": "Abfrageintervall (Sekunden)",
           "offline_after_minutes": "Gerät als offline melden nach (Minuten)",
           "relay_fault_detection": "Vor einem Relais warnen, das nicht mehr öffnet",
-          "local_gateway_url": "Lokale Gateway-URL (optional, für historische EM-Daten)"
+          "local_gateway_url": "Lokale Gateway-URL (optional, für historische EM-Daten)",
+          "device_health_detection": "Vor Geräten in schlechtem Zustand warnen",
+          "device_health_firmware": "Ausstehendes Firmware-Update als Befund werten"
         },
         "data_description": {
           "poll_interval": "3–60 s. Kleinere Werte fühlen sich flotter an, verbrauchen aber mehr von Shellys 1-req/s-Budget.",
           "offline_after_minutes": "2–1440 min, Standard 30. Der Sensor „Reporting“ eines Geräts fällt ab, sobald das Gerät so lange nichts mehr gemeldet hat. Das ist nur ein Basiswert: ein von Natur aus stilleres Gerät bekommt automatisch ein weiteres Fenster, Batterie- und BLE-Geräte werden getrennt behandelt. Ein kleinerer Wert beschleunigt die Erkennung deshalb vor allem bei Geräten, die durchgehend melden — etwa Zwischenstecker mit Leistungsmessung.",
           "relay_fault_detection": "Standardmäßig an. Beobachtet jeden Schaltkanal, der seinen eigenen Ausgang misst, und warnt, wenn das Relais sich als offen meldet, während weiterhin eine echte Last durch es fließt — ein verschweißter Kontakt. Abschalten, wenn ein Shelly in einer Wechselschaltung sitzt, wo der andere Schalter Strom durch die Messung schicken kann, obwohl das Relais wirklich offen ist.",
-          "local_gateway_url": "Nur nötig, wenn ein lokales Shelly-Gateway für historische Energiedaten genutzt wird."
+          "local_gateway_url": "Nur nötig, wenn ein lokales Shelly-Gateway für historische Energiedaten genutzt wird.",
+          "device_health_detection": "Standardmäßig an. Wertet aus, was jeder Abruf ohnehin liefert: WLAN-Signal (Warnung ab -70 dBm, Fehler ab -85 dBm), Komponententemperatur (70 °C / 85 °C), freier Speicher und freier Dateisystem-Platz (unter 20 % / 10 %), ein noch ausstehender Neustart sowie jede Komponente, die selbst einen Fehler meldet. Das kostet keine zusätzlichen Anfragen. Bluetooth-Geräte (BLU) werden nur nach dem Signal beurteilt, das ihr Gateway für sie meldet, Gen1-Geräte gar nicht. Gewertet wird nur die Eigenwärme einer Komponente, nie ein externer Fühler am Add-on.",
+          "device_health_firmware": "Standardmäßig aus. Ergänzt „Firmware-Update verfügbar“ als Befund. Auf einem typischen Konto hat die Mehrheit der Geräte eines offen — eingeschaltet leuchtet die Karte deshalb dauerhaft, und genau das sorgt dafür, dass die wichtigen Befunde untergehen."
         }
       },
       "devices": {
@@ -204,6 +208,10 @@
     "relay_fault": {
       "title": "Ein Shelly-Relais schaltet nicht mehr ab",
       "description": "{count} Schaltkanal/-kanäle von {entry_title} haben das Relais als **offen** gemeldet, während die geräteeigene Leistungsmessung weiterhin eine Last gemessen hat — mindestens zwei Minuten lang.\n\nGerät(e): {devices}\n\nSo sieht ein verschweißter Relaiskontakt aus. Der Aktor nimmt weiter Befehle an und meldet weiter *aus*, die Last schaltet aber nie wirklich ab — alles, was auf dem Abschalten beruht (eine Automation, ein Zeitplan, ein Bewegungsmelder), hört damit unbemerkt auf zu funktionieren, und die Last verbraucht weiter Strom.\n\nWas zu tun ist:\n\n1. Prüfen, ob die Last tatsächlich noch läuft. Der Diagnose-Sensor „Relay fault“ am Gerät führt die gemessene Leistung als Attribut mit.\n2. Wenn ja: den Aktor als defekt behandeln und den Austausch einplanen. Ein Kontakt, der einmal verschweißt, tut es wieder — und per Software ist er nicht mehr abzuschalten, nur noch über die Sicherung.\n3. Läuft die Last wirklich nicht, führt die Verdrahtung womöglich Strom an diesem Relais vorbei (etwa eine Wechselschaltung). Diese Warnung lässt sich in den Optionen der Integration abschalten.\n\nDie Warnung verschwindet von selbst, sobald der Kanal fünf Minuten lang wieder mit seiner eigenen Messung übereinstimmt."
+    },
+    "device_health": {
+      "title": "Einige Shelly-Geräte melden Probleme",
+      "description": "{count} Gerät(e) in {entry_title} haben einen Gesundheits-Schwellwert überschritten und lagen mindestens fünf Minuten lang darüber.\n\nBefunde: {summary}\n\nGerät(e): {devices}\n\nAlles davon stammt aus den Statusdaten, die die Integration ohnehin abruft — bei der Shelly Cloud wurde nichts zusätzlich angefragt. Was die einzelnen Befunde bedeuten (die Bezeichnungen oben sind englisch, weil sie direkt aus der Auswertung kommen):\n\n- **Wi-Fi signal** — das Gerät liegt bei -70 dBm oder schlechter. Die Verbindung funktioniert noch, muss aber viel wiederholen; das Gerät fällt häufiger aus der Cloud als der Rest. Gerät versetzen, Access Point versetzen oder einen näheren ergänzen.\n- **Temperature** — eine Komponente meldet 70 °C oder mehr. Meist ein Gerät in einer gedämmten Unterputzdose oder eines, das mehr Strom schaltet, als der Einbauort verträgt. Bewertet wird nur die Eigenwärme einer Komponente; ein externer Fühler am Shelly Add-on nicht, weil ein Fühler im Heizungsvorlauf bauartbedingt heiß ist.\n- **Free memory / Free storage** — weniger als 20 % frei. Skripte, Zeitpläne und Firmware-Updates brauchen diesen Platz; unter 10 % verweigert die Firmware Arbeit und startet neu.\n- **Restart pending** — eine Konfigurationsänderung ist noch nicht übernommen. Gerät in der Shelly-App neu starten.\n- **Component error** — das meldet das Gerät selbst, meistens ein angeschlossener Add-on-Fühler, der nicht mehr antwortet.\n- **Firmware update** — reine Information und standardmäßig aus. Erscheint hier nur, wenn du es in den Optionen eingeschaltet hast.\n\nDas ist eine Karte für das gesamte Konto, nie eine pro Gerät. Sie verschwindet von selbst, sobald alle Geräte wieder unter ihren Schwellwerten liegen; die ganze Prüfung lässt sich unter Einstellungen → Geräte & Dienste → Shelly Cloud DIY → Konfigurieren abschalten."
     }
   }
 }

--- a/custom_components/shelly_cloud_diy/translations/en.json
+++ b/custom_components/shelly_cloud_diy/translations/en.json
@@ -71,13 +71,17 @@
           "poll_interval": "Poll interval (seconds)",
           "offline_after_minutes": "Report a device as offline after (minutes)",
           "relay_fault_detection": "Warn about a relay that no longer opens",
-          "local_gateway_url": "Local gateway URL (optional, for EM historical data)"
+          "local_gateway_url": "Local gateway URL (optional, for EM historical data)",
+          "device_health_detection": "Warn about devices in poor health",
+          "device_health_firmware": "Count a pending firmware update as a finding"
         },
         "data_description": {
           "poll_interval": "3–60 s. Lower values feel snappier but consume more of Shelly's 1 req/s rate-limit budget.",
           "offline_after_minutes": "2–1440 min, default 30. Each device's \"Reporting\" sensor turns off once the device has been silent this long. It is only a base value: a device that is naturally quieter earns a wider window on its own, and battery or BLE devices are handled separately. Lowering it therefore mainly speeds up detection on devices that report continuously, such as power-metering plugs.",
           "relay_fault_detection": "On by default. Watches every switching channel that meters its own output and warns when the relay reports itself as open while a real load is still flowing through it — a contact that has welded shut. Turn this off if a Shelly of yours sits in a two-way circuit, where the other switch can push current through the meter while the relay is genuinely open.",
-          "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data."
+          "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data.",
+          "device_health_detection": "On by default. Interprets data every poll already returns: Wi-Fi signal (warning at -70 dBm, error at -85 dBm), component temperature (70 °C / 85 °C), free memory and free storage (under 20 % / 10 %), a restart the device is still waiting for, and any component reporting its own error. It costs no extra requests. Bluetooth (BLU) devices are judged only on the signal their gateway reports for them, and Gen1 devices are not judged at all. Only a component's own temperature counts, never an external Add-on probe.",
+          "device_health_firmware": "Off by default. Adds \"a firmware update is available\" as a finding. On a typical account most devices have one pending, so switching this on tends to keep the card permanently lit — which is exactly what stops you noticing the findings that matter."
         }
       },
       "devices": {
@@ -204,6 +208,10 @@
     "relay_fault": {
       "title": "A Shelly relay is no longer switching off",
       "description": "{count} switching channel(s) on {entry_title} reported the relay as **open** while the device's own power meter reported a load still flowing through it, for at least two minutes.\n\nDevice(s): {devices}\n\nThis is what a welded relay contact looks like. The actuator still accepts commands and still reports *off*, but the load never actually switches off — so anything that relies on switching it off (an automation, a schedule, a motion sensor) silently stops working, and the load keeps consuming power.\n\nWhat to do:\n\n1. Check whether the load really is still running. The \"Relay fault\" diagnostic sensor on the device carries the measured wattage as an attribute.\n2. If it is, treat the actuator as defective and plan to replace it. A contact that welds once tends to do it again, and it cannot be switched off in software — only at the breaker.\n3. If the load is genuinely not running, the wiring may be feeding current past this relay (for example a two-way circuit). You can switch this warning off in the integration options.\n\nThe warning clears on its own once the channel has agreed with its own meter again for five minutes."
+    },
+    "device_health": {
+      "title": "Some Shelly devices are reporting problems",
+      "description": "{count} device(s) on {entry_title} crossed a health threshold and stayed across it for at least five minutes.\n\nFindings: {summary}\n\nDevice(s): {devices}\n\nEverything behind this comes from the status data the integration already polls — nothing extra was requested from Shelly Cloud. What the individual findings mean:\n\n- **Wi-Fi signal** — the device sits at -70 dBm or worse. The link still works, but it retransmits a lot and the device will drop off the cloud more often than the rest of your fleet. Move the device, move the access point, or add one closer.\n- **Temperature** — a component reports 70 °C or more. Usually a device packed into an insulated wall box, or one switching more current than its installation allows for. Only a component's own temperature is judged; an external probe on a Shelly Add-on is not, because a sensor in a boiler pipe is hot by design.\n- **Free memory / Free storage** — under 20 % is left. Scripts, schedules and over-the-air updates need that room; below 10 % the firmware starts refusing work and rebooting.\n- **Restart pending** — a configuration change has not been applied yet. Restart the device from the Shelly app.\n- **Component error** — the device itself is reporting this one, most often a wired add-on sensor that no longer answers.\n- **Firmware update** — information only, and off by default. It appears here only if you switched it on in the options.\n\nThis is one card for the whole account, never one per device. It clears by itself as soon as every device is back below its thresholds, and the whole check can be switched off under Settings → Devices & services → Shelly Cloud DIY → Configure."
     }
   }
 }

--- a/tests/test_coordinator_init.py
+++ b/tests/test_coordinator_init.py
@@ -48,6 +48,9 @@ REQUIRED = {
     "_relay_fault_since",
     "_relay_healthy_since",
     "relay_faults",
+    "_health_streak",
+    "_health_since",
+    "device_health",
 }
 
 

--- a/tests/test_coverage_report.py
+++ b/tests/test_coverage_report.py
@@ -1,0 +1,197 @@
+"""Unit tests for the payload-coverage block of the device diagnostics.
+
+The block answers one question: *which parts of this device's payload produce
+no entity at all?* It is builder-derived on purpose. A report built from the
+description tables would have called ``energyReturned`` (#38), ``flood:<id>``
+(#41), Gen1 ``flood`` / ``smoke`` (#42) and ``wifi.rssi`` covered — all four
+had a finished description and no builder — so it would have found none of
+the four bugs it exists to find.
+
+Two properties matter more than the numbers:
+
+* it must never raise. A user downloads this from the device page to attach
+  to a bug report, and a broken coverage block must not take the raw status
+  down with it.
+* it must report key names and never values, because it sits directly beside
+  a redacted dump.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.shelly_cloud_diy import binary_sensor as binary_sensor_platform
+from custom_components.shelly_cloud_diy import diagnostics
+from custom_components.shelly_cloud_diy import sensor as sensor_platform
+from custom_components.shelly_cloud_diy.diagnostics import (
+    STRUCTURAL_STATUS_KEYS,
+    _coverage_diagnostics,
+)
+
+DEVICE_ID = "a0dd6cffee01"
+
+
+class _FakeCoordinator:
+    """Minimal coordinator: entities only read ``.devices[id]['status']``."""
+
+    def __init__(self, status: dict[str, Any]) -> None:
+        self.devices = {
+            DEVICE_ID: {"status": status, "device_code": "SNSW-001X16EU", "online": True}
+        }
+        self.data = self.devices
+        self.last_update_success = True
+
+
+def _covered_gen2_status() -> dict[str, Any]:
+    """A Gen2 payload in which every non-structural key becomes an entity.
+
+    ``switch:0`` via the power sensor, ``cloud`` via the Cloud binary sensor,
+    ``wifi`` via the RSSI sensor wired alongside this report. The remaining
+    keys are the status envelope and must land in ``ignored_keys``.
+    """
+    return {
+        "switch:0": {"id": 0, "output": True, "apower": 12.3},
+        "cloud": {"connected": True},
+        "wifi": {"rssi": -55},
+        "id": 0,
+        "serial": 17,
+        "ts": 1756000000.0,
+        "code": "SNSW-001X16EU",
+        "_updated": "2026-09-04 10:00:00",
+        "_dev_info": {"gen": "G2"},
+    }
+
+
+def _report(status: dict[str, Any]) -> dict[str, Any]:
+    return _coverage_diagnostics(_FakeCoordinator(status), DEVICE_ID, status)
+
+
+def test_unknown_component_type_is_reported() -> None:
+    """A component we have no builder for must show up, not vanish silently.
+
+    This is the case idea 3 of the neighbour-ideas plan is about: today an
+    unrecognised ``<type>:<id>`` produces nothing and says nothing, so the
+    only evidence is a device with fewer entities than the user expected.
+    """
+    status = _covered_gen2_status()
+    status["quantum:0"] = {"id": 0, "spin": "up"}
+    status["telemetry"] = {"whatever": 1}
+
+    report = _report(status)
+
+    assert "quantum:0" in report["uncovered_keys"]
+    assert "telemetry" in report["uncovered_keys"]
+    assert report["uncovered_count"] == 2
+
+
+def test_fully_covered_device_reports_nothing_uncovered() -> None:
+    """No false alarms: a payload we fully surface must come back empty."""
+    report = _report(_covered_gen2_status())
+
+    assert report["uncovered_keys"] == []
+    assert report["uncovered_count"] == 0
+    assert report["generation"] == "G2"
+    assert set(report["covered_keys"]) == {"switch:0", "cloud", "wifi"}
+    assert set(report["ignored_keys"]) == set(STRUCTURAL_STATUS_KEYS)
+
+
+def test_wifi_rssi_counts_as_coverage() -> None:
+    """Pins the join the report is meant to prove.
+
+    Before the RSSI descriptions were wired, ``wifi`` was a key on 35 of 35
+    Gen2+ devices that produced no entity — exactly what this block is for.
+    """
+    status = _covered_gen2_status()
+    assert "wifi" in _report(status)["covered_keys"]
+
+    del status["wifi"]["rssi"]
+    assert "wifi" in _report(status)["uncovered_keys"]
+
+
+def test_a_raising_builder_does_not_propagate(monkeypatch) -> None:
+    """One broken builder must cost its half of the report, nothing more."""
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("builder exploded")
+
+    monkeypatch.setattr(sensor_platform, "_create_rpc_sensors", boom)
+
+    report = _report(_covered_gen2_status())
+
+    assert "error" not in report
+    assert report["builder_errors"] == ["sensor.rpc: RuntimeError"]
+    # The binary-sensor half still ran, so its keys are still accounted for.
+    assert "cloud" in report["covered_keys"]
+
+
+def test_both_builders_raising_still_returns_a_report(monkeypatch) -> None:
+    """The degenerate case: nothing built, and still a usable answer."""
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise ValueError("nope")
+
+    monkeypatch.setattr(sensor_platform, "_create_rpc_sensors", boom)
+    monkeypatch.setattr(binary_sensor_platform, "_create_rpc_sensors", boom)
+
+    report = _report(_covered_gen2_status())
+
+    assert report["entities_built"] == 0
+    assert len(report["builder_errors"]) == 2
+    assert "switch:0" in report["uncovered_keys"]
+
+
+def test_a_failure_outside_the_builders_degrades_to_an_error(monkeypatch) -> None:
+    """Anything unforeseen must still leave the rest of diagnostics intact."""
+
+    def boom(_status: dict[str, Any]) -> str:
+        raise TypeError("classification exploded")
+
+    monkeypatch.setattr(diagnostics, "device_gen", boom)
+
+    report = _report(_covered_gen2_status())
+
+    assert report == {"error": "TypeError: classification exploded"}
+
+
+def test_empty_status_is_not_an_error() -> None:
+    """A device we have never had a payload for is a note, not a failure."""
+    assert _report({}) == {"note": "no status in the current snapshot"}
+
+
+def test_ble_device_is_measured_against_the_ble_builders() -> None:
+    """BLU devices take the other dispatch branch and must be judged there.
+
+    ``input:0`` on a BLU button is a real, previously invisible gap: it is
+    absent from the BLE tables, so no entity is created for it — which is
+    precisely what the report should say.
+    """
+    status = {
+        "_dev_info": {"gen": "GBLE"},
+        "temperature:0": {"id": 0, "tC": 21.4},
+        "devicepower:0": {"id": 0, "battery": {"percent": 100, "V": None}},
+        "input:0": {"id": 0, "state": None, "percent": None, "errors": []},
+        "reporter": {"rssi": -71},
+        "packetid:0": {"id": 0, "packetid": 42},
+    }
+
+    report = _report(status)
+
+    assert report["generation"] == "GBLE"
+    assert set(report["covered_keys"]) == {"temperature:0", "devicepower:0"}
+    assert report["uncovered_keys"] == ["input:0", "packetid:0", "reporter"]
+
+
+def test_no_status_value_ever_reaches_the_report() -> None:
+    """Redaction discipline: key names only.
+
+    The block sits next to a dump that strips ``mac`` / ``ssid`` / ``ip``,
+    and a coverage report that echoed values would be a way straight around
+    that.
+    """
+    status = _covered_gen2_status()
+    status["wifi"] = {"rssi": -55, "ssid": "SECRET-NETWORK", "sta_ip": "10.9.9.9"}
+    status["sys"] = {"mac": "A0DD6CFFEE01"}
+
+    rendered = repr(_report(status))
+
+    for planted in ("SECRET-NETWORK", "10.9.9.9", "A0DD6CFFEE01", "SNSW-001X16EU"):
+        assert planted not in rendered

--- a/tests/test_dead_descriptions.py
+++ b/tests/test_dead_descriptions.py
@@ -1,0 +1,366 @@
+"""Guard: every entity description is actually reachable from a builder.
+
+Four bugs in one month had the same shape. A description sat complete in one
+of the tables in ``entities/descriptions.py`` — right name, right device
+class, right unit — and no builder in ``sensor.py`` or ``binary_sensor.py``
+ever looked its key up. The device reported the value, the integration read
+the payload, and the entity was never created:
+
+* ``("emeter", "energyReturned")`` — a Shelly 3EM owner got the consumption
+  half of the meter and not the feed-in half (#38).
+* ``flood:<id>`` — a Shelly Flood Gen4 arrived with diagnostics and without
+  its alarm (#41).
+* Gen1 ``flood`` / ``smoke`` — the same, for the Gen1 leaf sensors (#42).
+* ``wifi.rssi`` / ``wifi_sta.rssi`` — signal strength, present on 35 of 35
+  Gen2+ devices in the recorded account snapshot, never surfaced.
+
+Not one of them was findable by reading either file alone: the table looks
+complete, and the builder looks complete. Only the *join* is broken, and
+nothing in Python checks a join that is expressed as a dict lookup.
+
+So this test performs the join statically. It parses both platform modules
+with ``ast`` — the same approach ``test_coordinator_init.py`` takes, and for
+the same reason: the failure is structural, so a static read catches it
+without a running Home Assistant — collects every key literal those modules
+can ever look up, and asserts that no table entry is left over.
+
+A lookup whose argument cannot be resolved to literals (``BLE_SENSORS`` is
+indexed by whatever component type the payload happens to carry) marks the
+whole table as dynamically reached, because in that case any key genuinely
+can be hit.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from custom_components.shelly_cloud_diy.entities import descriptions
+
+# The description tables and the two modules allowed to consume them.
+TABLES = (
+    "RPC_SENSORS",
+    "BLOCK_SENSORS",
+    "RPC_BINARY_SENSORS",
+    "BLOCK_BINARY_SENSORS",
+    "BLE_SENSORS",
+    "BLE_BINARY_SENSORS",
+)
+
+PLATFORM_MODULES = ("sensor.py", "binary_sensor.py")
+
+COMPONENT_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "shelly_cloud_diy"
+)
+
+# Entries that exist in a table and that NO builder reaches, knowingly.
+#
+# This is a backlog, not a design. Every line below is a reading a device
+# could be publishing today and that we do not surface — it is here because
+# wiring it up would rest on a shape nobody in this project has ever measured,
+# and lesson #32 is explicit that a fix must not smuggle in a second,
+# unevidenced assumption. Shrinking this list is the goal; growing it needs a
+# reason written down next to the entry.
+_INTENTIONALLY_UNWIRED: dict[str, set[Any]] = {
+    # Gen2+ ``illuminance:<id>.lux``. A real gap, and the only Gen2 one left.
+    # It is not wired because no Gen2+ device in any payload recorded from a
+    # real account carries an ``illuminance:<id>`` component — every one of
+    # the 24 illuminance readings in the snapshot belongs to a BLU device and
+    # is served by ``BLE_SENSORS["illuminance"]`` instead. Wiring the Gen2
+    # path would be an unmeasured guess shipped alongside a measured fix.
+    "RPC_SENSORS": {"illuminance"},
+    # Gen1 Block sensors. NO Gen1 device appears in any recorded payload —
+    # the snapshot holds 35 Gen2+ and 29 BLU devices and zero Gen1 — so every
+    # one of these would be wired against the vendor documentation alone.
+    # ``wifi_sta.rssi`` was wired from that documentation deliberately and in
+    # isolation; doing the same for eighteen more shapes in one change is the
+    # bulk guesswork #32 warns about. They need a Gen1 payload first.
+    "BLOCK_SENSORS": {
+        ("adc", "adc"),
+        ("device", "battery"),
+        ("device", "deviceTemp"),
+        ("device", "energy"),
+        ("device", "power"),
+        # Reactive power on the Gen1 3EM. Left out of the #38 fix on purpose,
+        # for exactly this reason, and still unmeasured.
+        ("emeter", "reactive"),
+        ("light", "energy"),
+        ("light", "power"),
+        ("relay", "energy"),
+        ("roller", "rollerEnergy"),
+        ("roller", "rollerPower"),
+        ("sensor", "extTemp"),
+        ("sensor", "gas"),
+        ("sensor", "humidity"),
+        ("sensor", "luminosity"),
+        ("sensor", "selfTest"),
+        ("sensor", "tilt"),
+        ("valve", "valve"),
+    },
+    # Gen1 top-level fault flags, same generation problem as above. These are
+    # the closest remaining relatives of the ``flood`` / ``smoke`` flags fixed
+    # in #42 and should be the first thing wired once a Gen1 payload exists.
+    "BLOCK_BINARY_SENSORS": {"overpower", "overtemperature", "vibration"},
+}
+
+
+def _literal(node: ast.AST) -> Any:
+    """Return the str / tuple-of-str a node denotes, else ``None``."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Tuple) and all(
+        isinstance(e, ast.Constant) and isinstance(e.value, str)
+        for e in node.elts
+    ):
+        return tuple(e.value for e in node.elts)
+    return None
+
+
+def _loop_bound_literals(tree: ast.AST) -> dict[str, set[Any]]:
+    """Map loop variables to the literals a literal iterable can bind them to.
+
+    Both platform modules drive their lookups from tables written inline, e.g.
+    ``for attr, desc_key in [("apower", "pm1_apower"), …]`` followed by
+    ``RPC_SENSORS.get(desc_key)``. The key at the lookup site is a variable,
+    so resolving it means reading the loop that binds it.
+    """
+    bound: dict[str, set[Any]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.For, ast.comprehension)):
+            continue
+        if not isinstance(node.iter, (ast.List, ast.Tuple)):
+            continue
+
+        if isinstance(node.target, ast.Name):
+            for element in node.iter.elts:
+                value = _literal(element)
+                if value is not None:
+                    bound.setdefault(node.target.id, set()).add(value)
+        elif isinstance(node.target, ast.Tuple):
+            names = [
+                e.id if isinstance(e, ast.Name) else None
+                for e in node.target.elts
+            ]
+            for element in node.iter.elts:
+                if not isinstance(element, ast.Tuple):
+                    continue
+                for position, sub in enumerate(element.elts):
+                    if position >= len(names) or names[position] is None:
+                        continue
+                    value = _literal(sub)
+                    if value is not None:
+                        bound.setdefault(names[position], set()).add(value)
+    return bound
+
+
+def _collect(path: Path) -> tuple[dict[str, set[Any]], set[str]]:
+    """Return (keys looked up per table, tables reached dynamically)."""
+    tree = ast.parse(path.read_text())
+    bound = _loop_bound_literals(tree)
+    looked_up: dict[str, set[Any]] = {name: set() for name in TABLES}
+    dynamic: set[str] = set()
+
+    def resolve(table: str, node: ast.AST) -> None:
+        value = _literal(node)
+        if value is not None:
+            looked_up[table].add(value)
+            return
+        if isinstance(node, ast.Name) and node.id in bound:
+            looked_up[table] |= bound[node.id]
+            return
+        # An unresolvable key means the table is indexed by whatever the
+        # payload carries, so every entry in it is genuinely reachable.
+        dynamic.add(table)
+
+    for node in ast.walk(tree):
+        # TABLE.get(key)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in looked_up
+            and node.args
+        ):
+            resolve(node.func.value.id, node.args[0])
+        # TABLE[key]
+        elif (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in looked_up
+        ):
+            resolve(node.value.id, node.slice)
+        # key in TABLE
+        elif (
+            isinstance(node, ast.Compare)
+            and len(node.ops) == 1
+            and isinstance(node.ops[0], ast.In)
+            and isinstance(node.comparators[0], ast.Name)
+            and node.comparators[0].id in looked_up
+        ):
+            resolve(node.comparators[0].id, node.left)
+        # for … in TABLE / TABLE.items() / TABLE.keys()
+        elif isinstance(node, (ast.For, ast.comprehension)):
+            iterated = node.iter
+            if isinstance(iterated, ast.Name) and iterated.id in looked_up:
+                dynamic.add(iterated.id)
+            elif (
+                isinstance(iterated, ast.Call)
+                and isinstance(iterated.func, ast.Attribute)
+                and isinstance(iterated.func.value, ast.Name)
+                and iterated.func.value.id in looked_up
+            ):
+                dynamic.add(iterated.func.value.id)
+
+    return looked_up, dynamic
+
+
+def _reachable_keys() -> tuple[dict[str, set[Any]], set[str]]:
+    """Join both platform modules into one reachability picture."""
+    reached: dict[str, set[Any]] = {name: set() for name in TABLES}
+    dynamic: set[str] = set()
+    for module in PLATFORM_MODULES:
+        module_keys, module_dynamic = _collect(COMPONENT_DIR / module)
+        for table, keys in module_keys.items():
+            reached[table] |= keys
+        dynamic |= module_dynamic
+    return reached, dynamic
+
+
+def test_every_description_is_reachable_from_a_builder() -> None:
+    """No table entry may exist without a builder that can create it."""
+    reached, dynamic = _reachable_keys()
+
+    orphans: dict[str, list[Any]] = {}
+    for table in TABLES:
+        if table in dynamic:
+            continue
+        allowed = _INTENTIONALLY_UNWIRED.get(table, set())
+        missing = [
+            key
+            for key in getattr(descriptions, table)
+            if key not in reached[table] and key not in allowed
+        ]
+        if missing:
+            orphans[table] = sorted(missing, key=repr)
+
+    assert not orphans, (
+        "Entity descriptions declared but no builder creates them — the "
+        "device reports the value and the entity never appears (the #38 / "
+        "#41 / #42 bug class):\n"
+        + "\n".join(
+            f"  {table}: {', '.join(repr(k) for k in keys)}"
+            for table, keys in sorted(orphans.items())
+        )
+        + "\n\nFix: wire the key into the matching builder in sensor.py or "
+        "binary_sensor.py. If it is genuinely unwirable today, add it to "
+        "_INTENTIONALLY_UNWIRED in this file WITH the reason."
+    )
+
+
+def test_wifi_rssi_is_wired_on_both_generations() -> None:
+    """The two RSSI descriptions specifically — the fourth instance.
+
+    Named on its own so a regression reads as "RSSI lost its builder" rather
+    than as one line in a list.
+    """
+    reached, _ = _reachable_keys()
+    assert "rssi" in reached["RPC_SENSORS"], (
+        "RPC_SENSORS['rssi'] is declared but no builder creates it; "
+        "wifi.rssi is present on every Gen2+ device we have ever recorded"
+    )
+    assert ("wifi_sta", "rssi") in reached["BLOCK_SENSORS"], (
+        "BLOCK_SENSORS[('wifi_sta', 'rssi')] is declared but no builder "
+        "creates it"
+    )
+
+
+def test_rssi_entities_read_the_right_field() -> None:
+    """Reachability is necessary but not sufficient — read the value too.
+
+    A builder can be wired to the correct description and still hand it the
+    wrong status key, which the static check above cannot see. The Gen1 shape
+    here comes from the vendor Gen1 API documentation
+    (https://shelly-api-docs.shelly.cloud/gen1/, /status), not from a
+    measurement: no Gen1 device appears in any recorded payload.
+    """
+    from custom_components.shelly_cloud_diy.sensor import (
+        _create_block_sensors,
+        _create_rpc_sensors,
+    )
+
+    device_id = "a0dd6cffee01"
+
+    gen2 = {"switch:0": {"id": 0, "output": True}, "wifi": {"rssi": -82}}
+    gen1 = {
+        "wifi_sta": {"connected": True, "ssid": "x", "ip": "10.0.0.2", "rssi": -54},
+        "tmp": {"tC": 21.0, "is_valid": True},
+    }
+
+    coordinator = _StatusOnlyCoordinator(device_id, gen2)
+    rpc = {e.unique_id: e for e in _create_rpc_sensors(device_id, gen2, set(), coordinator)}
+    assert rpc[f"{device_id}_wifi_rssi"].native_value == -82
+    assert rpc[f"{device_id}_wifi_rssi"].native_unit_of_measurement == "dBm"
+
+    coordinator = _StatusOnlyCoordinator(device_id, gen1)
+    block = {
+        e.unique_id: e for e in _create_block_sensors(device_id, gen1, set(), coordinator)
+    }
+    assert block[f"{device_id}_wifi_sta|rssi_0"].native_value == -54
+
+
+def test_rssi_entity_is_skipped_when_the_radio_reports_nothing() -> None:
+    """A component present but null must not become a permanently-unknown entity."""
+    from custom_components.shelly_cloud_diy.sensor import _create_rpc_sensors
+
+    device_id = "a0dd6cffee01"
+    status = {"switch:0": {"id": 0}, "wifi": {"rssi": None, "status": "got ip"}}
+    coordinator = _StatusOnlyCoordinator(device_id, status)
+
+    built = _create_rpc_sensors(device_id, status, set(), coordinator)
+    assert not [e for e in built if e.unique_id.endswith("_wifi_rssi")]
+
+
+class _StatusOnlyCoordinator:
+    """Minimal coordinator: entities only read ``.devices[id]['status']``."""
+
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {device_id: {"status": status, "online": True}}
+        self.data = self.devices
+        self.last_update_success = True
+
+
+def test_allowlist_only_holds_real_table_entries() -> None:
+    """A stale allowlist would silently mask a new orphan.
+
+    If an entry is renamed or removed from a table but left behind here, the
+    allowlist keeps growing while the guard quietly weakens.
+    """
+    stale: dict[str, list[Any]] = {}
+    for table, keys in _INTENTIONALLY_UNWIRED.items():
+        leftover = [key for key in keys if key not in getattr(descriptions, table)]
+        if leftover:
+            stale[table] = sorted(leftover, key=repr)
+
+    assert not stale, (
+        "_INTENTIONALLY_UNWIRED names entries that no longer exist in the "
+        f"description tables; remove them: {stale}"
+    )
+
+
+def test_dynamic_tables_are_the_expected_ones() -> None:
+    """Only the BLE tables may be reached by an unresolvable key.
+
+    A dynamic lookup switches the guard off for a whole table, so the set of
+    tables that get that exemption must not grow by accident — a refactor
+    that turned a literal lookup into a computed one would otherwise blind
+    the check without a single test failing.
+    """
+    _, dynamic = _reachable_keys()
+    assert dynamic == {"BLE_SENSORS", "BLE_BINARY_SENSORS"}, (
+        "Tables reached by an unresolvable key changed to "
+        f"{sorted(dynamic)}; a table listed here is exempt from the "
+        "dead-description check entirely"
+    )

--- a/tests/test_device_health.py
+++ b/tests/test_device_health.py
@@ -1,0 +1,756 @@
+"""Unit tests for the threshold health checks ("Doctor").
+
+Every threshold pinned here was chosen against a real 64-device account
+(``.planning/messungen/snapshot.json``, gitignored). Cross-checked against
+that payload while this was written, the evaluator finds 19 findings on 14
+devices with firmware off — an -82 dBm link, a switch at 78.5 °C, five dead
+add-on probes reporting ``errors: ["read"]`` — and **no** finding on any of
+the 29 BLE devices other than the gateway RSSI. Those numbers are what the
+cases below encode in a form the suite can keep honest.
+
+The coordinator-level tests drive the real production path with the same
+lightweight fake coordinator the relay-fault tests use.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.shelly_cloud_diy import coordinator as coordinator_mod
+from custom_components.shelly_cloud_diy.const import (
+    CONF_DEVICE_HEALTH_DETECTION,
+    CONF_DEVICE_HEALTH_FIRMWARE,
+    DEVICE_HEALTH_FIRMWARE_DEFAULT,
+    DOMAIN,
+)
+from custom_components.shelly_cloud_diy.coordinator import ShellyCloudCoordinator
+from custom_components.shelly_cloud_diy.device_health import (
+    CHECK_COMPONENT_ERROR,
+    CHECK_FILESYSTEM,
+    CHECK_FIRMWARE,
+    CHECK_RAM,
+    CHECK_RESTART,
+    CHECK_TEMPERATURE,
+    CHECK_WIFI,
+    FREE_ERROR_FRACTION,
+    FREE_WARNING_FRACTION,
+    HEALTH_MIN_SECONDS,
+    HEALTH_MIN_STREAK,
+    RSSI_ERROR_DBM,
+    RSSI_WARNING_DBM,
+    SEVERITY_ERROR,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+    TEMPERATURE_ERROR_C,
+    TEMPERATURE_WARNING_C,
+    HealthFinding,
+    evaluate_device_health,
+    health_verdict,
+    summarise_findings,
+)
+from custom_components.shelly_cloud_diy.repair_issues import (
+    ISSUE_DEVICE_HEALTH,
+    issue_id,
+)
+
+DEVICE = "84fce63b699c"
+OTHER = "d0ef76c69dd8"
+BLU = "XB106582483818186"
+
+# The measured healthy baseline of the account, so that a payload built from
+# these defaults produces exactly zero findings and any test that wants one
+# has to say so explicitly.
+RAM_SIZE = 262108
+RAM_FREE = 81072          # 30.9 % free
+FS_SIZE = 917504
+FS_FREE = 458752          # 50.0 % free
+
+
+def _gen2(
+    *,
+    rssi: int = -59,
+    tc: float | None = 63.36,
+    ram_free: int = RAM_FREE,
+    fs_free: int = FS_FREE,
+    restart: bool = False,
+    updates: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """A Gen2 status shaped like the real ones, healthy unless told otherwise."""
+    switch: dict[str, Any] = {"id": 0, "output": False, "apower": 0.0}
+    if tc is not None:
+        switch["temperature"] = {"tC": tc, "tF": tc * 1.8 + 32}
+    status: dict[str, Any] = {
+        "wifi": {"sta_ip": "192.168.1.5", "status": "got ip", "rssi": rssi},
+        "cloud": {"connected": True},
+        "switch:0": switch,
+        "sys": {
+            "ram_size": RAM_SIZE,
+            "ram_free": ram_free,
+            "fs_size": FS_SIZE,
+            "fs_free": fs_free,
+            "restart_required": restart,
+            "available_updates": updates if updates is not None else {},
+            "uptime": 7815949,
+        },
+    }
+    if extra:
+        status.update(extra)
+    return status
+
+
+def _gble(*, rssi: int = -59, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    """A BLE/gateway-bridged status, in the shape the cloud really sends."""
+    status: dict[str, Any] = {
+        "devicepower:0": {
+            "id": 0,
+            "battery": {"V": None, "percent": 100, "low": None},
+            "errors": [],
+        },
+        "temperature:0": {"id": 0, "tC": 21.4},
+        "humidity:0": {"id": 0, "rh": 47.5},
+        "reporter": {"id": "146221729481748", "rssi": rssi, "inrange": False},
+        "_dev_info": {
+            "id": BLU, "gen": "GBLE", "code": "SBHT-003C", "online": True,
+        },
+    }
+    if extra:
+        status.update(extra)
+    return status
+
+
+def _checks(findings: list[HealthFinding]) -> set[str]:
+    return {f.check for f in findings}
+
+
+def _one(findings: list[HealthFinding], check: str) -> HealthFinding:
+    matching = [f for f in findings if f.check == check]
+    assert len(matching) == 1, f"expected exactly one {check}, got {matching}"
+    return matching[0]
+
+
+# ── The baseline: a healthy device says nothing ───────────────────────
+
+
+def test_a_healthy_gen2_device_produces_no_findings() -> None:
+    """Built from the account's measured medians. If this ever starts
+    producing a finding, a threshold has drifted into the normal range."""
+    assert evaluate_device_health(_gen2()) == []
+
+
+def test_an_empty_or_broken_status_is_survivable() -> None:
+    assert evaluate_device_health({}) == []
+    assert evaluate_device_health(None) == []  # type: ignore[arg-type]
+
+
+# ── Wi-Fi signal ──────────────────────────────────────────────────────
+
+
+def test_a_strong_link_is_not_a_finding() -> None:
+    assert evaluate_device_health(_gen2(rssi=RSSI_WARNING_DBM + 1)) == []
+
+
+def test_the_warning_line_is_inclusive() -> None:
+    finding = _one(evaluate_device_health(_gen2(rssi=RSSI_WARNING_DBM)), CHECK_WIFI)
+    assert finding.severity == SEVERITY_WARNING
+
+
+def test_the_measured_worst_link_is_a_warning_not_an_error() -> None:
+    """-82 dBm is the worst Wi-Fi RSSI in the real snapshot. It has to land
+    between the two lines, or one of them is in the wrong place."""
+    finding = _one(evaluate_device_health(_gen2(rssi=-82)), CHECK_WIFI)
+    assert finding.severity == SEVERITY_WARNING
+    assert finding.detail == "-82 dBm"
+
+
+def test_the_error_line_is_inclusive() -> None:
+    finding = _one(evaluate_device_health(_gen2(rssi=RSSI_ERROR_DBM)), CHECK_WIFI)
+    assert finding.severity == SEVERITY_ERROR
+
+
+def test_a_missing_rssi_reading_is_not_a_perfect_link() -> None:
+    """Zero is what a device reports when it has no measurement. Read as a
+    number it is the best possible signal, which is the wrong answer in the
+    one direction that matters."""
+    assert evaluate_device_health(_gen2(rssi=0)) == []
+    assert evaluate_device_health(_gen2(rssi=None)) == []  # type: ignore[arg-type]
+
+
+# ── Temperature ───────────────────────────────────────────────────────
+
+
+def test_a_warm_but_normal_switch_is_not_a_finding() -> None:
+    assert evaluate_device_health(_gen2(tc=TEMPERATURE_WARNING_C - 0.1)) == []
+
+
+def test_the_measured_hottest_switch_crosses_the_warning_line() -> None:
+    """78.5 °C is the hottest reading in the real snapshot."""
+    finding = _one(evaluate_device_health(_gen2(tc=78.5)), CHECK_TEMPERATURE)
+    assert finding.severity == SEVERITY_WARNING
+    assert finding.component == "switch:0"
+    assert finding.detail == "78.5 °C"
+
+
+def test_the_temperature_error_line_is_inclusive() -> None:
+    finding = _one(
+        evaluate_device_health(_gen2(tc=TEMPERATURE_ERROR_C)), CHECK_TEMPERATURE
+    )
+    assert finding.severity == SEVERITY_ERROR
+
+
+def test_a_standalone_temperature_component_is_never_device_temperature() -> None:
+    """An add-on probe measures the world, not the device.
+
+    A sensor in a boiler flow pipe or a sauna is above 70 °C by design, and
+    the payload gives us nothing to tell that apart from an overheating
+    device — so a standalone ``temperature:<id>`` must produce no
+    temperature finding at all, however hot it reads. In the 64-device
+    sample both genuinely hot readings come from ``switch:0``, so this
+    exclusion costs nothing measured.
+    """
+    status = _gen2(extra={"temperature:100": {"id": 100, "tC": 91.0}})
+    assert evaluate_device_health(status) == []
+
+
+def test_an_add_on_probe_is_still_judged_on_its_own_error() -> None:
+    """Excluding the reading must not exclude the component: the real
+    payload carries ``temperature:100 → errors: ["read"]``, which is the
+    device reporting a broken probe and belongs in the card."""
+    status = _gen2(
+        extra={"temperature:100": {"id": 100, "tC": 91.0, "errors": ["read"]}}
+    )
+    findings = evaluate_device_health(status)
+    assert [f.check for f in findings] == [CHECK_COMPONENT_ERROR]
+
+
+def test_a_null_temperature_is_not_measured_as_zero() -> None:
+    status = _gen2(extra={"temperature:100": {"id": 100, "tC": None}})
+    assert evaluate_device_health(status) == []
+
+
+# ── Free memory and free filesystem ───────────────────────────────────
+
+
+def test_free_memory_just_above_the_line_is_silence() -> None:
+    ram = int(RAM_SIZE * FREE_WARNING_FRACTION) + 1
+    assert evaluate_device_health(_gen2(ram_free=ram)) == []
+
+
+def test_free_memory_at_the_line_warns() -> None:
+    ram = int(RAM_SIZE * FREE_WARNING_FRACTION) - 1
+    finding = _one(evaluate_device_health(_gen2(ram_free=ram)), CHECK_RAM)
+    assert finding.severity == SEVERITY_WARNING
+
+
+def test_free_memory_below_the_error_line_is_an_error() -> None:
+    ram = int(RAM_SIZE * FREE_ERROR_FRACTION) - 1
+    finding = _one(evaluate_device_health(_gen2(ram_free=ram)), CHECK_RAM)
+    assert finding.severity == SEVERITY_ERROR
+
+
+def test_free_storage_uses_the_same_two_lines() -> None:
+    warn = _one(
+        evaluate_device_health(
+            _gen2(fs_free=int(FS_SIZE * FREE_WARNING_FRACTION) - 1)
+        ),
+        CHECK_FILESYSTEM,
+    )
+    err = _one(
+        evaluate_device_health(
+            _gen2(fs_free=int(FS_SIZE * FREE_ERROR_FRACTION) - 1)
+        ),
+        CHECK_FILESYSTEM,
+    )
+    assert (warn.severity, err.severity) == (SEVERITY_WARNING, SEVERITY_ERROR)
+
+
+def test_a_device_reporting_no_capacity_is_not_judged() -> None:
+    """A zero total would make every device 0 % free — an integration-wide
+    false alarm out of one missing field."""
+    status = _gen2()
+    status["sys"]["ram_size"] = 0
+    status["sys"].pop("fs_size")
+    assert evaluate_device_health(status) == []
+
+
+# ── Restart pending and component errors ──────────────────────────────
+
+
+def test_a_pending_restart_is_reported() -> None:
+    finding = _one(evaluate_device_health(_gen2(restart=True)), CHECK_RESTART)
+    assert finding.severity == SEVERITY_ERROR
+
+
+def test_a_component_reporting_its_own_error_is_believed() -> None:
+    """The one check with no threshold to argue about: measured on real
+    hardware as ``temperature:100 -> ["read"]``."""
+    status = _gen2(
+        extra={"temperature:100": {"id": 100, "tC": None, "errors": ["read"]}}
+    )
+    finding = _one(evaluate_device_health(status), CHECK_COMPONENT_ERROR)
+    assert (finding.component, finding.detail) == ("temperature:100", "read")
+
+
+def test_an_empty_error_list_is_not_an_error() -> None:
+    status = _gen2(extra={"temperature:100": {"id": 100, "tC": 20.0, "errors": []}})
+    assert evaluate_device_health(status) == []
+
+
+def test_every_failing_component_is_its_own_finding() -> None:
+    """One device in the snapshot has five dead add-on probes. Collapsing
+    them to one would hide how much of the add-on is gone."""
+    status = _gen2(
+        extra={
+            f"temperature:{i}": {"id": i, "errors": ["read"]}
+            for i in range(100, 105)
+        }
+    )
+    assert len(evaluate_device_health(status)) == 5
+
+
+# ── Firmware: measured, and therefore opt-in ──────────────────────────
+
+
+UPDATES = {"stable": {"version": "2.0.0"}}
+
+
+def test_a_pending_firmware_update_is_silent_by_default() -> None:
+    """24 of 35 devices on the measured account had one pending. Default-on
+    would mean a permanently lit card that teaches the user to ignore it."""
+    assert DEVICE_HEALTH_FIRMWARE_DEFAULT is False
+    assert evaluate_device_health(_gen2(updates=UPDATES)) == []
+
+
+def test_a_pending_firmware_update_is_information_when_asked_for() -> None:
+    findings = evaluate_device_health(
+        _gen2(updates=UPDATES), include_firmware=True
+    )
+    finding = _one(findings, CHECK_FIRMWARE)
+    assert finding.severity == SEVERITY_INFO
+    assert finding.detail == "stable 2.0.0"
+
+
+def test_a_device_on_the_current_firmware_says_nothing_either_way() -> None:
+    assert evaluate_device_health(_gen2(updates={}), include_firmware=True) == []
+
+
+# ── BLE/gateway-bridged devices: the reduced set ──────────────────────
+
+
+def test_a_ble_device_is_judged_on_the_gateway_signal() -> None:
+    finding = _one(evaluate_device_health(_gble(rssi=-84)), CHECK_WIFI)
+    assert (finding.component, finding.severity) == ("reporter", SEVERITY_WARNING)
+
+
+def test_a_well_heard_ble_device_produces_nothing() -> None:
+    assert evaluate_device_health(_gble()) == []
+
+
+def test_a_ble_device_is_never_judged_against_gen2_fields() -> None:
+    """The payload here would trip the Gen2 checks if the reduced set were
+    not enforced: a component error and no ``sys`` block at all. "Unknown"
+    must never read as "unhealthy"."""
+    status = _gble(
+        extra={
+            "temperature:0": {"id": 0, "tC": 95.0},
+            "devicepower:0": {
+                "id": 0,
+                "battery": {"V": None, "percent": 3, "low": None},
+                "errors": ["broken"],
+            },
+        }
+    )
+    assert evaluate_device_health(status, include_firmware=True) == []
+
+
+def test_a_ble_device_without_a_reporter_block_is_not_judged() -> None:
+    status = _gble()
+    status.pop("reporter")
+    assert evaluate_device_health(status) == []
+
+
+# ── Gen1: deliberately not judged at all ──────────────────────────────
+
+
+def test_a_gen1_device_is_skipped_entirely() -> None:
+    """No Gen1 device exists in any payload ever recorded from this account,
+    so every Gen1 threshold would be a guess dressed up as a measurement —
+    the mistake behind issue #32. The payload below would trip three checks
+    if the Gen2 rules were applied to it by accident."""
+    status = {
+        "relays": [{"ison": False}],
+        "meters": [{"power": 0.0}],
+        "wifi_sta": {"connected": True, "rssi": -91},
+        "temperature": 96.0,
+        "update": {"has_update": True},
+        "ram_free": 100,
+        "ram_total": 50000,
+    }
+    assert evaluate_device_health(status, include_firmware=True) == []
+
+
+# ── The two gates ─────────────────────────────────────────────────────
+
+
+def test_neither_gate_alone_is_enough() -> None:
+    assert not health_verdict(HEALTH_MIN_STREAK, 0.0, HEALTH_MIN_SECONDS - 1)
+    assert not health_verdict(HEALTH_MIN_STREAK - 1, 0.0, HEALTH_MIN_SECONDS + 1)
+    assert health_verdict(HEALTH_MIN_STREAK, 0.0, HEALTH_MIN_SECONDS)
+
+
+def test_a_finding_with_no_start_time_is_never_confirmed() -> None:
+    assert not health_verdict(HEALTH_MIN_STREAK, None, 10_000.0)
+
+
+# ── The aggregated summary ────────────────────────────────────────────
+
+
+def test_the_summary_counts_findings_not_devices() -> None:
+    findings = {
+        DEVICE: (
+            HealthFinding(CHECK_COMPONENT_ERROR, "temperature:100", "error", "read"),
+            HealthFinding(CHECK_COMPONENT_ERROR, "temperature:101", "error", "read"),
+            HealthFinding(CHECK_WIFI, "wifi", "warning", "-81 dBm"),
+        ),
+        OTHER: (HealthFinding(CHECK_WIFI, "wifi", "warning", "-76 dBm"),),
+    }
+    # Ordered by count, then by check id — so a tie renders deterministically
+    # rather than however the last poll happened to iterate.
+    assert summarise_findings(findings) == "Component error (2), Wi-Fi signal (2)"
+
+
+def test_an_empty_summary_is_empty_rather_than_a_stray_separator() -> None:
+    assert summarise_findings({}) == ""
+
+
+# ── Driven through the coordinator ────────────────────────────────────
+
+
+class _FakeApi:
+    def __init__(self, devices_status: dict[str, Any]) -> None:
+        self.devices_status = devices_status
+
+    async def get_all_status(self) -> dict[str, Any]:
+        return {"devices_status": self.devices_status}
+
+
+class _StubHass:
+    def async_create_task(self, coro: Any) -> None:
+        coro.close()
+
+
+@pytest.fixture(autouse=True)
+def _inert_repair_issues(monkeypatch):
+    """Silence every repair wrapper except the one under test.
+
+    The stub ``hass`` below has no issue registry, and the poll dispatches
+    ``SIGNAL_NEW_DEVICE`` into a Home Assistant that does not exist.
+    """
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_rate_limit_issue",
+        lambda hass, entry, *, active: None,
+    )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_missing_devices_issue",
+        lambda hass, entry, *, active, missing, names: None,
+    )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_relay_fault_issue",
+        lambda hass, entry, *, active, faults, names: None,
+    )
+    monkeypatch.setattr(
+        coordinator_mod, "async_dispatcher_send", lambda *args, **kwargs: None
+    )
+
+
+class _CardRecorder:
+    """Captures what the aggregated card was last told."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[bool, dict, dict]] = []
+
+    def __call__(self, hass, entry, *, active, findings, names) -> None:
+        self.calls.append((active, dict(findings), dict(names)))
+
+    @property
+    def last_active(self) -> bool:
+        return self.calls[-1][0]
+
+    @property
+    def last_findings(self) -> dict:
+        return self.calls[-1][1]
+
+
+@pytest.fixture
+def card(monkeypatch) -> _CardRecorder:
+    recorder = _CardRecorder()
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_device_health_issue", recorder
+    )
+    return recorder
+
+
+def _coordinator(**options: Any) -> ShellyCloudCoordinator:
+    """A coordinator with only the polling wiring in place.
+
+    ``__init__`` wants a HomeAssistant instance and a ConfigEntry; none of
+    the health logic does. ``test_coordinator_init.py`` is the guard that
+    keeps this shortcut from hiding a missing assignment.
+    """
+    coord = object.__new__(ShellyCloudCoordinator)
+    coord._api = _FakeApi({})
+    coord.hass = _StubHass()
+    coord._entry = SimpleNamespace(
+        entry_id="entry", title="Shelly Cloud DIY",
+        options={"enabled_devices": [], "create_all_initially": True, **options},
+    )
+    coord.devices = {}
+    coord._known_device_ids = set()
+    coord.device_names = {}
+    coord._names_attempted = set()
+    coord._name_lookup_in_flight = False
+    coord.virtual_configs = {}
+    coord._vcomp_config_in_flight = False
+    coord._sleep_seen = {}
+    coord.checkins = {}
+    coord._rate_limit_streak = 0
+    coord._rate_limit_since = None
+    coord._rate_limit_reported = False
+    coord._missing_streak = {}
+    coord._missing_since = {}
+    coord._relay_fault_streak = {}
+    coord._relay_fault_since = {}
+    coord._relay_healthy_since = {}
+    coord.relay_faults = set()
+    coord._health_streak = {}
+    coord._health_since = {}
+    coord.device_health = {}
+    coord._display_names = lambda ids: {
+        d: coord.device_names[d] for d in ids if d in coord.device_names
+    }
+    return coord
+
+
+def _poll(coord: ShellyCloudCoordinator, statuses: dict[str, Any], at: float) -> None:
+    """Run one full poll with ``time.monotonic`` pinned to ``at``.
+
+    Patched rather than slept through: the time gate is five minutes, and a
+    real-time test would outlast the rest of the suite several times over.
+    """
+    coord._api.devices_status = statuses
+    original = time.monotonic
+    time.monotonic = lambda: at  # type: ignore[assignment]
+    try:
+        asyncio.run(coord._async_update_data())
+    finally:
+        time.monotonic = original  # type: ignore[assignment]
+
+
+def _drive(
+    coord: ShellyCloudCoordinator,
+    statuses: dict[str, Any],
+    *,
+    start: float = 0.0,
+    polls: int = 8,
+    step: float = 60.0,
+) -> None:
+    """Poll ``polls`` times, each with a fresh fingerprint so every device
+    counts as having genuinely checked in."""
+    for i in range(polls):
+        fresh = {
+            did: {**status, "serial": int(start) + i, "_updated": f"t{start}-{i}"}
+            for did, status in statuses.items()
+        }
+        _poll(coord, fresh, start + i * step)
+
+
+def test_a_healthy_fleet_never_raises_the_card(card) -> None:
+    coord = _coordinator()
+    _drive(coord, {DEVICE: _gen2(), BLU: _gble()})
+    assert coord.device_health == {}
+    assert card.last_active is False
+
+
+def test_a_sustained_finding_is_reported(card) -> None:
+    coord = _coordinator()
+    _drive(coord, {DEVICE: _gen2(rssi=-82)})
+    assert list(coord.device_health) == [DEVICE]
+    assert _checks(list(coord.device_health[DEVICE])) == {CHECK_WIFI}
+    assert card.last_active is True
+
+
+def test_nothing_is_said_before_both_gates_are_served(card) -> None:
+    """Three check-ins inside a minute serve the streak but not the clock:
+    a device is allowed to be briefly warm after a firmware flash without
+    the user hearing about it."""
+    coord = _coordinator()
+    _drive(coord, {DEVICE: _gen2(rssi=-82)}, polls=HEALTH_MIN_STREAK + 1, step=10.0)
+    assert coord.device_health == {}
+    assert card.last_active is False
+
+
+def test_the_clock_alone_is_not_enough_either(card) -> None:
+    """Two check-ins ten minutes apart clear the time gate and still must
+    not produce a verdict — one report either side of a long gap is not a
+    sustained condition."""
+    coord = _coordinator()
+    _drive(coord, {DEVICE: _gen2(rssi=-82)}, polls=HEALTH_MIN_STREAK - 1, step=600.0)
+    assert coord.device_health == {}
+
+
+def test_a_finding_clears_on_the_first_contradicting_checkin(card) -> None:
+    """Deliberately NOT delayed the way the relay detector's clear is. A
+    device now reporting 60 °C is not hiding a hot chip, so holding the
+    finding open would just be showing something that stopped being true."""
+    coord = _coordinator()
+    _drive(coord, {DEVICE: _gen2(tc=78.5)})
+    assert coord.device_health[DEVICE]
+
+    _drive(coord, {DEVICE: _gen2(tc=60.0)}, start=1000.0, polls=1)
+    assert coord.device_health == {}
+    assert card.last_active is False
+
+
+def test_a_flapping_value_has_to_serve_both_gates_again(card) -> None:
+    """One clean check-in wipes the history, so a value that crosses the
+    line every other poll can never accumulate a streak."""
+    coord = _coordinator()
+    for i in range(20):
+        rssi = -82 if i % 2 else -50
+        _drive(
+            coord, {DEVICE: _gen2(rssi=rssi)},
+            start=float(i * 100), polls=1,
+        )
+    assert coord.device_health == {}
+
+
+def test_a_frozen_device_cannot_earn_a_finding(card) -> None:
+    """A device that stops reporting keeps re-serving its last payload. If
+    polls counted instead of check-ins, one stale snapshot repeated for
+    three hours would manufacture a verdict against gates measured in
+    minutes."""
+    coord = _coordinator()
+    hot = _gen2(tc=90.0)
+    for i in range(200):
+        _poll(coord, {DEVICE: {**hot, "serial": 1, "_updated": "frozen"}}, i * 60.0)
+    assert coord.device_health == {}
+
+
+def test_a_standing_finding_survives_the_device_going_quiet(card) -> None:
+    """A device that drops off the cloud at 90 °C is not cooler for having
+    stopped talking about it."""
+    coord = _coordinator()
+    _drive(coord, {DEVICE: _gen2(tc=90.0)})
+    assert coord.device_health[DEVICE]
+
+    for i in range(50):
+        _poll(
+            coord,
+            {DEVICE: {**_gen2(tc=90.0), "serial": 9, "_updated": "frozen"}},
+            10_000.0 + i * 60.0,
+        )
+    assert list(coord.device_health) == [DEVICE]
+
+
+def test_two_unhealthy_devices_share_one_card(card) -> None:
+    """The measured account would have produced 24 firmware cards alone. One
+    card per device is what makes a repair panel unreadable, so the manager
+    is called once with every device on it."""
+    coord = _coordinator()
+    _drive(
+        coord,
+        {
+            DEVICE: _gen2(rssi=-82),
+            OTHER: _gen2(tc=90.0),
+            BLU: _gble(),
+        },
+    )
+    assert set(coord.device_health) == {DEVICE, OTHER}
+    assert card.last_active is True
+    assert set(card.last_findings) == {DEVICE, OTHER}
+
+
+def test_several_findings_on_one_device_are_all_carried(card) -> None:
+    coord = _coordinator()
+    _drive(
+        coord,
+        {DEVICE: _gen2(rssi=-86, tc=90.0, ram_free=100, restart=True)},
+    )
+    assert _checks(list(coord.device_health[DEVICE])) == {
+        CHECK_WIFI, CHECK_TEMPERATURE, CHECK_RAM, CHECK_RESTART
+    }
+
+
+def test_firmware_findings_stay_out_unless_the_option_is_set(card) -> None:
+    coord = _coordinator()
+    _drive(coord, {DEVICE: _gen2(updates=UPDATES)})
+    assert coord.device_health == {}
+    assert card.last_active is False
+
+
+def test_firmware_findings_appear_once_the_option_is_set(card) -> None:
+    coord = _coordinator(**{CONF_DEVICE_HEALTH_FIRMWARE: True})
+    _drive(coord, {DEVICE: _gen2(updates=UPDATES)})
+    assert _checks(list(coord.device_health[DEVICE])) == {CHECK_FIRMWARE}
+
+
+def test_the_option_switches_the_check_off_and_drops_its_verdicts(card) -> None:
+    coord = _coordinator(**{CONF_DEVICE_HEALTH_DETECTION: False})
+    _drive(coord, {DEVICE: _gen2(rssi=-86, tc=90.0)})
+    assert coord.device_health == {}
+    assert card.last_active is False
+
+
+def test_switching_the_check_off_clears_a_standing_card(card) -> None:
+    """The user unticking the option must take the card with it, not leave
+    a verdict nothing will ever re-evaluate."""
+    coord = _coordinator()
+    _drive(coord, {DEVICE: _gen2(rssi=-86)})
+    assert coord.device_health[DEVICE]
+
+    coord._entry.options = {
+        **coord._entry.options, CONF_DEVICE_HEALTH_DETECTION: False,
+    }
+    _drive(coord, {DEVICE: _gen2(rssi=-86)}, start=5000.0, polls=1)
+    assert coord.device_health == {}
+    assert coord._health_streak == {}
+    assert card.last_active is False
+
+
+def test_a_device_the_user_unticks_stops_being_reported(card) -> None:
+    """The finding is about hardware Home Assistant no longer looks at."""
+    coord = _coordinator()
+    _drive(coord, {DEVICE: _gen2(rssi=-86)})
+    assert coord.device_health[DEVICE]
+
+    coord._entry.options = {
+        **coord._entry.options,
+        "create_all_initially": False,
+        "enabled_devices": [OTHER],
+    }
+    _drive(coord, {DEVICE: _gen2(rssi=-86)}, start=5000.0, polls=1)
+    assert coord.device_health == {}
+    assert card.last_active is False
+
+
+# ── The card is cleaned up with the entry ─────────────────────────────
+
+
+def test_removing_the_entry_deletes_the_health_card(monkeypatch) -> None:
+    """A kind missing from ``async_clear_entry_issues`` outlives the entry
+    that raised it, and nothing ever comes back to remove it."""
+    from custom_components.shelly_cloud_diy import repair_issues
+
+    deleted: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        repair_issues.ir, "async_delete_issue",
+        lambda hass, domain, iid: deleted.append((domain, iid)),
+    )
+    repair_issues.async_clear_entry_issues(
+        None, SimpleNamespace(entry_id="entry", title="Shelly Cloud DIY")
+    )
+    assert (DOMAIN, issue_id(ISSUE_DEVICE_HEALTH, "entry")) in deleted

--- a/tests/test_offline_reporting.py
+++ b/tests/test_offline_reporting.py
@@ -77,6 +77,10 @@ def _inert_repair_issues(monkeypatch):
         coordinator_mod, "async_manage_relay_fault_issue",
         lambda hass, entry, *, active, faults, names: None,
     )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_device_health_issue",
+        lambda hass, entry, *, active, findings, names: None,
+    )
 
 MAINS_ID = "ecda3bc59ec8"
 BLE_ID = "XB106582483818186"
@@ -164,6 +168,9 @@ def _coordinator(devices_status: dict[str, Any] | None = None, **options: Any) -
     coord._relay_fault_since = {}
     coord._relay_healthy_since = {}
     coord.relay_faults = set()
+    coord._health_streak = {}
+    coord._health_since = {}
+    coord.device_health = {}
     return coord
 
 

--- a/tests/test_rediscovery.py
+++ b/tests/test_rediscovery.py
@@ -71,6 +71,10 @@ def _inert_repair_issues(monkeypatch):
         coordinator_mod, "async_manage_relay_fault_issue",
         lambda hass, entry, *, active, faults, names: None,
     )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_device_health_issue",
+        lambda hass, entry, *, active, findings, names: None,
+    )
 
 DEVICE_ID = "ecda3bc59ec8"
 OTHER_ID = "d0ef76c7a454"
@@ -138,6 +142,9 @@ def _coordinator(devices_status: dict[str, Any]) -> ShellyCloudCoordinator:
     coord._relay_fault_since = {}
     coord._relay_healthy_since = {}
     coord.relay_faults = set()
+    coord._health_streak = {}
+    coord._health_since = {}
+    coord.device_health = {}
     return coord
 
 

--- a/tests/test_relay_fault.py
+++ b/tests/test_relay_fault.py
@@ -66,6 +66,10 @@ def _inert_repair_issues(monkeypatch):
         coordinator_mod, "async_manage_missing_devices_issue",
         lambda hass, entry, *, active, missing, names: None,
     )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_device_health_issue",
+        lambda hass, entry, *, active, findings, names: None,
+    )
     # Every device here is enabled (``create_all_initially``) so that the
     # relay evaluation sees it at all, which also makes the poll dispatch
     # SIGNAL_NEW_DEVICE into a Home Assistant that does not exist.
@@ -224,6 +228,9 @@ def _coordinator(devices_status: dict[str, Any], **options: Any) -> ShellyCloudC
     coord._relay_fault_since = {}
     coord._relay_healthy_since = {}
     coord.relay_faults = set()
+    coord._health_streak = {}
+    coord._health_since = {}
+    coord.device_health = {}
     # The real one reaches into the HA device registry for a fallback label.
     # Its behaviour belongs to the missing-devices card and is covered there.
     coord._display_names = lambda ids: {

--- a/tests/test_repair_issues.py
+++ b/tests/test_repair_issues.py
@@ -60,10 +60,13 @@ _EXPECTED_ISSUE_KEYS = {
     "missing_devices",
     "history_import_failed",
     "relay_fault",
+    "device_health",
 }
 
 # Everything the async_manage_* wrappers actually supply as placeholders.
-_SUPPLIED_PLACEHOLDERS = {"entry_title", "count", "device_ids", "devices"}
+_SUPPLIED_PLACEHOLDERS = {
+    "entry_title", "count", "device_ids", "devices", "summary",
+}
 
 
 # ── Part A: issue id scoping ──────────────────────────────────────────
@@ -405,6 +408,9 @@ class _RealCoordinatorDriver:
         coord._relay_fault_since = {}
         coord._relay_healthy_since = {}
         coord.relay_faults = set()
+        coord._health_streak = {}
+        coord._health_since = {}
+        coord.device_health = {}
         self.coord = coord
 
         sink = self.sink

--- a/tests/test_sleeping_availability.py
+++ b/tests/test_sleeping_availability.py
@@ -405,6 +405,10 @@ def _inert_repair_issues(monkeypatch):
         coordinator_mod, "async_manage_relay_fault_issue",
         lambda hass, entry, *, active, faults, names: None,
     )
+    monkeypatch.setattr(
+        coordinator_mod, "async_manage_device_health_issue",
+        lambda hass, entry, *, active, findings, names: None,
+    )
 
 
 def _live_coordinator(devices_status: dict[str, Any]) -> ShellyCloudCoordinator:
@@ -434,6 +438,9 @@ def _live_coordinator(devices_status: dict[str, Any]) -> ShellyCloudCoordinator:
     coord._relay_fault_since = {}
     coord._relay_healthy_since = {}
     coord.relay_faults = set()
+    coord._health_streak = {}
+    coord._health_since = {}
+    coord.device_health = {}
     return coord
 
 


### PR DESCRIPTION
Two work packages from `.planning/PLAN-neighbour-ideas.md`, both grounded in a real 64-device account snapshot rather than in guesses.

## 1. Device health checks ("Doctor")

Every poll already returns Wi-Fi signal, component temperatures, free RAM and filesystem, a pending restart and per-component error arrays. None of it was interpreted. One **aggregated** repair card now does — never one per device.

**Cost: zero.** No extra request, no extra credential, nothing from the 1 req/s budget.

| Check | Warning | Error | Measured range in the sample |
|---|---|---|---|
| Wi-Fi signal | ≤ -70 dBm | ≤ -85 dBm | **-82 … -31** (warning fires, error does not) |
| Component temperature | ≥ 70 °C | ≥ 85 °C | **36.6 … 78.5** |
| Free RAM | < 20 % | < 10 % | 30.4 … 54.2 % |
| Free filesystem | < 20 % | < 10 % | 25.0 … 50.4 % |
| Restart pending | — | truthy | field on 35/35, `true` never observed |
| Component error | — | non-empty `errors` | `temperature:100 → ["read"]` |
| Firmware update | info | — | **opt-in**, off by default |

On the reference account: **19 findings across 14 of 64 devices** with firmware off. Neither silent nor noisy.

**Two gates** before anything is said — three *check-ins* (not polls) plus five minutes. Clearing is immediate: unlike a welded contact, nothing measured here can produce an innocent sample mid-fault.

**Only a component's own heat counts.** A standalone `temperature:<id>` is an external Add-on probe measuring the world; a sensor in a boiler flow pipe is hot by design and the payload cannot distinguish it from an overheating device. The exclusion costs nothing measured — both hot readings in the sample come from `switch:0` — and a broken probe is still caught by the component-error check.

**BLU devices** are judged only on the RSSI their gateway reports. **Gen1 devices are not judged at all**: none appears in any recorded payload, so every Gen1 threshold would rest on documentation rather than evidence.

**Firmware findings are off by default** because 24 of 35 Gen2 devices on the reference account had an update pending. A card lit on two thirds of a fleet teaches the user to ignore the card.

## 2. Wi-Fi signal sensors, and a guard against the gap that hid them

`RPC_SENSORS["rssi"]` and `BLOCK_SENSORS[("wifi_sta", "rssi")]` have existed since the first release and no builder ever looked either up. Signal strength is present on 35/35 Gen2+ devices and produced no entity. **Fourth instance of one bug class this month** after #38, #41 and #42.

Both wired, gated on a non-null reading so a Pro on Ethernet gets no permanently-unknown entity. The Gen1 shape comes from the vendor documentation and says so.

Two guards so it cannot recur quietly:

- **`tests/test_dead_descriptions.py`** — parses both platform modules with `ast` and fails when a description is declared that no builder looks up. Unwired entries need an explicit allowlist entry with a reason; it holds 22 today, 21 of them Gen1 shapes with no real payload to verify against. Shrinking it is the goal.
- **A `coverage` block in device diagnostics** — names the payload keys that produce no entity. Derived from the *builders*, not the description tables; a table-derived report would have called all four bugs "covered". Never raises: any failure degrades to an error string so the rest of the download survives.

That report's largest remaining gaps on the reference account: `sys`, `reporter` (the only BLU signal figure) and BLU `input:0` on 13 devices — a button press that currently produces nothing.

## Verification

- 376 passed / 2 skipped on HA 2025.1.4 (py3.12), 377 / 1 on HA 2026.7.2 (py3.14)
- All three translation files parse; card and option text mirrored EN + DE
- Evaluator cross-checked against the real snapshot: the -82 dBm device, the 78.5 °C switch and the five `errors: ["read"]` add-on channels are all found; **0 findings on the 29 BLU devices beyond RSSI**

## Not verified

`restart_required: true` and a non-empty `devicepower.errors` never occur in the sample — coded from field presence, not observed. No Gen1 hardware was available for the Gen1 RSSI sensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XarCtwJ7JnsgAgaUytQhQs
