### PR TITLE
feat(sensor): surface the BLU gateway signal and a firmware-update flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ full reasoning and the reporters' credits:
 the history is readable from a checkout alone, including on the Gitea mirror,
 which has no release pages.
 
+## Unreleased
+
+- **New: a Gateway signal sensor for Bluetooth (BLU) devices.** How well the
+  bridging gateway hears the device — the only signal figure a BLU sensor has,
+  present on every one of them and until now surfaced nowhere. Named after the
+  gateway deliberately: a poor reading may mean the gateway sits in the wrong
+  place rather than the sensor. The gateway's id rides along as an attribute,
+  because a device can be picked up by a different one after a move.
+- **New: a Firmware update flag on Gen2+ devices**, with the offered version as
+  an attribute. A diagnostic flag, not an installer — flashing firmware stays
+  with the local integration. Note this is deliberately not the same default as
+  the health card's firmware finding, which stays opt-in: an entity waits to be
+  looked at, a repair card interrupts, and on a typical account most devices
+  have an update pending.
+
 ## v0.11.0 — 2026-09-04
 
 - **New: a warning when a device is running hot, weak or short of memory.**

--- a/README.de.md
+++ b/README.de.md
@@ -255,11 +255,22 @@ Auf einem typischen Konto hat die Mehrheit der Geräte eines offen; eine Karte,
 die dauerhaft leuchtet, ist eine Karte, die du nicht mehr liest — auch an dem
 Tag, an dem sie ein Gerät bei 85 °C meldet.
 
-Jedes Gen2+-Gerät bekommt außerdem einen **WLAN-Signal**-Sensor (Kategorie
-Diagnose), und die Geräte-Diagnose enthält einen *coverage*-Abschnitt, der
-benennt, welche Teile des Payloads bei uns noch gar keine Entität erzeugen — so
-taucht eine Lücke in einem Fehlerbericht auf, statt darauf zu warten, dass sie
-jemandem auffällt.
+Neben der Karte machen drei Diagnose-Entitäten Werte sichtbar, die die ganze
+Zeit in den Daten lagen und nirgends ankamen:
+
+- **WLAN-Signal** auf jedem Gen2+-Gerät.
+- **Gateway-Signal** auf jedem Bluetooth-Gerät (BLU) — wie gut das brückende
+  Gateway es hört. Bewusst nach dem Gateway benannt: ein BLU-Sensor hat keine
+  eigene Funkzahl, ein schlechter Wert kann also heißen, dass das Gateway falsch
+  steht, nicht der Sensor.
+- **Firmware-Update**, ein Kennzeichen auf jedem Gen2+-Gerät, das eines meldet,
+  mit der angebotenen Version als Attribut. Ein Kennzeichen, kein Installer —
+  das Flashen bleibt bei der lokalen Integration.
+
+Die Geräte-Diagnose enthält außerdem einen *coverage*-Abschnitt, der benennt,
+welche Teile des Payloads bei uns noch gar keine Entität erzeugen — so taucht
+eine Lücke in einem Fehlerbericht auf, statt darauf zu warten, dass sie jemandem
+auffällt.
 
 Die ganze Prüfung lässt sich in den Optionen abschalten.
 

--- a/README.md
+++ b/README.md
@@ -243,10 +243,21 @@ none:
 typical account most devices have one; a card that is permanently lit is a card
 you stop reading, including on the day it reports a device cooking at 85 °C.
 
-Every Gen2+ device also gets a **Wi-Fi signal** sensor (diagnostic category), and
-device diagnostics carry a *coverage* section naming the parts of a device's
-payload that still produce no entity — so a gap turns up in a bug report instead
-of waiting for someone to notice it.
+Alongside the card, three diagnostic entities surface readings that were in the
+data all along and went nowhere:
+
+- **Wi-Fi signal** on every Gen2+ device.
+- **Gateway signal** on every Bluetooth (BLU) device — how well the bridging
+  gateway hears it. Named after the gateway on purpose: a BLU sensor has no
+  radio figure of its own, so a poor reading may mean the gateway is in the
+  wrong place rather than the sensor.
+- **Firmware update**, a flag on every Gen2+ device that reports one, with the
+  offered version as an attribute. It is a flag, not an installer — flashing
+  firmware stays with the local integration.
+
+Device diagnostics also carry a *coverage* section naming the parts of a
+device's payload that still produce no entity, so a gap turns up in a bug report
+instead of waiting for someone to notice it.
 
 The whole check has an off switch in the options.
 

--- a/custom_components/shelly_cloud_diy/binary_sensor.py
+++ b/custom_components/shelly_cloud_diy/binary_sensor.py
@@ -415,6 +415,25 @@ def _create_rpc_sensors(
                     coordinator, device_id, desc, 0, "cloud", "connected"
                 ))
 
+    # Firmware update — ``sys.available_updates``. A top-level, non-indexed
+    # key, read by name like ``cloud.connected`` above.
+    #
+    # Created whenever the field is a dict, INCLUDING an empty one: ``{}`` is
+    # the device saying it is current (11 of the 35 Gen2+ devices in the
+    # recorded account snapshot), which is a real "off" and not a missing
+    # reading. That is the opposite gate to the BLU signal sensor, and it is
+    # the shape of the field that decides which one applies.
+    sys_block = status.get("sys")
+    if isinstance(sys_block, dict) and isinstance(
+        sys_block.get("available_updates"), dict
+    ):
+        uid = f"{device_id}_firmware_update"
+        if uid not in created:
+            created.add(uid)
+            entities.append(
+                ShellyFirmwareUpdateBinarySensor(coordinator, device_id)
+            )
+
     # Virtual boolean components (READ-ONLY) — Gen2/Gen3 ``boolean:<id>.value``.
     # Exposed read-only for the same reason as the virtual sensors in sensor.py:
     # the cloud status carries no component config (writable-view / name) and the
@@ -432,6 +451,84 @@ def _create_rpc_sensors(
                     ))
 
     return entities
+
+
+class ShellyFirmwareUpdateBinarySensor(ShellyBaseEntity, BinarySensorEntity):
+    """Whether the device is offering a stable firmware update.
+
+    ⚠ The health *repair card* built on the very same field is opt-in and
+    off by default, and the difference is deliberate — do not harmonise the
+    two. 24 of the 35 Gen2+ devices in the measured account had an update
+    pending, so a card would be permanently lit on two thirds of a fleet and
+    would teach the user to ignore the card that also reports a device
+    cooking at 85 °C. An entity has the opposite property: it never
+    interrupts, it waits in the collapsed diagnostics section until someone
+    looks or writes an automation, and being "on" on 24 devices costs
+    nothing. Hence: card off by default, entity created by default.
+
+    Beta offers read ``off``. Nudging a user towards a beta build is not
+    what a default-on flag should do; the version is still reported as an
+    attribute, so the reading is not lost.
+
+    This is NOT the HA update platform: no install button, no release notes,
+    no version comparison. It is a diagnostic flag over a field the cloud
+    already hands us — flashing firmware stays with the native, local
+    integration.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.UPDATE
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "Firmware update"
+    # Stated rather than inherited, because it is the decision this class is
+    # about: unlike the Cloud sensor next to it, this reading is meaningful
+    # on every device that reports it, so it is registered enabled.
+    _attr_entity_registry_enabled_default = True
+    # No ``_status_key = "sys"`` on purpose. The diagnostics coverage report
+    # works at top-level-key granularity, so claiming ``sys`` here would mark
+    # the whole block covered while uptime, free RAM and free filesystem
+    # still produce no entity. Three real gaps would stop being reported to
+    # buy this one entity a mention.
+
+    def __init__(
+        self, coordinator: ShellyCloudCoordinator, device_id: str
+    ) -> None:
+        """Initialize the firmware update sensor."""
+        super().__init__(coordinator, device_id, 0)
+        self._attr_unique_id = f"{device_id}_firmware_update"
+
+    def _available_updates(self) -> dict[str, Any] | None:
+        """Return the ``sys.available_updates`` map, or None if unreadable."""
+        sys_block = self.device_status.get("sys")
+        if not isinstance(sys_block, dict):
+            return None
+        updates = sys_block.get("available_updates")
+        return updates if isinstance(updates, dict) else None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True while a stable firmware version is on offer."""
+        updates = self._available_updates()
+        if updates is None:
+            return None
+        stable = updates.get("stable")
+        return isinstance(stable, dict) and bool(stable.get("version"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose the offered version — the number is the useful part.
+
+        "An update exists" cannot be acted on; "the offer here is 2.0.0,
+        while five other devices are only offered 1.7.5" can.
+        """
+        updates = self._available_updates()
+        if not updates:
+            return None
+        attributes: dict[str, Any] = {}
+        for channel in ("stable", "beta"):
+            entry = updates.get(channel)
+            if isinstance(entry, dict) and entry.get("version"):
+                attributes[f"{channel}_version"] = entry["version"]
+        return attributes or None
 
 
 class RpcVirtualBinarySensor(ShellyBaseEntity, BinarySensorEntity):

--- a/custom_components/shelly_cloud_diy/diagnostics.py
+++ b/custom_components/shelly_cloud_diy/diagnostics.py
@@ -75,11 +75,15 @@ DEVICE_TO_REDACT = {"name", "cloud_name", "ssid", "sta_ip", "ip", "mac"}
 #
 # Deliberately NOT excluded, although both are tempting:
 #
-#   sys        carries uptime, RAM and filesystem headroom and the pending
-#              firmware version. None of it is an entity today, and that is
-#              a real gap the report should keep saying out loud.
-#   reporter   the bridging gateway's RSSI — on a BLU device it is the only
-#              signal figure there is, and it has no description at all.
+#   sys        carries uptime, RAM and filesystem headroom. The pending
+#              firmware version became an entity, but that entity claims no
+#              status key on purpose (see ShellyFirmwareUpdateBinarySensor):
+#              this report judges a top-level block whole, and the three
+#              readings above still surface nowhere.
+#   reporter   the bridging gateway's RSSI, and on a BLU device the only
+#              signal figure there is. Surfaced by the gateway signal sensor
+#              now — but only while the gateway reports a usable reading, so
+#              the key still has to be able to appear as a gap.
 STRUCTURAL_STATUS_KEYS = frozenset(
     {"_updated", "_dev_info", "serial", "ts", "id", "code"}
 )
@@ -299,7 +303,9 @@ def _coverage_diagnostics(
     set, and the answer is assembled from the entities they actually return.
     The two device-wide binary sensors (Reporting, Relay fault) are left out
     because they derive from no single status key and would only blur the
-    picture.
+    picture. The firmware flag is left out for the neighbouring reason: it
+    reads one field of ``sys`` and claiming the whole block would hide the
+    three readings in it that still produce nothing.
 
     Key NAMES only, never values — this block sits next to a redacted dump
     and must not become a way around it.

--- a/custom_components/shelly_cloud_diy/sensor.py
+++ b/custom_components/shelly_cloud_diy/sensor.py
@@ -11,7 +11,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from homeassistant.const import PERCENTAGE, UnitOfElectricPotential, EntityCategory
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfElectricPotential,
+)
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
 from .const import DOMAIN, SIGNAL_DEVICE_REMOVED, device_gen, is_gen2_status
@@ -709,6 +714,22 @@ class BlockSensor(ShellyBaseEntity, SensorEntity):
         return value
 
 
+def _usable_rssi(value: Any) -> int | float | None:
+    """Return a signal reading, or ``None`` when the radio reported none.
+
+    Two shapes mean "no measurement" and both would otherwise become an
+    entity: a missing or null reading, and a non-negative one — a receiver
+    that has not heard the transmitter yet reports ``0``, which as dBm would
+    read as a perfect link. ``bool`` is rejected for the same reason
+    ``device_health._as_number`` rejects it: a ``bool`` is an ``int`` in
+    Python, so a payload carrying ``rssi: true`` would otherwise be treated
+    as a number rather than as the malformed reading it is.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return value if value < 0 else None
+
+
 def _create_ble_sensors(
     device_id: str,
     status: dict[str, Any],
@@ -777,6 +798,28 @@ def _create_ble_sensors(
                         coordinator=coordinator, device_id=device_id
                     )
                 )
+
+    # reporter.rssi — the bridging gateway's view of this device. A top-level
+    # block, so it is read by name rather than through the ``<type>:<channel>``
+    # scan above, the same way the Gen2 builder reads ``wifi.rssi``.
+    #
+    # Present on 29 of 29 gateway-bridged devices in the recorded account
+    # snapshot (-43 … -84 dBm), and it is the only signal figure a BLU device
+    # has at all. The health checks have been reading it since they were
+    # written; nothing ever surfaced it — the same gap as ``wifi.rssi``.
+    #
+    # Gated on a usable reading rather than on the key, because the block is
+    # also there before the gateway has heard the beacon.
+    reporter = status.get("reporter")
+    if isinstance(reporter, dict) and _usable_rssi(reporter.get("rssi")) is not None:
+        uid = f"{device_id}_ble_reporter_rssi"
+        if uid not in created:
+            created.add(uid)
+            entities.append(
+                BleReporterSignalSensor(
+                    coordinator=coordinator, device_id=device_id
+                )
+            )
 
     return entities
 
@@ -946,3 +989,65 @@ class BleBatteryVoltageSensor(ShellyBaseEntity, SensorEntity):
         if not isinstance(battery, dict):
             return None
         return battery.get("V")
+
+
+class BleReporterSignalSensor(ShellyBaseEntity, SensorEntity):
+    """How well the bridging gateway hears this device (``reporter.rssi``).
+
+    Named after the gateway on purpose. A BLU sensor has no IP link and no
+    radio figure of its own; what the cloud carries is the *receiver's* view
+    of the beacon. An entity called plain "Signal" sitting next to a battery
+    reading would be read as the sensor's own transmitter, and a user acting
+    on a bad number would move the wrong device.
+
+    Deliberately not an entry in ``BLE_SENSORS``: that table is keyed by the
+    component type of a ``<type>:<channel>`` key and is consumed by a loop
+    over exactly those keys, so a ``reporter`` entry could never be reached
+    from it. This follows the two battery sensors above instead, which are
+    the other readings whose shape the table cannot express.
+    """
+
+    _attr_name = "Gateway signal"
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    # See BleBatteryPercentSensor: declared so the diagnostics coverage
+    # report can tell that ``reporter`` is a surfaced key and not a gap.
+    _status_key = "reporter"
+
+    def __init__(
+        self,
+        *,
+        coordinator: ShellyCloudCoordinator,
+        device_id: str,
+    ) -> None:
+        super().__init__(coordinator, device_id, 0)
+        self._attr_unique_id = f"{device_id}_ble_reporter_rssi"
+
+    @property
+    def native_value(self) -> int | float | None:
+        """Return the gateway's current signal reading for this device."""
+        reporter = self.device_status.get("reporter")
+        if not isinstance(reporter, dict):
+            return None
+        # Same filter the builder gates on, so a link that stops being
+        # measurable reads as unknown rather than as a perfect 0 dBm.
+        return _usable_rssi(reporter.get("rssi"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Name the gateway the reading was taken at.
+
+        One gateway relays for many BLU devices, and a device can be picked
+        up by a different one after a move or a reboot — so a poor reading
+        is only actionable together with the identity of the receiver that
+        took it. It is free: the id sits in the same block as the value.
+        """
+        reporter = self.device_status.get("reporter")
+        if not isinstance(reporter, dict):
+            return None
+        gateway = reporter.get("id")
+        if gateway is None:
+            return None
+        return {"gateway_id": str(gateway)}

--- a/tests/test_ble_reporter_signal.py
+++ b/tests/test_ble_reporter_signal.py
@@ -1,0 +1,186 @@
+"""Unit tests for the BLU gateway signal sensor (``reporter.rssi``).
+
+A Shelly BLU device has no IP link, so it has no radio figure of its own.
+What the cloud carries instead is ``reporter.rssi`` — how well the bridging
+gateway hears the beacon. It is present on 29 of 29 gateway-bridged devices
+in the recorded account snapshot (-43 … -84 dBm), the health checks have been
+reading it since they were written, and no entity ever surfaced it: the same
+gap ``wifi.rssi`` had on the Gen2 side.
+
+These tests drive the real creation loop (``_create_ble_sensors``) and the
+real entity with a lightweight fake coordinator, so they run identically
+against any HA version and need no running Home Assistant.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import EntityCategory
+
+from custom_components.shelly_cloud_diy.const import device_gen
+from custom_components.shelly_cloud_diy.sensor import (
+    BleReporterSignalSensor,
+    _create_ble_sensors,
+    _usable_rssi,
+)
+
+DEVICE_ID = "XB106582483818186"
+GATEWAY_ID = "146221729481748"
+UID = f"{DEVICE_ID}_ble_reporter_rssi"
+
+
+class _FakeCoordinator:
+    """Minimal coordinator: entities only read ``.devices[id]['status']``."""
+
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {
+            device_id: {
+                "status": status,
+                "device_code": "SBHT-003C",
+                "online": True,
+            }
+        }
+        self.data = self.devices
+        self.last_update_success = True
+
+
+def _blu_status(reporter: Any = "default") -> dict[str, Any]:
+    """The shape a BLU H&T arrives in, gateway block included."""
+    status: dict[str, Any] = {
+        "_dev_info": {"gen": "GBLE"},
+        "temperature:0": {"id": 0, "tC": 21.4},
+        "humidity:0": {"id": 0, "rh": 48.0},
+        "devicepower:0": {"id": 0, "battery": {"percent": 100, "V": None}},
+    }
+    if reporter == "default":
+        reporter = {"id": GATEWAY_ID, "rssi": -59, "inrange": False}
+    if reporter is not None:
+        status["reporter"] = reporter
+    return status
+
+
+def _build(status: dict[str, Any], created: set[str] | None = None):
+    coord = _FakeCoordinator(DEVICE_ID, status)
+    entities = _create_ble_sensors(
+        DEVICE_ID, status, set() if created is None else created, coord
+    )
+    return entities, {e.unique_id: e for e in entities}
+
+
+def test_blu_payload_is_classified_as_a_bridged_device() -> None:
+    """Guards the branch: only the BLE builder ever sees ``reporter``."""
+    assert device_gen(_blu_status()) == "GBLE"
+
+
+def test_gateway_signal_sensor_is_created_and_reads_the_gateway_view() -> None:
+    """The reading the 29 measured BLU devices all carry becomes an entity."""
+    _, by_uid = _build(_blu_status())
+
+    sensor = by_uid[UID]
+    assert isinstance(sensor, BleReporterSignalSensor)
+    assert sensor.native_value == -59
+    assert sensor.native_unit_of_measurement == "dBm"
+    assert sensor.device_class is SensorDeviceClass.SIGNAL_STRENGTH
+    assert sensor.state_class is SensorStateClass.MEASUREMENT
+    assert sensor.entity_category is EntityCategory.DIAGNOSTIC
+
+
+def test_the_name_says_the_reading_belongs_to_the_gateway() -> None:
+    """A BLU sensor has no radio of its own; the name must not imply one."""
+    _, by_uid = _build(_blu_status())
+
+    assert "gateway" in by_uid[UID].name.lower()
+
+
+def test_the_relaying_gateway_is_exposed_as_an_attribute() -> None:
+    """One gateway relays for many devices, so the reading needs a receiver."""
+    _, by_uid = _build(_blu_status())
+
+    assert by_uid[UID].extra_state_attributes == {"gateway_id": GATEWAY_ID}
+
+
+def test_no_gateway_id_means_no_attributes_rather_than_a_null_one() -> None:
+    """An attribute reading ``None`` would look like a named gateway."""
+    _, by_uid = _build(_blu_status({"rssi": -70}))
+
+    assert by_uid[UID].extra_state_attributes is None
+
+
+def test_no_entity_without_a_usable_reading() -> None:
+    """The gate is the reading, not the key.
+
+    The block exists on a gateway that has not heard the beacon yet, and an
+    entity that can only ever say "unknown" — or claim a perfect 0 dBm — is
+    worse than no entity.
+    """
+    for reporter in (
+        None,
+        {},
+        {"id": GATEWAY_ID},
+        {"id": GATEWAY_ID, "rssi": None},
+        {"id": GATEWAY_ID, "rssi": 0},
+        {"id": GATEWAY_ID, "rssi": 7},
+        {"id": GATEWAY_ID, "rssi": "strong"},
+        {"id": GATEWAY_ID, "rssi": True},
+    ):
+        _, by_uid = _build(_blu_status(reporter))
+        assert UID not in by_uid, f"entity built for reporter={reporter!r}"
+
+
+def test_a_device_without_the_block_still_gets_its_other_sensors() -> None:
+    """Absence of ``reporter`` must cost exactly one entity, not the rest."""
+    entities, by_uid = _build(_blu_status(None))
+
+    assert UID not in by_uid
+    assert f"{DEVICE_ID}_ble_temperature_0" in by_uid
+    assert f"{DEVICE_ID}_ble_battery_percent" in by_uid
+
+
+def test_a_reading_that_stops_being_usable_reads_unknown() -> None:
+    """The live value applies the same filter the builder gated on."""
+    status = _blu_status()
+    _, by_uid = _build(status)
+    sensor = by_uid[UID]
+
+    status["reporter"]["rssi"] = 0
+    assert sensor.native_value is None
+
+    del status["reporter"]
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes is None
+
+
+def test_the_sensor_is_created_once_per_device() -> None:
+    """The ``created`` set is what stops a rediscovery duplicating entities."""
+    created: set[str] = set()
+    _build(_blu_status(), created)
+    _, by_uid = _build(_blu_status(), created)
+
+    assert UID not in by_uid
+
+
+def test_the_coverage_report_can_see_which_key_this_entity_reads() -> None:
+    """``_status_key`` is the only way the diagnostics report learns this.
+
+    Without it ``reporter`` would keep being listed as an uncovered key even
+    though it now produces an entity — the mirror image of the bug the report
+    exists to find.
+    """
+    _, by_uid = _build(_blu_status())
+
+    assert by_uid[UID]._status_key == "reporter"
+
+
+def test_usable_rssi_rejects_everything_that_is_not_a_measurement() -> None:
+    """The shared filter, pinned on its own."""
+    assert _usable_rssi(-59) == -59
+    assert _usable_rssi(-43.5) == -43.5
+    assert _usable_rssi(0) is None
+    assert _usable_rssi(12) is None
+    assert _usable_rssi(None) is None
+    assert _usable_rssi("-59") is None
+    # A bool is an int in Python; a payload of ``rssi: true`` is malformed,
+    # not a one-decibel link.
+    assert _usable_rssi(True) is None
+    assert _usable_rssi(False) is None

--- a/tests/test_coverage_report.py
+++ b/tests/test_coverage_report.py
@@ -61,6 +61,18 @@ def _covered_gen2_status() -> dict[str, Any]:
     }
 
 
+def _ble_status() -> dict[str, Any]:
+    """A gateway-bridged payload with three surfaced keys and two that nothing reads."""
+    return {
+        "_dev_info": {"gen": "GBLE"},
+        "temperature:0": {"id": 0, "tC": 21.4},
+        "devicepower:0": {"id": 0, "battery": {"percent": 100, "V": None}},
+        "input:0": {"id": 0, "state": None, "percent": None, "errors": []},
+        "reporter": {"id": "146221729481748", "rssi": -71},
+        "packetid:0": {"id": 0, "packetid": 42},
+    }
+
+
 def _report(status: dict[str, Any]) -> dict[str, Any]:
     return _coverage_diagnostics(_FakeCoordinator(status), DEVICE_ID, status)
 
@@ -164,20 +176,33 @@ def test_ble_device_is_measured_against_the_ble_builders() -> None:
     absent from the BLE tables, so no entity is created for it — which is
     precisely what the report should say.
     """
-    status = {
-        "_dev_info": {"gen": "GBLE"},
-        "temperature:0": {"id": 0, "tC": 21.4},
-        "devicepower:0": {"id": 0, "battery": {"percent": 100, "V": None}},
-        "input:0": {"id": 0, "state": None, "percent": None, "errors": []},
-        "reporter": {"rssi": -71},
-        "packetid:0": {"id": 0, "packetid": 42},
-    }
+    status = _ble_status()
 
     report = _report(status)
 
     assert report["generation"] == "GBLE"
-    assert set(report["covered_keys"]) == {"temperature:0", "devicepower:0"}
-    assert report["uncovered_keys"] == ["input:0", "packetid:0", "reporter"]
+    assert set(report["covered_keys"]) == {
+        "temperature:0",
+        "devicepower:0",
+        "reporter",
+    }
+    assert report["uncovered_keys"] == ["input:0", "packetid:0"]
+
+
+def test_reporter_counts_as_coverage_only_while_it_reads() -> None:
+    """The BLU counterpart of the Wi-Fi case above.
+
+    ``reporter`` was the largest measured gap on the BLU side — present on
+    29 of 29 gateway-bridged devices and surfaced by nothing. It is covered
+    by the gateway signal sensor now, but only when the gateway actually
+    reports a reading: no entity is built for an unusable one, so the key
+    must go back to being a gap rather than silently counting as covered.
+    """
+    status = _ble_status()
+    assert "reporter" in _report(status)["covered_keys"]
+
+    status["reporter"]["rssi"] = None
+    assert "reporter" in _report(status)["uncovered_keys"]
 
 
 def test_no_status_value_ever_reaches_the_report() -> None:

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -1,0 +1,218 @@
+"""Unit tests for the Gen2+ "Firmware update" binary sensor.
+
+``sys.available_updates`` is present on 35 of 35 Gen2+ devices in the recorded
+account snapshot, and non-empty on 24 of them (18× 2.0.0, 5× 1.7.5, one beta).
+Nothing in the integration surfaced it: the health check that reads the same
+field is opt-in and off by default, precisely because a repair card lit on two
+thirds of a fleet is wallpaper. An entity does not have that problem, which is
+why this one exists and is created by default — see the class docstring before
+"harmonising" the two.
+
+The tests drive the real creation loop (``_create_rpc_sensors``) and the real
+entity with a lightweight fake coordinator, so they need no running HA.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import EntityCategory
+
+from custom_components.shelly_cloud_diy.binary_sensor import (
+    ShellyFirmwareUpdateBinarySensor,
+    _create_ble_binary_sensors,
+    _create_rpc_sensors,
+)
+
+DEVICE_ID = "a0dd6cffee01"
+UID = f"{DEVICE_ID}_firmware_update"
+
+
+class _FakeCoordinator:
+    """Minimal coordinator: entities only read ``.devices[id]['status']``."""
+
+    def __init__(self, device_id: str, status: dict[str, Any]) -> None:
+        self.devices = {
+            device_id: {
+                "status": status,
+                "device_code": "SNSW-001X16EU",
+                "online": True,
+            }
+        }
+        self.data = self.devices
+        self.last_update_success = True
+
+
+def _gen2_status(updates: Any = "absent") -> dict[str, Any]:
+    """A Gen2 payload, optionally carrying ``sys.available_updates``."""
+    sys_block: dict[str, Any] = {
+        "mac": "A0DD6CFFEE01",
+        "uptime": 545909,
+        "restart_required": False,
+    }
+    if updates != "absent":
+        sys_block["available_updates"] = updates
+    return {
+        "switch:0": {"id": 0, "output": True, "apower": 12.3},
+        "cloud": {"connected": True},
+        "wifi": {"rssi": -55},
+        "sys": sys_block,
+    }
+
+
+def _build(status: dict[str, Any], created: set[str] | None = None):
+    coord = _FakeCoordinator(DEVICE_ID, status)
+    entities = _create_rpc_sensors(
+        DEVICE_ID, status, set() if created is None else created, coord
+    )
+    return entities, {e.unique_id: e for e in entities}
+
+
+def test_a_pending_stable_update_reads_on() -> None:
+    """The 18 devices offering 2.0.0 in the snapshot are the main case."""
+    _, by_uid = _build(_gen2_status({"stable": {"version": "2.0.0"}}))
+
+    sensor = by_uid[UID]
+    assert isinstance(sensor, ShellyFirmwareUpdateBinarySensor)
+    assert sensor.is_on is True
+    assert sensor.device_class is BinarySensorDeviceClass.UPDATE
+    assert sensor.entity_category is EntityCategory.DIAGNOSTIC
+
+
+def test_the_offered_version_is_the_useful_part() -> None:
+    """Bare "an update exists" cannot be acted on; a version number can."""
+    _, by_uid = _build(_gen2_status({"stable": {"version": "1.7.5"}}))
+
+    assert by_uid[UID].extra_state_attributes == {"stable_version": "1.7.5"}
+
+
+def test_an_up_to_date_device_still_gets_the_entity() -> None:
+    """``{}`` is a reading, not a missing field.
+
+    11 of the 35 measured devices report it, and it means "current". Skipping
+    them would leave a fleet where only the devices in trouble have the
+    entity — so the one device that goes quiet looks identical to a healthy
+    one.
+    """
+    _, by_uid = _build(_gen2_status({}))
+
+    sensor = by_uid[UID]
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes is None
+
+
+def test_a_beta_offer_is_reported_but_does_not_read_on() -> None:
+    """One device in the snapshot offers only a beta.
+
+    A default-on flag must not nudge anyone into installing a beta build, so
+    the verdict stays ``off`` — while the version is still surfaced, because
+    dropping the reading entirely would be its own kind of dishonesty.
+    """
+    _, by_uid = _build(_gen2_status({"beta": {"version": "2.0.0-beta3"}}))
+
+    sensor = by_uid[UID]
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes == {"beta_version": "2.0.0-beta3"}
+
+
+def test_both_channels_are_reported_together() -> None:
+    """A device offering both must not lose one of the two versions."""
+    _, by_uid = _build(
+        _gen2_status(
+            {"stable": {"version": "2.0.0"}, "beta": {"version": "2.1.0-beta1"}}
+        )
+    )
+
+    sensor = by_uid[UID]
+    assert sensor.is_on is True
+    assert sensor.extra_state_attributes == {
+        "stable_version": "2.0.0",
+        "beta_version": "2.1.0-beta1",
+    }
+
+
+def test_no_entity_when_the_device_does_not_report_the_field() -> None:
+    """No field, no entity — an always-unknown flag helps nobody."""
+    for updates in ("absent", None, "yes", []):
+        _, by_uid = _build(_gen2_status(updates))
+        assert UID not in by_uid, f"entity built for available_updates={updates!r}"
+
+
+def test_no_entity_without_a_sys_block_at_all() -> None:
+    """Some payloads carry no ``sys``; that must not raise or invent one."""
+    status = _gen2_status()
+    del status["sys"]
+
+    _, by_uid = _build(status)
+    assert UID not in by_uid
+
+
+def test_a_malformed_channel_entry_reads_off_rather_than_raising() -> None:
+    """The cloud's shapes are not a contract; a surprise must not crash HA."""
+    status = _gen2_status({"stable": "2.0.0"})
+    _, by_uid = _build(status)
+
+    sensor = by_uid[UID]
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes is None
+
+
+def test_the_verdict_follows_the_payload() -> None:
+    """A device that gets flashed must clear the flag on the next poll."""
+    status = _gen2_status({"stable": {"version": "2.0.0"}})
+    _, by_uid = _build(status)
+    sensor = by_uid[UID]
+    assert sensor.is_on is True
+
+    status["sys"]["available_updates"] = {}
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes is None
+
+
+def test_the_sensor_is_created_once_per_device() -> None:
+    """The ``created`` set is what stops a rediscovery duplicating entities."""
+    created: set[str] = set()
+    _build(_gen2_status({}), created)
+    _, by_uid = _build(_gen2_status({}), created)
+
+    assert UID not in by_uid
+
+
+def test_it_is_registered_enabled_unlike_the_repair_card() -> None:
+    """Pins the decision the class docstring argues for.
+
+    The repair card over the same field defaults OFF because 24 of 35 devices
+    would light it permanently. The entity defaults ON because it never
+    interrupts anyone. If someone ever "harmonises" the two, this fails.
+    """
+    _, by_uid = _build(_gen2_status({"stable": {"version": "2.0.0"}}))
+
+    assert by_uid[UID].entity_registry_enabled_default is True
+
+
+def test_it_claims_no_status_key_so_sys_stays_a_reported_gap() -> None:
+    """Deliberate: the coverage report works at top-level-key granularity.
+
+    Claiming ``sys`` here would mark the whole block covered while uptime,
+    free RAM and free filesystem still produce no entity — three real gaps
+    traded away for one entity's mention.
+    """
+    _, by_uid = _build(_gen2_status({"stable": {"version": "2.0.0"}}))
+    sensor = by_uid[UID]
+
+    for attribute in ("_status_key", "_component_key", "_attr_key"):
+        assert not hasattr(sensor, attribute), attribute
+
+
+def test_a_bridged_device_gets_no_firmware_flag() -> None:
+    """BLU devices take the other branch and carry no ``sys`` block."""
+    status = {
+        "_dev_info": {"gen": "GBLE"},
+        "temperature:0": {"id": 0, "tC": 21.4},
+        "reporter": {"id": "146221729481748", "rssi": -71},
+    }
+    coord = _FakeCoordinator(DEVICE_ID, status)
+
+    built = _create_ble_binary_sensors(DEVICE_ID, status, set(), coord)
+
+    assert not [e for e in built if e.unique_id == UID]


### PR DESCRIPTION
Closes the two **measured** gaps the v0.11.0 coverage report named. Both readings have always been in the poll and nothing ever showed them.

## Gateway signal (BLU)

`reporter.rssi` is present on **29 of 29** gateway-bridged devices in the recorded account snapshot (-43 … -84 dBm) and is the **only** signal figure a BLU device has — it has no IP link and no radio figure of its own. The health checks have been reading it since they were written; nothing surfaced it.

Named **"Gateway signal"**, not "Signal": it is the *receiver's* view of the beacon. A user acting on a bad number by moving the sensor would be moving the wrong device. The gateway's id rides along as an attribute, because a device can be picked up by a different gateway after a move or a reboot.

Gated on a **usable** reading — null or `>= 0` produces no entity, since a receiver that has not heard the beacon reports `0`, which as dBm would read as a perfect link.

## Firmware update flag (Gen2+)

`sys.available_updates` is present on **35 of 35** Gen2+ devices, **24** with an offer pending. Created whenever the field is a dict, empty included: `{}` is the device saying it is current — a real "off", not a missing reading. That is the *opposite* gate to the BLU sensor, and the shape of the field is what decides which applies.

Beta-only offers read `off` (nudging users toward a beta is not a default-on flag's job); the version is still reported as an attribute.

**A flag, not an installer.** No install button, no release notes. Flashing firmware stays with the native local integration.

### One asymmetry that is deliberate

The entity is **enabled by default** while the health card's firmware finding stays **opt-in**. An entity waits in the collapsed diagnostics section until someone looks or writes an automation; a repair card interrupts. On a typical account most devices have an update pending, so a card would be permanently lit and would teach the user to ignore the card that also reports a device cooking at 85 °C. Both classes carry that reasoning in a comment so nobody later "harmonises" them.

### And one non-claim

The firmware sensor deliberately declares **no** status key, so `sys` keeps appearing in the coverage report. Uptime, free RAM and free filesystem still surface nowhere — buying one entity a mention should not hide three real gaps.

## Verification

- 401 passed / 2 skipped on HA 2025.1.4 (py3.12), 402 / 1 on HA 2026.7.2 (py3.14)
- Against the real 64-device snapshot: **29 gateway-signal entities on 29/29 BLU devices**, **35 firmware entities on 35/35 Gen2+**, 23 reading `on`. `reporter` left the uncovered list entirely (29 devices → 0). No builder errors.
- The dead-description guard passes unchanged; neither item consumes a description-table entry, so the allowlist is untouched — the 21 Gen1 entries remain, as intended.

## Docs, in this PR rather than at release time

Both READMEs now list the three diagnostic entities, and the CHANGELOG gained an **Unreleased** section so the next release cannot ship without them. That is the direct fix for v0.11.0 shipping with its READMEs stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XarCtwJ7JnsgAgaUytQhQs
