### PR TITLE
feat(control): switch virtual components on devices the account owns (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ which has no release pages.
 
 ## Unreleased
 
+- **New: switching virtual components over the cloud — opt-in, and off by
+  default.** An irrigation controller's zones and a script's boolean can be
+  read through the documented Cloud Control API but not written: every
+  documented route answers "no such route" (measured, with a known-good call
+  as the negative control). They can be written over the cloud WebSocket relay
+  Shelly's own app uses, which is **undocumented** and which Shelly support
+  declared unsupported on 2026-07-27 — so it is a switch the user turns on
+  knowingly, not a default. Switching it on asks for the Shelly account
+  sign-in the relay needs (the password is used once and never stored; only
+  the resulting token is, and turning the option off again deletes it) and
+  opens a second connection used for commands only. It works **only on devices
+  the account owns** — Shelly's relay refuses to route to a shared device, and
+  every device carrying such a component is asked once per session (never per
+  poll), with the answer in diagnostics so
+  "why has my device no switch" is answerable from a bug report. The new
+  switch is created **beside** the existing read-only sensor of the same
+  component, never instead of it: replacing it would silently break every
+  automation already pointing at it. A failed command raises an error in the
+  UI and in the automation trace instead of reporting a success, and the state
+  afterwards comes from the next poll rather than an optimistic guess — a
+  guess is exactly what would hide a valve that accepted the command and did
+  not move; if the control channel itself is down, the switch goes unavailable
+  rather than looking operable. **With the option off nothing about the integration changes:** no
+  sign-in, no second connection, no probe, no new entity.
+- The poll, the offline detector, the relay-fault detector and the health
+  checks are untouched by all of the above, and their tests pass unchanged.
 - **New: a Gateway signal sensor for Bluetooth (BLU) devices.** How well the
   bridging gateway hears the device — the only signal figure a BLU sensor has,
   present on every one of them and until now surfaced nowhere. Named after the

--- a/README.de.md
+++ b/README.de.md
@@ -108,6 +108,7 @@ Lücke schließt dieses Projekt.
 | 📡 **Ausfall-Erkennung** | Ein **Reporting**-Sensor je Gerät, der abfällt, sobald sich ein Gerät nicht mehr meldet — das Signal, das `cloud.connected` nicht liefern kann (siehe unten). | ✅ ausgeliefert |
 | ⚡ **Warnung bei klebendem Kontakt** | Meldet, wenn ein Relais sich als offen meldet, während die geräteeigene Messung weiter eine Last sieht — ein verschweißter Kontakt (siehe unten). | ✅ ausgeliefert |
 | 🩺 **Gesundheitsprüfung** | Meldet, wenn ein Gerät heiß läuft, sein WLAN-Signal schwach ist oder ihm Speicher ausgeht — aus Daten, die der Abruf ohnehin liefert, ohne eine einzige zusätzliche Anfrage (siehe unten). | ✅ ausgeliefert |
+| 🎛️ **Cloud-Steuerung** | Schalter für virtuelle Komponenten — die Zonen eines Bewässerungscomputers, der Boolean eines Skripts —, die die dokumentierte API überhaupt nicht schreiben kann. Standardmäßig aus, läuft über einen **nicht unterstützten** Kanal und funktioniert nur auf Geräten, die deinem Konto gehören (siehe unten). | 🧪 Opt-in |
 | 📈 **Energie-Verlaufsimport** | Importiert historische Energiedaten in die Home-Assistant-Langzeitstatistik. | ✅ ausgeliefert |
 | ⚙️ **Config- + Options-Flow** | `auth_key` einfügen; Poll-Intervall und Geräte-Auswahl später anpassen. | ✅ ausgeliefert |
 | 🌍 **Lokalisierte UI** | Englische und deutsche Übersetzungen für jeden sichtbaren Text. | ✅ ausgeliefert |
@@ -273,6 +274,58 @@ eine Lücke in einem Fehlerbericht auf, statt darauf zu warten, dass sie jemande
 auffällt.
 
 Die ganze Prüfung lässt sich in den Optionen abschalten.
+
+### Schalten, was die dokumentierte API nicht schalten kann *(Opt-in, nicht unterstützt)*
+
+Manches, was ein Shelly kann, hat in der dokumentierten Cloud-Control-API keine
+Route. Die Zonen eines Bewässerungscomputers oder der Boolean, den ein Skript
+anbietet, sind *virtuelle Komponenten*: Die Cloud verrät ihren Zustand bereitwillig
+und bietet keinen Weg, ihn zu ändern. Jede dokumentierte Route antwortet „diese
+Route gibt es nicht" — gemessen, mit einer bekannt funktionierenden Anfrage als
+Gegenprobe, die etwas anderes antwortet. Es ist also wirklich Abwesenheit und
+kein falscher Parameter.
+
+Es gibt einen anderen Weg, und es lohnt sich, deutlich zu sagen, welchen. Shellys
+eigene App spricht über ein Cloud-WebSocket-Relay mit den Geräten, das deren
+eigenes RPC transportiert — und dieses Relay nimmt den Schreibbefehl an. Es ist
+**undokumentiert**, und der Shelly-Support hat am 27.07.2026 erklärt, dass
+undokumentierte Endpunkte nicht Teil der unterstützten API sind. Es kann sich
+jederzeit ändern oder verschwinden.
+
+Deshalb ist es **standardmäßig aus**, und das Einschalten hat einen Preis:
+
+- Es braucht die **Anmeldung an deinem Shelly-Konto**, weil das Relay ein
+  Konto-Token akzeptiert und nicht den Authorization cloud key. Das Passwort
+  wird einmal zur Anmeldung verwendet und **nie gespeichert** — gespeichert wird
+  nur das daraus entstehende Token, an derselben Stelle wie der Cloud Key, und
+  das Abschalten der Option löscht es wieder.
+- Es öffnet eine **zweite Verbindung** zur Shelly Cloud, ausschließlich für
+  Befehle. Der Gerätezustand kommt weiterhin aus dem normalen Abruf, es ändert
+  sich also nichts an dem, was heute schon funktioniert.
+- Es funktioniert **nur auf Geräten, die deinem Konto gehören**. Shellys Relay
+  weigert sich, zu einem geteilten Gerät zu routen, und daran führt von hier aus
+  kein Weg vorbei. Jedes Gerät, das eine solche Komponente hat, wird einmal pro
+  Sitzung gefragt — nicht bei jedem Abruf —, und die Antwort (eigenes Gerät,
+  nicht erreichbar oder „nicht feststellbar") steht in der Diagnose der
+  Integration. *„Warum hat mein Gerät keinen Schalter"* lässt sich damit aus
+  einem Fehlerbericht beantworten.
+
+**Der neue Schalter entsteht neben dem bestehenden schreibgeschützten Sensor,
+nicht an dessen Stelle.** Diese Doppelung ist Absicht: Den Sensor zu ersetzen
+würde jede Automatisierung und jede Dashboard-Karte, die darauf zeigt, still
+kaputtmachen — und „hört unbemerkt auf zu funktionieren" ist genau der Fehler,
+gegen den diese Funktion gebaut ist.
+
+**Ein Befehl, der scheitert, scheitert laut.** Wenn die Zone nicht geschaltet
+hat, gibt es einen Fehler in der Oberfläche und in der Automatisierungs-Trace —
+nie einen stillen Erfolg. Der Zustand danach kommt aus dem nächsten Abruf und
+nicht aus einer optimistischen Annahme, denn genau eine optimistische Annahme
+würde ein Ventil verbergen, das den Befehl angenommen und sich nicht bewegt hat.
+Ist der Kanal selbst weg, sagt der Schalter das, indem er **nicht verfügbar**
+wird — statt bedienbar auszusehen und bei jedem Druck zu scheitern.
+
+Einschalten unter *Einstellungen → Geräte & Dienste → Shelly Cloud DIY →
+Konfigurieren*.
 
 ---
 
@@ -490,11 +543,21 @@ Noch nicht fertig — gern ausprobieren, aber noch nicht darauf verlassen.
   und -Eingänge eines Shellys über das LAN auf den Ersatz, für Resilienz, die
   einen Internet- und einen Home-Assistant-Ausfall übersteht.
 
-### 🔭 Meilenstein 2 — OAuth + WebSocket-Realtime *(geplant)*
+### 🎛️ Cloud-Steuerung *(Opt-in, nicht unterstützt — siehe oben)*
 
-Push-basierte Updates statt Polling: Sub-Sekunden-Latenz und ~0 Steady-State-
-Traffic, durch Authentifizierung per OAuth und Abo der Shelly-Cloud-Events über
-einen WebSocket.
+OAuth-Anmeldung plus das Cloud-WebSocket-Relay, ausschließlich für **Befehle**:
+Schalten der virtuellen Komponenten, die die dokumentierte API nicht schreiben
+kann — auf Geräten, die deinem Konto gehören.
+
+### 🔭 Push statt Polling *(nicht als Ersatz geplant)*
+
+Dasselbe Relay kann auch Zustände pushen, und das wurde gemessen: Push kommt nur
+für Geräte an, die dem Konto **gehören**, und schlafende Batterie- und
+BLU-Geräte pushen überhaupt nie. Es kann sich also vor den Abruf setzen, ihn
+aber nie ersetzen — und die Frische-Informationen, auf denen der Ausfall-Sensor
+aufbaut, stehen in den gepushten Frames gar nicht drin. Falls es gebaut wird,
+dann als rein additive Schicht, und die ehrliche Zusage lautet „schneller, wo es
+geht, nie schlechter" — nicht „kein Polling mehr".
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Gen2 / BLE-gateway coverage** in one package. That is the gap this project close
 | 📡 **Offline detection** | A per-device **Reporting** sensor that turns off when a device stops checking in — the signal `cloud.connected` cannot give you (see below). | ✅ shipped |
 | ⚡ **Stuck-contact warning** | Warns when a relay reports itself as open while the device's own meter still sees a load — a welded contact (see below). | ✅ shipped |
 | 🩺 **Health checks** | Warns when a device runs hot, its Wi-Fi signal is weak, or it is short of memory or storage — from data the poll already returns, at no extra request (see below). | ✅ shipped |
+| 🎛️ **Cloud control** | Switches for virtual components — an irrigation controller's zones, a script's boolean — that the documented API cannot write at all. Off by default, rides an **unsupported** channel, and works only on devices your account owns (see below). | 🧪 opt-in |
 | 📈 **Energy history import** | Imports historical energy data into Home Assistant long-term statistics. | ✅ shipped |
 | ⚙️ **Config + options flow** | Paste your `auth_key`; tune the poll interval and per-device enablement later. | ✅ shipped |
 | 🌍 **Localised UI** | English and German translations for every user-visible string. | ✅ shipped |
@@ -260,6 +261,53 @@ device's payload that still produce no entity, so a gap turns up in a bug report
 instead of waiting for someone to notice it.
 
 The whole check has an off switch in the options.
+
+### Switching what the documented API cannot switch *(opt-in, unsupported)*
+
+Some things a Shelly can do have no route in the documented Cloud Control API.
+An irrigation controller's zones, or the boolean a script exposes, are *virtual
+components*: the cloud will happily tell you their state, and offers no way to
+change it. Every documented route answers "no such route" — measured, with a
+known-good call answering something else, so it really is absence and not a
+wrong parameter.
+
+There is another way, and it is worth being blunt about what it is. Shelly's own
+app talks to devices over a cloud WebSocket relay that carries a device's own
+RPC, and that relay does accept the write. It is **undocumented**, and Shelly
+support stated on 2026-07-27 that undocumented endpoints are not part of the
+supported API. It can change or disappear without notice.
+
+So it is **off by default**, and switching it on is a decision with a price
+tag:
+
+- It needs your **Shelly account sign-in**, because the relay accepts an account
+  token and not the Authorization cloud key. The password is used once to sign
+  in and is **never stored** — only the resulting token is, in the same place
+  the cloud key lives, and switching the option off again deletes it.
+- It opens a **second connection** to Shelly Cloud, used for commands only. Your
+  device state still comes from the ordinary poll, so nothing that already works
+  changes behaviour.
+- It works **only on devices your account owns**. Shelly's relay refuses to
+  route to a device that was shared with you, and there is no way around that
+  from here. Every device that carries such a component is asked once per
+  session — not on every poll — and the answer, owned or not routable or "could
+  not tell", is in the integration's diagnostics, so *"why has my device no
+  switch"* is answerable from a bug report.
+
+**The new switch appears next to the existing read-only sensor, not instead of
+it.** That redundancy is deliberate: replacing the sensor would silently break
+every automation and dashboard card already pointing at it, and "silently stops
+working" is the exact failure this feature is designed against.
+
+**A command that fails, fails loudly.** If the zone did not switch, you get an
+error in the UI and in the automation trace — never a quiet success. The state
+you see afterwards comes from the next poll rather than from an optimistic
+guess, because an optimistic guess is precisely what would hide a valve that
+accepted the command and did not move. If the channel itself is down, the switch
+says so by going **unavailable**, rather than looking operable and throwing on
+every press.
+
+Turn it on under *Settings → Devices & services → Shelly Cloud DIY → Configure*.
 
 ---
 
@@ -467,11 +515,20 @@ try it, but don't depend on it yet.
   scripts, and inputs onto its replacement over the LAN, for resilience that
   survives both an internet and a Home Assistant outage.
 
-### 🔭 Milestone 2 — OAuth + WebSocket realtime *(planned)*
+### 🎛️ Cloud control *(opt-in, unsupported — see above)*
 
-Push-based updates instead of polling: sub-second latency and ~0 steady-state
-traffic, by authenticating via OAuth and subscribing to Shelly Cloud events over
-a WebSocket.
+OAuth sign-in plus the cloud WebSocket relay, used for **commands only**:
+switching the virtual components the documented API cannot write, on devices
+your account owns.
+
+### 🔭 Push instead of polling *(not planned as a replacement)*
+
+The same relay can push state, and it was measured: push arrives only for
+devices the account **owns**, and sleeping battery and BLU devices never push at
+all. So it can sit in front of the poll but can never replace it — and the
+freshness bookkeeping the offline sensor is built on is not in the pushed
+frames. If it is built, it will be a strictly additive layer, and the honest
+promise is "faster where possible, never worse", not "no more polling".
 
 ---
 

--- a/custom_components/shelly_cloud_diy/__init__.py
+++ b/custom_components/shelly_cloud_diy/__init__.py
@@ -96,16 +96,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # See const.CONF_CLOUD_CONTROL.
     if coordinator.cloud_control:
         await _async_setup_cloud_control(hass, entry, coordinator)
+        # Registered IN ADDITION to the explicit teardown in
+        # ``async_unload_entry``, not instead of it, because the two cover
+        # different failures and neither covers both:
+        #
+        #   * ``async_unload_entry`` runs on a normal unload, including when
+        #     the platform unload then fails — the on-unload callbacks do not
+        #     run in that case (Home Assistant only processes them when the
+        #     unload succeeded).
+        #   * this callback runs when SETUP fails, where the component's
+        #     ``async_unload_entry`` is never called at all: an entry that is
+        #     not LOADED is short-circuited in ``ConfigEntry.async_unload``.
+        #
+        # Without it, a setup that raises below would leave the relay socket,
+        # its reconnect ladder and the ownership loop running for an entry
+        # that never came up — refreshing an OAuth token forever for nothing.
+        # ``async_disable_cloud_control`` is idempotent, so running twice is
+        # free.
+        entry.async_on_unload(coordinator.async_disable_cloud_control)
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Historical-data service (local-gateway CSV flow, unchanged from
-    # pre-pivot). Kept here so existing users of the download service
-    # retain that capability through the pivot.
-    historical_service = HistoricalDataService(hass, coordinator, entry)
-    hass.data[DOMAIN][f"{entry.entry_id}_historical"] = historical_service
-    await _register_services(hass, historical_service)
-    await historical_service.setup_auto_sync()
+        # Historical-data service (local-gateway CSV flow, unchanged from
+        # pre-pivot). Kept here so existing users of the download service
+        # retain that capability through the pivot.
+        historical_service = HistoricalDataService(hass, coordinator, entry)
+        hass.data[DOMAIN][f"{entry.entry_id}_historical"] = historical_service
+        await _register_services(hass, historical_service)
+        await historical_service.setup_auto_sync()
+    except Exception:
+        # The one failure the callback above cannot catch: Home Assistant's
+        # generic setup handler is the only branch that does NOT process the
+        # on-unload callbacks, so an unexpected error here would otherwise
+        # strand the channel with nothing left to close it.
+        await coordinator.async_disable_cloud_control()
+        raise
 
     # Snapshot of the options as loaded, so the update listener can tell an
     # options change (reload) from an ``entry.data`` write (do not reload).

--- a/custom_components/shelly_cloud_diy/__init__.py
+++ b/custom_components/shelly_cloud_diy/__init__.py
@@ -7,10 +7,13 @@ Entry point that:
 - Wires up the historical-data service (local-gateway flavour; unchanged
   from the pre-pivot code path).
 - Provides ghost-entity purging on device removal from the HA UI.
+- Brings up the opt-in cloud control channel (OAuth + the cloud
+  WebSocket relay) when — and only when — the user asked for it.
 
-The pre-pivot Integrator-API machinery (JWT token refresh, WebSocket
-client, consent-callback webhook) is intentionally absent here. Those
-move to Milestone 2 when OAuth + WebSocket land.
+Cloud control is a strictly additive second channel. The poll owns the
+state of every device and is untouched by it; the relay only ever carries
+commands the documented HTTP API has no route for. With the option off
+none of it is constructed.
 """
 from __future__ import annotations
 
@@ -19,7 +22,7 @@ from functools import partial
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
@@ -28,13 +31,17 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .api.cloud_control import ShellyCloudControl
+from .api.cloud_ws import ShellyCloudWebSocket
+from .api.oauth import OAuthToken, ShellyTokenManager
 from .const import (
     CONF_AUTH_KEY,
     CONF_CREATE_ALL_INITIALLY,
     CONF_ENABLED_DEVICES,
+    CONF_OAUTH_TOKEN,
     CONF_SERVER_URI,
     DOMAIN,
     PLATFORMS,
+    REAUTH_CLOUD_CONTROL,
     SIGNAL_DEVICE_REMOVED,
 )
 from .coordinator import ShellyCloudCoordinator
@@ -43,6 +50,7 @@ from .services.fleet_map import async_handle_fleet_map
 from .services.historical import HistoricalDataService
 from .services.orphans import async_handle_detect_orphans
 from .services.replace_device import async_handle_replace_device
+from .utils.token_store import token_from_storage, token_to_storage
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,6 +89,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # bookkeeping regardless of the underlying API).
     _purge_deleted_entities(hass, entry)
 
+    # Opt-in, and inert unless opted in: with the option off nothing below
+    # runs, so there is no OAuth round-trip, no second connection, no probe
+    # and no control entity. The reading comes from the coordinator so the
+    # option has one interpretation, not one per module.
+    # See const.CONF_CLOUD_CONTROL.
+    if coordinator.cloud_control:
+        await _async_setup_cloud_control(hass, entry, coordinator)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Historical-data service (local-gateway CSV flow, unchanged from
@@ -91,22 +107,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _register_services(hass, historical_service)
     await historical_service.setup_auto_sync()
 
+    # Snapshot of the options as loaded, so the update listener can tell an
+    # options change (reload) from an ``entry.data`` write (do not reload).
+    hass.data[DOMAIN][f"{entry.entry_id}_options"] = dict(entry.options)
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Tear down a config entry cleanly."""
+    """Tear down a config entry cleanly.
+
+    The cloud control channel is closed here rather than through
+    ``entry.async_on_unload``, for the same reason the historical service is:
+    Home Assistant runs the on-unload callbacks only when the platform unload
+    *succeeded*. A failed unload would otherwise leave the relay socket, its
+    reconnect ladder and the ownership loop running — and the next reload
+    would build a second set on top of them.
+    """
     historical: HistoricalDataService | None = hass.data[DOMAIN].pop(
         f"{entry.entry_id}_historical", None
     )
     if historical:
         historical.cancel_auto_sync()
 
+    coordinator: ShellyCloudCoordinator | None = hass.data[DOMAIN].get(entry.entry_id)
+    if coordinator is not None:
+        # Idempotent: with cloud control off there is nothing to close.
+        await coordinator.async_disable_cloud_control()
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
+        hass.data[DOMAIN].pop(f"{entry.entry_id}_options", None)
     return unload_ok
 
 
@@ -126,7 +159,18 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 
 async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload when the user changes poll interval / gateway URL."""
+    """Reload when the user changes poll interval / gateway URL.
+
+    Home Assistant fires this listener for a write to ``entry.data`` as well
+    as to ``entry.options``, and a refreshed OAuth token is a write to
+    ``entry.data``. Reloading for one would tear the poll down and rebuild
+    every entity because a background token rotation happened, so a change
+    that left the options identical is not a reason to reload.
+    """
+    previous = hass.data.get(DOMAIN, {}).get(f"{entry.entry_id}_options")
+    if previous is not None and previous == dict(entry.options):
+        _LOGGER.debug("Shelly Cloud DIY: entry data updated, options unchanged")
+        return
     _LOGGER.info("Shelly Cloud DIY: options changed, reloading")
     await hass.config_entries.async_reload(entry.entry_id)
 
@@ -149,6 +193,115 @@ def _migrate_to_v0_4_0(hass: HomeAssistant, entry: ConfigEntry) -> None:
         "Shelly Cloud DIY: migrated config entry to v0.4.0 — "
         "all devices remain enabled; use options flow to curate."
     )
+
+
+# ── Cloud control (opt-in) ──────────────────────────────────────────────
+
+
+@callback
+def _start_cloud_control_reauth(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Ask the user to sign in to Shelly again — for the token, not the key.
+
+    Both credentials fail into the same reauth flow, so the flow is told
+    which one is being asked for. Without the marker the user would be shown
+    the Authorization-cloud-key form for a rejected OAuth token and would
+    quite reasonably paste a perfectly good key into it.
+
+    Only the marker is passed. The flow reads nothing else out of it, and
+    handing a token to a flow context is how a token ends up in a place
+    nobody thought to check.
+    """
+    entry.async_start_reauth(hass, data={REAUTH_CLOUD_CONTROL: True})
+
+
+async def _async_setup_cloud_control(
+    hass: HomeAssistant, entry: ConfigEntry, coordinator: ShellyCloudCoordinator
+) -> None:
+    """Bring the cloud control channel up, or explain why it stayed down.
+
+    Never raises. The channel is an opt-in extra on top of an entry whose
+    real job is the poll: a relay that is unreachable, or an account whose
+    sign-in has expired, must cost the user their control entities and
+    nothing else. Both cases are logged, both are visible in diagnostics,
+    and an expired sign-in additionally asks for re-authentication.
+    """
+    token = token_from_storage(entry.data.get(CONF_OAUTH_TOKEN))
+    if token is None:
+        _LOGGER.warning(
+            "Cloud control is switched on but this entry holds no Shelly "
+            "sign-in; asking for one"
+        )
+        _start_cloud_control_reauth(hass, entry)
+        return
+
+    async def _persist_token(new_token: OAuthToken) -> None:
+        """Store a refreshed token — but only when it is worth a write.
+
+        Measured against a live account: the ``refresh_token`` does not
+        rotate. So the durable half of the record is normally unchanged and
+        the only thing a write would save is an access token that expires in
+        twelve hours anyway, at the price of a config-entry write (and a
+        listener wake-up) on every refresh, forever.
+        """
+        stored = token_from_storage(entry.data.get(CONF_OAUTH_TOKEN))
+        if stored is None:
+            # The entry holds no sign-in, and the only way it got that way is
+            # that the user switched cloud control off — which deletes it.
+            # A refresh still in flight on the closing connection must not
+            # put it back.
+            return
+        if stored.refresh_token == new_token.refresh_token:
+            return
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_OAUTH_TOKEN: token_to_storage(new_token)},
+        )
+
+    ws: ShellyCloudWebSocket | None = None
+    try:
+        # Inside the guard, not above it: reading the server URI can raise on
+        # a hand-edited entry and building the transport rejects an unusable
+        # host, and either escaping here would abort the entry setup — taking
+        # the poll down over the optional half of the integration.
+        server_uri = entry.data[CONF_SERVER_URI]
+        session = async_get_clientsession(hass)
+        tokens = ShellyTokenManager(
+            session, server_uri, token=token, on_token_refreshed=_persist_token
+        )
+        ws = ShellyCloudWebSocket(
+            session,
+            server_uri,
+            tokens.async_get_token,
+            on_token_rejected=tokens.async_force_refresh,
+            on_reauth=partial(_start_cloud_control_reauth, hass, entry),
+        )
+        await coordinator.async_enable_cloud_control(ws)
+    except ConfigEntryAuthFailed:
+        # Raised by the token manager when the stored sign-in is spent. It
+        # would abort the whole entry setup if it were left to propagate,
+        # taking the poll down over the optional half of the integration.
+        _LOGGER.warning(
+            "Cloud control: the stored Shelly sign-in was rejected; "
+            "asking for a new one. Polling is unaffected"
+        )
+        if ws is not None:
+            await ws.disconnect()
+        _start_cloud_control_reauth(hass, entry)
+    except Exception as err:  # noqa: BLE001 — see the docstring
+        # Deliberately every remaining exception, not a list of the expected
+        # ones: an optional channel that fails in an unforeseen way must
+        # still not abort the entry setup and take the poll with it.
+        #
+        # Type name only, never ``err`` itself: an aiohttp error's own text
+        # embeds the connect URL, and that URL carries the access token as a
+        # query parameter.
+        _LOGGER.error(
+            "Cloud control could not connect (%s); control entities are not "
+            "created this session. Polling is unaffected",
+            type(err).__name__,
+        )
+        if ws is not None:
+            await ws.disconnect()
 
 
 # ── Service registration ────────────────────────────────────────────────

--- a/custom_components/shelly_cloud_diy/api/cloud_ws.py
+++ b/custom_components/shelly_cloud_diy/api/cloud_ws.py
@@ -1,0 +1,747 @@
+"""Shelly Cloud WebSocket relay — a command channel, and nothing else.
+
+The cloud WebSocket is not a status feed for this integration. It is a generic
+JSON-RPC relay: whatever RPC a Gen2+ device understands locally can be sent to
+it through the cloud, which is the only way to reach components the documented
+HTTP Cloud Control API has no route for at all (measured 2026-08-09: a
+``Boolean.Set`` on a virtual component succeeded over the relay while every
+documented HTTP route answered 404 — with a negative control, a known-good
+``set/switch``, answering 400, so those 404s are genuinely "no such route").
+
+**What this module deliberately does not do: push.** The transport it is
+harvested from also handled ``Shelly:StatusOnChange`` frames and fed them to the
+coordinator. All of that is removed, and the file was renamed away from
+``websocket.py`` so the removal is not quietly undone:
+
+* The offline detector, the relay-fault detector and the health checks are
+  hardware-confirmed against the poll. The freshness fields ``checkin_marker()``
+  reads are **not present in the WS frame**, so feeding relay frames into the
+  coordinator would corrupt exactly the bookkeeping those three are built on.
+* Push works only for devices the account owns, so it can never replace the
+  poll anyway. Control can ship now; push can be added later as a strictly
+  additive layer.
+
+Unsolicited frames are therefore read off the socket and dropped. The poll
+remains the single source of state.
+
+Ownership
+---------
+The relay refuses to route to devices the session does not own, answering
+``WRONG_ID``. That is measured, and it is measured *with* a negative control:
+deliberately malformed device ids return the identical error, which refutes the
+"you formatted the id wrongly" reading. It is the only known runtime ownership
+signal — no field in any cloud payload carries ownership — so
+:meth:`ShellyCloudWebSocket.async_classify_ownership` sends one cheap
+``Shelly.GetDeviceInfo`` and reads the answer. ``WRONG_ID`` is a verdict about a
+device, not a fault in the transport, and is never treated as one.
+
+Failure is loud
+---------------
+Every call raises on failure instead of returning ``None``. The first consumer
+is an irrigation controller, where the realistic failure is *the zone did not
+switch* — a silently swallowed error there breaks a watering schedule and looks
+like success. The exceptions subclass
+:class:`~homeassistant.exceptions.HomeAssistantError` so they surface in the UI
+and in automation traces, and the repo's :class:`ShellyCloudError` so existing
+handlers keep working.
+
+Credential handling
+-------------------
+The access token rides in the connect URL as ``?t=<token>``, which makes this
+module the most leak-prone place in the integration:
+
+* A failed handshake raises ``aiohttp.WSServerHandshakeError`` whose ``__str__``
+  embeds ``request_info.url`` — the **full** URL, token included — and ERROR
+  logging is on by default. Every connect failure is therefore re-raised with
+  the query string stripped, and no aiohttp error object is ever interpolated
+  into a message or a log record; only its type name is.
+* Inbound frames are logged at DEBUG only, through :func:`_redact`.
+* The one transmission site is marked ``# CREDENTIAL:`` below, matching the
+  convention ``api/cloud_control.py`` uses for the auth_key
+  (see ``docs/AUTH_KEY.md``).
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import random
+import time
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+import aiohttp
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+
+from .cloud_control import ShellyCloudError
+
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
+
+_LOGGER = logging.getLogger(__name__)
+
+# Wire facts, verified live: the relay listens on 6113 and this path, and takes
+# the access token as a query parameter.
+_WSS_PORT = 6113
+_WSS_PATH = "/shelly/wss/hk_sock"
+
+# Reconnect ladder. Bounded on purpose — an unbounded backoff means a socket
+# that never comes back after a long cloud outage.
+_RECONNECT_MIN_S = 1.0
+_RECONNECT_MAX_S = 60.0
+
+# Up to 10 % jitter, so many Home Assistant instances do not reconnect in
+# lock-step after a Shelly Cloud outage and re-create the outage themselves.
+_RECONNECT_JITTER = 0.1
+
+# A session has to last this long before it counts as "worked" and resets the
+# ladder. Without the threshold, a relay that accepts a connection and drops it
+# again immediately keeps the backoff pinned at its minimum — the ladder would
+# switch itself off in exactly the situation it exists for.
+_BACKOFF_RESET_AFTER_S = 60.0
+
+# aiohttp ping interval; the relay drops idle sockets silently otherwise, and a
+# command against a half-dead socket would wait for its full timeout.
+_HEARTBEAT_S = 30
+
+_DEFAULT_REQUEST_TIMEOUT_S = 10.0
+_DEFAULT_CONNECT_TIMEOUT_S = 30.0
+
+# Relay-level error strings (they are the relay's own, not a device's).
+_ERROR_WRONG_ID = "WRONG_ID"
+_ERROR_UNAUTHORIZED = "UNAUTHORIZED"
+
+# WS close code the relay uses for a broken/expired session token.
+_CLOSE_CODE_TOKEN_BROKEN = 4401
+
+# An error code goes into exception messages, so it is capped rather than
+# trusted: it arrives from the wire.
+_MAX_ERROR_CODE_LEN = 64
+
+# Keys whose values must be scrubbed before a frame reaches a log line.
+_REDACT_KEYS = frozenset(
+    {"token", "access_token", "refresh_token", "code", "t", "auth_key", "password"}
+)
+
+
+def _redact(value: Any) -> Any:
+    """Return a copy of ``value`` with known-sensitive values masked.
+
+    Log-only; the original frame is never mutated. Matching is by key name,
+    so the key set has to be exhaustive on every credential-bearing name that
+    can appear in a frame — which is why it also covers names this transport
+    does not itself send.
+    """
+    if isinstance(value, dict):
+        return {k: ("***" if k in _REDACT_KEYS else _redact(v)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact(v) for v in value]
+    return value
+
+
+class ShellyCloudWsError(ShellyCloudError, HomeAssistantError):
+    """A cloud-relay call failed.
+
+    Doubly based on purpose: ``HomeAssistantError`` so a failed command shows up
+    where the user acts (the UI, an automation trace) instead of only in the
+    log, ``ShellyCloudError`` so the existing ``except`` clauses in this
+    integration keep catching it.
+    """
+
+
+class ShellyCloudWsNotConnectedError(ShellyCloudWsError):
+    """No relay connection was open when the call was made."""
+
+
+class ShellyCloudWsTransportError(ShellyCloudWsError):
+    """Connect, handshake or send failed at the network level."""
+
+
+class ShellyCloudWsTimeoutError(ShellyCloudWsError):
+    """The relay accepted the request and never answered it.
+
+    Distinct from a transport error because the command may well have been
+    executed — "no answer" is not "did not happen", and a caller must not
+    report either outcome as certain.
+    """
+
+
+class ShellyCloudWsAuthError(ShellyCloudWsError):
+    """The relay rejected the session token.
+
+    Never retried in place: a rejected token stays rejected, so the only useful
+    responses are a fresh token or asking the user to sign in again.
+    """
+
+
+class ShellyCloudWsCommandError(ShellyCloudWsError):
+    """The relay answered with an error for this device and method.
+
+    ``code`` is the relay's own short error string (e.g. ``WRONG_ID``), kept as
+    an attribute so callers can branch on it without parsing the message.
+    """
+
+    def __init__(self, message: str, *, code: str) -> None:
+        """Store the relay's error code alongside the readable message."""
+        super().__init__(message)
+        self.code = code
+
+
+class DeviceOwnership(StrEnum):
+    """What the relay says about routing to one device.
+
+    ``NOT_ROUTABLE`` is deliberately not called "shared": the relay refuses a
+    device that was never on the account and one that was removed from it in
+    exactly the same way, so the honest statement is about routing, not about
+    who owns what.
+    """
+
+    OWNED = "owned"
+    NOT_ROUTABLE = "not_routable"
+    UNKNOWN = "unknown"
+
+
+def _relay_error_code(error: Any) -> str:
+    """Reduce a relay error field to one short, comparable code string.
+
+    The relay answers a refused route with a bare string (``"WRONG_ID"``,
+    measured). A device-side JSON-RPC error can instead arrive as
+    ``{"code": …, "message": …}``. Both are reduced to a single short string, so
+    the ownership classifier compares one thing and nothing unbounded from the
+    wire reaches an exception message.
+    """
+    if isinstance(error, str):
+        return error.strip()[:_MAX_ERROR_CODE_LEN]
+    if isinstance(error, dict):
+        for key in ("error", "message", "code"):
+            value = error.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()[:_MAX_ERROR_CODE_LEN]
+            if isinstance(value, int):
+                return str(value)
+    return "UNKNOWN"
+
+
+class ShellyCloudWebSocket:
+    """One reconnecting relay connection for one Shelly account.
+
+    Bound to a single host, unlike the transport this was harvested from, which
+    carried a ``host`` argument on every call and kept a map of connections. The
+    Cloud Control API gives an account exactly one server URI (the login code's
+    own ``user_api_url`` claim names it), and the relay on that host answers for
+    every device id the account lists — including the ones it refuses to route
+    to, which is how ``WRONG_ID`` was measured in the first place. A per-call
+    host was an artefact of the Integrator-era client; keeping it would only
+    invite callers to invent a second connection that has nothing to talk to.
+    """
+
+    def __init__(
+        self,
+        session: ClientSession,
+        server_uri: str,
+        token_provider: Callable[[], Awaitable[str]],
+        *,
+        on_token_rejected: Callable[[], Awaitable[str]] | None = None,
+        on_reauth: Callable[[], None] | None = None,
+        request_timeout_s: float = _DEFAULT_REQUEST_TIMEOUT_S,
+        connect_timeout_s: float = _DEFAULT_CONNECT_TIMEOUT_S,
+    ) -> None:
+        """Prepare the transport. Nothing connects until :meth:`connect`.
+
+        Args:
+            session: shared aiohttp session.
+            server_uri: the account's server URI or bare host.
+            token_provider: **async** callable returning the current access
+                token. Awaited on every connect attempt, so a reconnect after a
+                long outage carries a current token rather than the one the
+                socket was originally opened with.
+            on_token_rejected: awaited when the relay rejects the session token
+                on a live connection, to mint a fresh one before the next
+                attempt. May raise ``ConfigEntryAuthFailed`` to say the
+                credentials are genuinely gone.
+            on_reauth: called when re-authentication needs the user. The wiring
+                layer binds this to ``entry.async_start_reauth``; a
+                ``ConfigEntryAuthFailed`` raised inside this module's background
+                task would be swallowed by asyncio and reach nobody.
+            request_timeout_s: how long one JSON-RPC round trip may take.
+            connect_timeout_s: how long :meth:`connect` waits for the first
+                connection attempt to resolve.
+        """
+        self._session = session
+        self._host = self._normalise_host(server_uri)
+        self._token_provider = token_provider
+        self._on_token_rejected = on_token_rejected
+        self._on_reauth = on_reauth
+        self._request_timeout_s = request_timeout_s
+        self._connect_timeout_s = connect_timeout_s
+
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._task: asyncio.Task | None = None
+        self._running = False
+        self._auth_failed = False
+        self._message_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        self._first_attempt: asyncio.Future | None = None
+
+    # ── Properties ──────────────────────────────────────────────────────
+
+    @property
+    def host(self) -> str:
+        """The relay host this transport talks to."""
+        return self._host
+
+    @property
+    def connected(self) -> bool:
+        """True while a relay connection is open."""
+        return self._ws is not None and not self._ws.closed
+
+    @property
+    def auth_failed(self) -> bool:
+        """True once the relay's rejection has been escalated to reauth."""
+        return self._auth_failed
+
+    @staticmethod
+    def _normalise_host(server_uri: str) -> str:
+        """Reduce a server URI to the bare host the relay is addressed by.
+
+        Accepts what the config entry already stores, in any of the shapes the
+        Shelly app shows it in (``shelly-42-eu.shelly.cloud``,
+        ``https://shelly-42-eu.shelly.cloud/``), because asking the caller to
+        normalise it is how a scheme ends up inside a ``wss://`` URL.
+        """
+        raw = server_uri.strip()
+        if not raw:
+            raise ValueError("server_uri must not be empty")
+        raw = raw.split("://", 1)[-1]
+        raw = raw.split("/", 1)[0]
+        return raw.split(":", 1)[0]
+
+    # ── Connection lifecycle ────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Open the relay connection and keep it open.
+
+        Returns once the first connection is established, and raises if that
+        first attempt fails — an opt-in control channel that cannot come up
+        should say so at setup rather than sit in a silent retry loop while its
+        entities pretend to work. Drops *after* a working connection are a
+        different matter and are healed by the reconnect ladder.
+        """
+        if self._task is not None and not self._task.done():
+            return
+        self._running = True
+        self._auth_failed = False
+        self._first_attempt = asyncio.get_running_loop().create_future()
+        self._task = asyncio.create_task(self._connection_loop())
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self._first_attempt), self._connect_timeout_s
+            )
+        except asyncio.TimeoutError as err:
+            await self.disconnect()
+            raise ShellyCloudWsTimeoutError(
+                f"Cloud relay {self._host} did not connect within "
+                f"{self._connect_timeout_s:.0f}s"
+            ) from err
+        except BaseException:
+            # The loop has already stopped itself on a first-attempt failure;
+            # await the task so no exception is left orphaned in the loop.
+            await self.disconnect()
+            raise
+
+    async def disconnect(self) -> None:
+        """Close the connection, stop reconnecting, and fail anything in flight."""
+        self._running = False
+        ws, self._ws = self._ws, None
+        if ws is not None and not ws.closed:
+            await ws.close()
+        task, self._task = self._task, None
+        if task is not None and not task.done():
+            task.cancel()
+            # The loop is being torn down; whatever it was doing is moot, and a
+            # failure raised here would mask the caller's own reason for
+            # disconnecting.
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        first, self._first_attempt = self._first_attempt, None
+        if first is not None:
+            if not first.done():
+                first.cancel()
+            elif not first.cancelled():
+                # Retrieve any stored exception. Nobody is waiting for it any
+                # more, and an unretrieved one is reported by asyncio at
+                # garbage-collection time — in a log the user reads.
+                first.exception()
+        self._fail_pending("the relay connection was closed")
+        _LOGGER.debug("Cloud relay connection to %s closed", self._host)
+
+    async def _connection_loop(self) -> None:
+        """Reconnect with bounded exponential backoff plus jitter."""
+        backoff = _RECONNECT_MIN_S
+        while self._running:
+            started = time.monotonic()
+            try:
+                await self._connect_and_listen()
+            except asyncio.CancelledError:
+                raise
+            except ShellyCloudWsAuthError as err:
+                if self._fail_first_attempt(err):
+                    # A token minted seconds ago was refused; looping on it
+                    # would only repeat the refusal.
+                    break
+                if not await self._handle_token_rejected():
+                    break
+            except ShellyCloudWsError as err:
+                _LOGGER.error(
+                    "Cloud relay error for %s: %s", self._host, type(err).__name__
+                )
+                if self._fail_first_attempt(err):
+                    break
+            except Exception as err:  # noqa: BLE001
+                # Never ``str(err)`` — a raw aiohttp error embeds the
+                # ``?t=<token>`` URL.
+                _LOGGER.error(
+                    "Unexpected cloud relay failure for %s: %s",
+                    self._host,
+                    type(err).__name__,
+                )
+                if self._fail_first_attempt(err):
+                    break
+            else:
+                if time.monotonic() - started >= _BACKOFF_RESET_AFTER_S:
+                    # A connection that actually worked resets the ladder, so a
+                    # long-lived session is not punished for an old outage.
+                    backoff = _RECONNECT_MIN_S
+
+            if not self._running:
+                break
+            sleep_for = backoff + random.uniform(0, backoff * _RECONNECT_JITTER)
+            _LOGGER.info("Reconnecting to cloud relay %s in %.1fs", self._host, sleep_for)
+            await asyncio.sleep(sleep_for)
+            backoff = min(backoff * 2, _RECONNECT_MAX_S)
+
+    async def _connect_and_listen(self) -> None:
+        """Open one connection and read from it until it closes.
+
+        Raises:
+            ShellyCloudWsAuthError: handshake 401/403, or a 4401 close.
+            ShellyCloudWsTransportError: any other connect failure. Neither
+                message ever carries the token-bearing URL.
+        """
+        token = await self._token_provider()
+        # CREDENTIAL (sent 1/1): the OAuth access token, as the ``t`` query
+        # parameter of the relay URL. Destination is the account's own host,
+        # normalised once in ``_normalise_host``. This URL must never be
+        # logged, echoed into an exception, or put in diagnostics.
+        url = f"wss://{self._host}:{_WSS_PORT}{_WSS_PATH}?t={token}"
+        safe_url = url.split("?", 1)[0]
+
+        _LOGGER.info("Connecting to cloud relay %s", self._host)
+        try:
+            ws = await self._session.ws_connect(
+                url, ssl=True, heartbeat=_HEARTBEAT_S
+            )
+        except aiohttp.WSServerHandshakeError as err:
+            status = getattr(err, "status", None)
+            if status in (401, 403):
+                raise ShellyCloudWsAuthError(
+                    f"Cloud relay rejected the session at {safe_url} (HTTP {status})"
+                ) from None
+            raise ShellyCloudWsTransportError(
+                f"Cloud relay handshake failed at {safe_url} (HTTP {status})"
+            ) from None
+        except asyncio.TimeoutError:
+            raise ShellyCloudWsTransportError(
+                f"Timeout connecting to cloud relay {self._host}"
+            ) from None
+        except aiohttp.ClientError as err:
+            # ``from None`` and the type name only: the aiohttp error carries
+            # the token-bearing URL in both its message and its context.
+            raise ShellyCloudWsTransportError(
+                f"Cloud relay connect failed to {self._host} ({type(err).__name__})"
+            ) from None
+
+        self._ws = ws
+        self._resolve_first_attempt()
+        close_reason = ""
+        try:
+            _LOGGER.info("Cloud relay connected to %s", self._host)
+            async for msg in ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    self._handle_message(msg.data)
+                elif msg.type == aiohttp.WSMsgType.ERROR:
+                    _LOGGER.error(
+                        "Cloud relay transport error for %s: %s",
+                        self._host,
+                        type(ws.exception()).__name__,
+                    )
+                    break
+                elif msg.type in (
+                    aiohttp.WSMsgType.CLOSE,
+                    aiohttp.WSMsgType.CLOSING,
+                    aiohttp.WSMsgType.CLOSED,
+                ):
+                    close_reason = str(msg.extra or "")
+                    break
+        finally:
+            self._ws = None
+            # Anything in flight is now unanswerable. Failing it here turns a
+            # dropped connection into an immediate, honest error instead of a
+            # command that waits out its whole timeout.
+            self._fail_pending("the relay connection dropped")
+
+        if ws.close_code == _CLOSE_CODE_TOKEN_BROKEN or "Token-Broken" in close_reason:
+            raise ShellyCloudWsAuthError(
+                f"Cloud relay {self._host} closed the session as unauthenticated"
+            )
+
+    async def _handle_token_rejected(self) -> bool:
+        """Refresh the rejected token. Returns False if the loop must stop."""
+        if self._on_token_rejected is None:
+            self._signal_reauth()
+            return False
+        try:
+            await self._on_token_rejected()
+        except ConfigEntryAuthFailed:
+            _LOGGER.error(
+                "Cloud relay authentication for %s failed permanently", self._host
+            )
+            self._signal_reauth()
+            return False
+        except Exception as err:  # noqa: BLE001 — type name only, never a token
+            _LOGGER.error(
+                "Refreshing the rejected cloud relay token failed: %s",
+                type(err).__name__,
+            )
+        return True
+
+    def _signal_reauth(self) -> None:
+        """Ask Home Assistant to re-authenticate the entry, exactly once."""
+        self._auth_failed = True
+        self._running = False
+        if self._on_reauth is None:
+            return
+        try:
+            self._on_reauth()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("Starting re-authentication failed: %s", type(err).__name__)
+
+    # ── First-attempt bookkeeping ───────────────────────────────────────
+
+    def _resolve_first_attempt(self) -> None:
+        """Let a waiting :meth:`connect` return once a connection is up."""
+        if self._first_attempt is not None and not self._first_attempt.done():
+            self._first_attempt.set_result(None)
+
+    def _fail_first_attempt(self, err: BaseException) -> bool:
+        """Report a failure to a waiting :meth:`connect`.
+
+        Returns True when this was the first attempt, which is the loop's signal
+        to stop: the caller is being told, so a background retry would only
+        duplicate work the caller is about to decide on.
+        """
+        if self._first_attempt is None or self._first_attempt.done():
+            return False
+        self._first_attempt.set_exception(err)
+        self._running = False
+        return True
+
+    # ── Requests ────────────────────────────────────────────────────────
+
+    async def send_jrpc_request(
+        self,
+        device_id: str,
+        method: str,
+        params: dict | None = None,
+        *,
+        timeout: float | None = None,
+    ) -> dict:
+        """Send one JSON-RPC call over the relay and return its result.
+
+        This is the whole point of the module: ``method``/``params`` are the
+        device's own local RPC, so anything a Gen2+ device understands can be
+        reached — including the virtual components the HTTP API has no route
+        for.
+
+        Returns:
+            The relay's ``response`` object, i.e. the RPC result.
+
+        Raises:
+            ShellyCloudWsNotConnectedError: no connection is open.
+            ShellyCloudWsTimeoutError: no answer within the timeout.
+            ShellyCloudWsAuthError: the relay rejected the session token.
+            ShellyCloudWsCommandError: the relay refused the call (``WRONG_ID``
+                for a device it will not route to, or a device-side error).
+            ShellyCloudWsTransportError: the send itself failed.
+
+        It never returns ``None`` for any of those. The first consumer switches
+        water valves, and a caller that cannot tell "switched" from "did not
+        switch" is worse than one that fails.
+        """
+        ws = self._ws
+        if ws is None or ws.closed:
+            raise ShellyCloudWsNotConnectedError(
+                f"No cloud relay connection to {self._host} for {method}"
+            )
+
+        self._message_id += 1
+        trid = self._message_id
+        frame = {
+            "event": "Shelly:JrpcRequest",
+            "trid": trid,
+            "deviceId": device_id,
+            "method": method,
+            "params": params or {},
+        }
+        _LOGGER.debug("Cloud relay request: %s", _redact(frame))
+
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[trid] = future
+        try:
+            try:
+                await ws.send_json(frame)
+            except (aiohttp.ClientError, ConnectionError, RuntimeError) as err:
+                raise ShellyCloudWsTransportError(
+                    f"Sending {method} to {device_id} failed "
+                    f"({type(err).__name__})"
+                ) from None
+            try:
+                message = await asyncio.wait_for(
+                    future, timeout if timeout is not None else self._request_timeout_s
+                )
+            except asyncio.TimeoutError as err:
+                raise ShellyCloudWsTimeoutError(
+                    f"No cloud relay answer for {method} on {device_id}"
+                ) from err
+        finally:
+            self._pending.pop(trid, None)
+
+        response = message.get("response")
+        if not isinstance(response, dict):
+            raise ShellyCloudWsCommandError(
+                f"Malformed cloud relay answer for {method} on {device_id}",
+                code="UNKNOWN",
+            )
+
+        error = response.get("error")
+        if error is not None:
+            code = _relay_error_code(error)
+            if code == _ERROR_UNAUTHORIZED:
+                # Log the marker, never the frame: the relay may echo session
+                # material on this path. No retry — see ShellyCloudWsAuthError.
+                _LOGGER.error(
+                    "Cloud relay reported UNAUTHORIZED: device=%s method=%s",
+                    device_id,
+                    method,
+                )
+                self._signal_reauth()
+                # A session the relay refuses is worth nothing, and leaving it
+                # open would let further commands queue against a dead one.
+                with contextlib.suppress(Exception):
+                    await ws.close()
+                raise ShellyCloudWsAuthError(
+                    f"Cloud relay rejected the session for {method} on {device_id}"
+                )
+            raise ShellyCloudWsCommandError(
+                f"Cloud relay refused {method} on {device_id}: {code}", code=code
+            )
+
+        _LOGGER.debug(
+            "Cloud relay answered %s for %s with keys %s",
+            method,
+            device_id,
+            sorted(response),
+        )
+        return response
+
+    async def async_classify_ownership(self, device_id: str) -> DeviceOwnership:
+        """Ask the relay whether it will route to ``device_id`` at all.
+
+        Sends one ``Shelly.GetDeviceInfo`` — the cheapest call that proves
+        routing — and reads the answer:
+
+        * an answer ⇒ :attr:`DeviceOwnership.OWNED`;
+        * ``WRONG_ID`` ⇒ :attr:`DeviceOwnership.NOT_ROUTABLE`, the measured
+          signal for a device the session does not own (shared, or gone);
+        * anything else ⇒ :attr:`DeviceOwnership.UNKNOWN`.
+
+        ``UNKNOWN`` exists so a timeout or an unfamiliar relay error is never
+        laundered into a verdict about the device. A caller may cache the two
+        definite answers for the session; it must not cache ``UNKNOWN`` as if it
+        were one, which is also why no cache lives in here — the lifetime of the
+        answer belongs to whoever holds the device list.
+
+        A rejected session token propagates as
+        :class:`ShellyCloudWsAuthError` instead of being reported as a device
+        verdict: it says nothing about the device, and classifying a whole
+        account as "unknown" would hide that the session is simply dead.
+        """
+        try:
+            await self.send_jrpc_request(device_id, "Shelly.GetDeviceInfo")
+        except ShellyCloudWsAuthError:
+            raise
+        except ShellyCloudWsCommandError as err:
+            if err.code == _ERROR_WRONG_ID:
+                _LOGGER.debug(
+                    "Cloud relay will not route to %s (%s)", device_id, err.code
+                )
+                return DeviceOwnership.NOT_ROUTABLE
+            _LOGGER.debug(
+                "Cloud relay gave an unclassifiable answer for %s: %s",
+                device_id,
+                err.code,
+            )
+            return DeviceOwnership.UNKNOWN
+        except ShellyCloudWsError as err:
+            _LOGGER.debug(
+                "Ownership probe for %s could not complete: %s",
+                device_id,
+                type(err).__name__,
+            )
+            return DeviceOwnership.UNKNOWN
+        return DeviceOwnership.OWNED
+
+    # ── Inbound frames ──────────────────────────────────────────────────
+
+    def _handle_message(self, data: str) -> None:
+        """Route one inbound frame to its waiting request, or drop it."""
+        try:
+            message = json.loads(data)
+        except json.JSONDecodeError:
+            _LOGGER.debug("Unparseable frame from cloud relay %s", self._host)
+            return
+        if not isinstance(message, dict):
+            _LOGGER.debug("Unexpected frame shape from cloud relay %s", self._host)
+            return
+
+        # Correlate on ``trid`` alone, not on the event name: the round trip was
+        # measured by transaction id, and the response event name was not.
+        trid = message.get("trid")
+        future = self._pending.get(trid) if isinstance(trid, int) else None
+        if future is not None:
+            if not future.done():
+                future.set_result(message)
+            return
+
+        # Everything else is push, and this transport does not consume push —
+        # see the module docstring. Dropping it is the design, not a gap.
+        _LOGGER.debug("Ignoring unsolicited relay frame: %s", _redact(message))
+
+    def _fail_pending(self, reason: str) -> None:
+        """Fail every in-flight request; a lost answer must never look like one."""
+        pending, self._pending = self._pending, {}
+        for future in pending.values():
+            if not future.done():
+                future.set_exception(
+                    ShellyCloudWsNotConnectedError(
+                        f"Cloud relay request to {self._host} was lost: {reason}"
+                    )
+                )
+
+    def __repr__(self) -> str:
+        """Host and state only — the token this object connects with is not printable."""
+        return (
+            f"ShellyCloudWebSocket(host={self._host!r}, connected={self.connected}, "
+            f"auth_failed={self._auth_failed})"
+        )

--- a/custom_components/shelly_cloud_diy/api/oauth.py
+++ b/custom_components/shelly_cloud_diy/api/oauth.py
@@ -1,0 +1,499 @@
+"""Shelly Cloud OAuth login client and the redacting token types.
+
+The documented Cloud Control API authenticates with the account's ``auth_key``
+and that is what the poll uses — unchanged. This module exists for the *other*
+channel: the cloud WebSocket relay (``api/cloud_ws.py``) accepts an OAuth access
+token only, so opting an entry into cloud control means signing in once with the
+Shelly account credentials and holding a token afterwards.
+
+The flow, verified against a live throwaway account (2026-07-13):
+
+1. ``POST https://api.shelly.cloud/oauth/login`` — a **fixed** host, not the
+   account's server URI. Form ``email`` / ``password=sha1(plaintext)`` /
+   ``client_id=shelly-diy`` → ``{isok: true, data: {code}}``, where ``code`` is a
+   short-lived JWT whose payload carries the account's own ``user_api_url``.
+2. ``POST <user_api_url>/oauth/auth`` — form ``client_id`` / ``code`` → the
+   **top-level** ``{access_token, token_type, expires_in, refresh_token}`` shape
+   (no ``isok``/``data`` wrapper; that asymmetry is measured, not assumed).
+
+Measured lifecycle facts this module is built on: the access token lives 12 h
+and is a JWT with an ``exp`` claim, and the ``refresh_token`` does **not**
+rotate — a refresh that omits it is normal and must not strand the account.
+
+Credential handling — canonical statement
+-----------------------------------------
+``api/cloud_control.py`` makes the claim "here is everywhere your auth_key
+goes" checkable with one ``grep``; this module holds itself to the same rule for
+the password and the tokens, because they are strictly more powerful (the
+password is the account itself). ``docs/AUTH_KEY.md`` is the user-facing
+statement; if the rules below change, change that file too.
+
+1. **The plaintext password lives in exactly one function.**
+   :func:`sha1_password` hashes it at the flow boundary; every other function
+   here takes the digest. Nothing that performs I/O ever sees the plaintext, so
+   it cannot be logged, persisted, or put in a traceback by accident.
+2. **Never logged, never in an exception message.** Log records carry an HTTP
+   status and a path-only URL. Exception messages carry the same. A raw
+   ``aiohttp`` error is reported by *type name* only, because
+   ``ClientResponseError.__str__`` embeds the full request URL — which on this
+   API can carry token material.
+3. **Never in a repr.** :class:`OAuthToken` and :class:`ShellyTokenManager`
+   override ``__repr__``. A dataclass' generated repr would print the token into
+   any f-string, log line or traceback frame summary that touches it.
+4. **Nothing is persisted here.** The manager keeps the live token in RAM and
+   hands a refreshed one to an optional callback, so the decision of *where* a
+   token is stored stays with the wiring layer and out of this module.
+
+Every site that transmits a credential is marked ``# CREDENTIAL:`` below, so the
+transmissions can be enumerated by reading rather than by inference. There are
+three, all form POSTs, all to the account's own host: the login, the code
+exchange, and the refresh.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+import aiohttp
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+
+from .cloud_control import (
+    ShellyCloudControl,
+    ShellyCloudError,
+    ShellyCloudRateLimitError,
+    ShellyCloudTransportError,
+)
+
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
+
+_LOGGER = logging.getLogger(__name__)
+
+# Wire facts. They live here rather than in ``const.py`` because this slice is
+# the transport only — the wiring pass that adds the option and the entities is
+# free to promote them once something else needs them.
+OAUTH_LOGIN_URL = "https://api.shelly.cloud/oauth/login"
+OAUTH_CLIENT_ID = "shelly-diy"
+
+# Refresh this far ahead of expiry, so a token is renewed before a command needs
+# it rather than after one has already failed.
+TOKEN_REFRESH_MARGIN_S = 300
+
+# Used only when a token carries neither ``expires_in`` nor a readable ``exp``.
+# Short on purpose: a wrong-but-short TTL costs one extra refresh, a
+# wrong-but-long one costs a dead session.
+TOKEN_FALLBACK_TTL_S = 3600
+
+# Per-request timeout for the two short OAuth round-trips.
+_DEFAULT_TIMEOUT_S = 10
+
+# One retry on a rate-limit rejection, then surface it. Matches the interval
+# ``cloud_control._post`` settled on: 1.2 s was borderline in testing.
+_RATE_LIMIT_BACKOFF_S = 1.5
+
+# Reuse the auth_key client's base-URL normaliser (bare host vs. https:// prefix,
+# trailing slash). It is a pure static helper and touches no credential state.
+_normalise_base_url = ShellyCloudControl._normalise_base_url  # noqa: SLF001
+
+
+class ShellyOAuthError(ShellyCloudError, HomeAssistantError):
+    """OAuth login, exchange or refresh failed.
+
+    Subclasses :class:`~homeassistant.exceptions.HomeAssistantError` as well as
+    the repo's own base so a failure surfaces in the UI and in an automation
+    trace instead of only in the log, while ``except ShellyCloudError`` in
+    existing callers keeps working.
+
+    The message is always sanitised: an HTTP status and/or a path-only URL,
+    never a server body, a token, or a token-bearing query string.
+    """
+
+
+class ShellyOAuthTransportError(ShellyOAuthError, ShellyCloudTransportError):
+    """Network-level failure during an OAuth round-trip (DNS, TLS, timeout)."""
+
+
+class ShellyOAuthRateLimitError(ShellyOAuthError, ShellyCloudRateLimitError):
+    """The account's 1 req/s budget rejected the OAuth round-trip."""
+
+
+@dataclass(frozen=True)
+class OAuthToken:
+    """One access/refresh token pair, with a **redacting** ``__repr__``.
+
+    ``expires_at`` is absolute epoch seconds, not a duration, so a token that
+    has been sitting in memory answers "am I still valid" correctly without
+    anyone tracking when it was minted.
+    """
+
+    access_token: str
+    expires_at: float
+    refresh_token: str | None = None
+
+    def expires_within(self, seconds: float) -> bool:
+        """True if the token expires within ``seconds`` from now (or already has)."""
+        return time.time() >= (self.expires_at - seconds)
+
+    @property
+    def is_expired(self) -> bool:
+        """True once the token is at or past its expiry epoch."""
+        return self.expires_within(0)
+
+    def __repr__(self) -> str:
+        # MANDATORY. The generated dataclass repr would print the token itself,
+        # and a repr reaches places a deliberate log call never does: f-strings,
+        # ``logging`` argument formatting, traceback frame summaries.
+        return (
+            f"OAuthToken(expires_at={self.expires_at}, "
+            f"refresh={'yes' if self.refresh_token else 'no'})"
+        )
+
+
+def sha1_password(plaintext: str) -> str:
+    """Hash the plaintext password at the earliest boundary.
+
+    Shelly's ``/oauth/login`` expects ``password=sha1(plaintext)``. This is the
+    only function in the integration that sees the plaintext; everything else
+    takes the hex digest. That is what makes "the password is never stored and
+    never logged" a structural property rather than a promise — the layers that
+    do I/O never hold the value in the first place.
+
+    The digest is not a security improvement over the password (it is
+    password-equivalent to this API) and is treated with the same care.
+    """
+    # sha1 is Shelly's choice of wire format, not a hashing decision of ours.
+    return hashlib.sha1(plaintext.encode()).hexdigest()  # noqa: S324
+
+
+def _b64url_json(segment: str) -> dict[str, Any]:
+    """Decode one base64url JWT segment into its claims (no signature check).
+
+    We are a client, not a validator: ``exp`` and ``user_api_url`` are read for
+    expiry bookkeeping and routing only, never for an authorisation decision.
+    """
+    segment += "=" * (-len(segment) % 4)
+    return json.loads(base64.urlsafe_b64decode(segment))
+
+
+def _decode_expiry(jwt: str, expires_in: Any = None) -> float:
+    """Return the absolute expiry epoch for an access token.
+
+    Preference order: an explicit ``expires_in`` from the token response, then
+    the JWT ``exp`` claim, then :data:`TOKEN_FALLBACK_TTL_S`. A malformed token
+    degrades to the short fallback rather than raising — the caller still holds
+    a usable token and simply refreshes sooner.
+    """
+    now = time.time()
+    if expires_in is not None:
+        try:
+            return now + float(expires_in)
+        except (TypeError, ValueError):
+            pass
+    try:
+        exp = _b64url_json(jwt.split(".")[1]).get("exp")
+        return float(exp) if exp else now + TOKEN_FALLBACK_TTL_S
+    except Exception:  # noqa: BLE001 — malformed JWT → conservative short TTL
+        return now + TOKEN_FALLBACK_TTL_S
+
+
+def _extract_field(body: Any, key: str) -> Any:
+    """Read ``key`` from a top-level or ``{data: {...}}``-wrapped body.
+
+    Shelly's two OAuth responses disagree with each other: the login wraps
+    ``code`` in ``data``, the token exchange returns the tokens top-level.
+    Trying both shapes costs nothing and avoids a silent mis-parse if a future
+    firmware aligns them.
+    """
+    if not isinstance(body, dict):
+        return None
+    value = body.get(key)
+    if value is not None:
+        return value
+    data = body.get("data")
+    if isinstance(data, dict):
+        return data.get(key)
+    return None
+
+
+def _server_uri_from_code(code: str) -> str | None:
+    """Extract the account's ``user_api_url`` from the login ``code`` JWT."""
+    try:
+        uri = _b64url_json(code.split(".")[1]).get("user_api_url")
+        return uri if isinstance(uri, str) and uri else None
+    except Exception:  # noqa: BLE001 — fall back to the caller-supplied host
+        return None
+
+
+async def _post_form(
+    session: ClientSession,
+    url: str,
+    payload: dict[str, str],
+    *,
+    timeout_s: int = _DEFAULT_TIMEOUT_S,
+) -> Any:
+    """POST a form body and return parsed JSON, with sanitised error handling.
+
+    Mirrors ``ShellyCloudControl._post`` for status handling and the single
+    rate-limit retry, and deliberately diverges on one point: no branch here may
+    put a server body into a message. The v1 client can quote Shelly's own error
+    text safely because that text never contains the auth_key; an OAuth body
+    contains the tokens themselves.
+
+    ``payload`` — which carries the password digest, the login code or the
+    refresh token — is never logged, not even at DEBUG.
+    """
+    safe_url = str(url).split("?", 1)[0]
+    timeout = aiohttp.ClientTimeout(total=timeout_s)
+    data: Any = None
+    for attempt in range(2):
+        try:
+            async with session.post(url, data=payload, timeout=timeout) as response:
+                status = response.status
+                if status in (401, 403):
+                    # Shelly signals its 1 req/s limit as HTTP 401 with a
+                    # ``max_req`` body, so a rejection is only a credential
+                    # failure once the body says it is not a rate limit.
+                    body_text = await response.text()
+                    if ShellyCloudControl._is_rate_limit_body(body_text):  # noqa: SLF001
+                        if attempt == 0:
+                            await asyncio.sleep(_RATE_LIMIT_BACKOFF_S)
+                            continue
+                        raise ShellyOAuthRateLimitError("Rate limit exceeded (1 req/s)")
+                    _LOGGER.debug("OAuth POST %s rejected: HTTP %s", safe_url, status)
+                    raise ShellyOAuthError(f"OAuth request rejected (HTTP {status})")
+                if status == 429:
+                    if attempt == 0:
+                        await asyncio.sleep(_RATE_LIMIT_BACKOFF_S)
+                        continue
+                    raise ShellyOAuthRateLimitError("Rate limit exceeded (1 req/s)")
+                response.raise_for_status()
+                data = await response.json(content_type=None)
+                break
+        except asyncio.TimeoutError as err:
+            raise ShellyOAuthTransportError(f"Timeout calling {safe_url}") from err
+        except aiohttp.ClientError as err:
+            # NEVER interpolate ``err``: ClientResponseError embeds the full
+            # request URL in ``__str__``, and on this API the URL can carry the
+            # token. The type name is enough to tell DNS from TLS from reset.
+            raise ShellyOAuthTransportError(
+                f"HTTP error calling {safe_url} ({type(err).__name__})"
+            ) from err
+    _LOGGER.debug("OAuth POST %s ok", safe_url)
+    return data
+
+
+async def request_code(session: ClientSession, email: str, password_sha1: str) -> str:
+    """Sign in at the fixed ``/oauth/login`` host and return the single-use code.
+
+    ``password_sha1`` is the digest from :func:`sha1_password`; the plaintext
+    never reaches this layer. A response without a ``code`` raises
+    :class:`ShellyOAuthError` rather than returning ``None``, so a renamed field
+    fails loudly at setup instead of half-configuring an entry.
+    """
+    # CREDENTIAL (sent 1/3): the password digest, as a form field, to the fixed
+    # Shelly login host. This is the only request in the integration that
+    # carries anything derived from the account password. (docs/AUTH_KEY.md)
+    payload = {
+        "email": email,
+        "password": password_sha1,
+        "client_id": OAUTH_CLIENT_ID,
+    }
+    body = await _post_form(session, OAUTH_LOGIN_URL, payload)
+    code = _extract_field(body, "code")
+    if not isinstance(code, str) or not code:
+        raise ShellyOAuthError("OAuth login response carried no 'code'")
+    return code
+
+
+async def exchange_code(session: ClientSession, server_uri: str, code: str) -> OAuthToken:
+    """Exchange the login ``code`` at ``<server_uri>/oauth/auth`` for a token."""
+    base = _normalise_base_url(server_uri)
+    url = f"{base}/oauth/auth"
+    # CREDENTIAL (sent 2/3): the single-use login code, as a form field, to the
+    # account's own host — the one named by the code's ``user_api_url`` claim.
+    payload = {"client_id": OAUTH_CLIENT_ID, "code": code}
+    body = await _post_form(session, url, payload)
+
+    access_token = _extract_field(body, "access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise ShellyOAuthError("OAuth token response carried no 'access_token'")
+    refresh = _extract_field(body, "refresh_token")
+    return OAuthToken(
+        access_token=access_token,
+        expires_at=_decode_expiry(access_token, _extract_field(body, "expires_in")),
+        refresh_token=refresh if isinstance(refresh, str) and refresh else None,
+    )
+
+
+async def login(
+    session: ClientSession,
+    server_uri: str,
+    email: str,
+    password_sha1: str,
+) -> OAuthToken:
+    """Run the full sign-in: :func:`request_code` then :func:`exchange_code`.
+
+    The login code's ``user_api_url`` claim takes precedence over the caller's
+    ``server_uri``: the exchange must hit the account's own regional host, and
+    the account itself is the authority on which one that is. The caller's value
+    is the fallback for a code we could not read.
+    """
+    code = await request_code(session, email, password_sha1)
+    return await exchange_code(session, _server_uri_from_code(code) or server_uri, code)
+
+
+async def refresh_token(
+    session: ClientSession, server_uri: str, refresh_token: str
+) -> OAuthToken:
+    """Exchange a stored refresh token for a fresh :class:`OAuthToken`.
+
+    The refresh posts ``grant_type=refresh_token`` to the same ``/oauth/auth``
+    endpoint the code exchange uses. Measured against the live test account: the
+    ``refresh_token`` does **not** rotate, so a response that omits one is the
+    normal case and the caller's durable secret is carried forward. Treating a
+    missing rotation as "the token is gone" would strand the account after the
+    first refresh.
+    """
+    base = _normalise_base_url(server_uri)
+    url = f"{base}/oauth/auth"
+    # CREDENTIAL (sent 3/3): the refresh token, as a form field, to the
+    # account's own host. Same destination as the exchange above.
+    payload = {
+        "client_id": OAUTH_CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }
+    body = await _post_form(session, url, payload)
+
+    access_token = _extract_field(body, "access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise ShellyOAuthError("OAuth refresh response carried no 'access_token'")
+    rotated = _extract_field(body, "refresh_token")
+    return OAuthToken(
+        access_token=access_token,
+        expires_at=_decode_expiry(access_token, _extract_field(body, "expires_in")),
+        refresh_token=rotated if isinstance(rotated, str) and rotated else refresh_token,
+    )
+
+
+class ShellyTokenManager:
+    """Holds the live OAuth token for one config entry and renews it.
+
+    Two jobs, both about not surprising the user:
+
+    * **Serialise.** Every refresh runs under one lock, so a reconnect storm or
+      several entities asking at once produce a single round-trip rather than a
+      burst against a 1 req/s budget.
+    * **Escalate honestly.** With no usable refresh token, or after the server
+      rejects the one we hold, the manager raises
+      :class:`~homeassistant.exceptions.ConfigEntryAuthFailed` so Home Assistant
+      asks the user to sign in again. There is deliberately no
+      password-at-rest rung to fall back on: the password is never stored, so a
+      dead refresh token genuinely means "ask the human".
+
+    Persistence is the caller's business. The manager keeps the token in RAM and
+    hands each new one to ``on_token_refreshed``; deciding where it is written
+    stays outside the module that holds the secret.
+    """
+
+    def __init__(
+        self,
+        session: ClientSession,
+        server_uri: str,
+        *,
+        token: OAuthToken | None = None,
+        on_token_refreshed: Callable[[OAuthToken], Awaitable[None]] | None = None,
+    ) -> None:
+        """Bind the manager to one account.
+
+        Args:
+            session: shared aiohttp session used for the refresh round-trip.
+            server_uri: the account's server URI (bare host or full URL).
+            token: the token from the initial :func:`login`, or one restored
+                from storage. Without it the first call escalates to reauth.
+            on_token_refreshed: awaited with every newly minted token, for the
+                caller to persist. An exception from it is logged and swallowed
+                — a storage failure must not take the live session down.
+        """
+        self._session = session
+        self._server_uri = server_uri
+        self._token = token
+        self._on_token_refreshed = on_token_refreshed
+        self._lock = asyncio.Lock()
+        self._auth_failed = False
+
+    @property
+    def auth_failed(self) -> bool:
+        """True once a refresh failure has escalated to reauth."""
+        return self._auth_failed
+
+    @property
+    def expires_at(self) -> float | None:
+        """Expiry epoch of the held token, for diagnostics. Never the token."""
+        return self._token.expires_at if self._token else None
+
+    async def async_get_token(self) -> str:
+        """Return a valid access token, refreshing ahead of expiry.
+
+        Serves the cached token unless it is within
+        :data:`TOKEN_REFRESH_MARGIN_S` of expiring, so the ordinary case costs
+        no network traffic at all.
+        """
+        async with self._lock:
+            if self._token is None or self._token.expires_within(TOKEN_REFRESH_MARGIN_S):
+                await self._refresh_locked()
+            assert self._token is not None  # set by _refresh_locked, or it raised
+            return self._token.access_token
+
+    async def async_force_refresh(self) -> str:
+        """Mint a fresh token unconditionally and return it.
+
+        Bound to the relay's token-rejected hook. A rejection means the current
+        access token is not accepted, so re-serving it would spin; only a new
+        one can break the loop.
+        """
+        async with self._lock:
+            await self._refresh_locked()
+            assert self._token is not None
+            return self._token.access_token
+
+    async def _refresh_locked(self) -> None:
+        """Refresh the token; the caller holds the lock."""
+        stored_refresh = self._token.refresh_token if self._token else None
+        if not stored_refresh:
+            # No durable credential and no password at rest: the only honest
+            # move is to ask the user.
+            self._auth_failed = True
+            raise ConfigEntryAuthFailed(
+                "No Shelly refresh token available; sign in again"
+            )
+        try:
+            self._token = await refresh_token(
+                self._session, self._server_uri, stored_refresh
+            )
+        except ShellyOAuthRateLimitError:
+            # A rate limit says nothing about the credential. Keep the old token
+            # and let the caller retry rather than pushing the user into reauth.
+            raise
+        except ShellyOAuthError as err:
+            self._auth_failed = True
+            raise ConfigEntryAuthFailed(str(err)) from err
+        self._auth_failed = False
+        if self._on_token_refreshed is not None:
+            try:
+                await self._on_token_refreshed(self._token)
+            except Exception as err:  # noqa: BLE001 — type name only, never a token
+                _LOGGER.error(
+                    "Storing the refreshed Shelly token failed: %s", type(err).__name__
+                )
+
+    def __repr__(self) -> str:
+        # MANDATORY, same reasoning as OAuthToken: the default repr of an object
+        # holding a token is one f-string away from a log line.
+        return f"ShellyTokenManager(expires_at={self.expires_at})"

--- a/custom_components/shelly_cloud_diy/config_flow.py
+++ b/custom_components/shelly_cloud_diy/config_flow.py
@@ -917,6 +917,23 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
             _LOGGER.info(
                 "Cloud control switched off; the stored Shelly sign-in was deleted"
             )
-        if data != self.config_entry.data:
+        data_changed = data != self.config_entry.data
+        if data_changed:
             self.hass.config_entries.async_update_entry(self.config_entry, data=data)
+
+        # A fresh sign-in with the options left exactly as they were reloads
+        # nothing on its own, and the entry would sit with a valid token and a
+        # dead channel until the next restart. Neither write reaches a
+        # listener: the data write is correctly ignored because the options
+        # did not change, and Home Assistant fires no listener at all for an
+        # options write that changes nothing.
+        #
+        # This is reachable, not theoretical — it is exactly what happens when
+        # a token is rejected and the user re-signs-in through Options instead
+        # of through the repair card, which is the case the sign-in step
+        # exists for.
+        if data_changed and dict(self.config_entry.options) == options:
+            self.hass.config_entries.async_schedule_reload(
+                self.config_entry.entry_id
+            )
         return self.async_create_entry(title="", data=options)

--- a/custom_components/shelly_cloud_diy/config_flow.py
+++ b/custom_components/shelly_cloud_diy/config_flow.py
@@ -14,8 +14,16 @@ User setup is a two-step flow:
    only want cloud-only devices materialised.
 
 Options flow exposes the poll interval, the optional local gateway URL
-for the historical-data service, and a mirror of the device-selection
-step so users can change their mind later.
+for the historical-data service, a mirror of the device-selection step so
+users can change their mind later, and the opt-in cloud control channel.
+
+Switching cloud control on adds a third step asking for the Shelly account
+sign-in, because the relay that channel uses accepts an OAuth token and
+nothing else. The password is hashed by ``oauth.sha1_password`` before it
+leaves the step and is never stored; the token that comes back is written
+to ``entry.data`` next to the ``auth_key``. Switching the option off again
+deletes that token — an unused credential kept "just in case" is a
+liability, and signing in again costs one form.
 """
 from __future__ import annotations
 
@@ -34,6 +42,9 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
 )
 
 from .api.cloud_control import (
@@ -42,13 +53,23 @@ from .api.cloud_control import (
     ShellyCloudError,
     ShellyCloudTransportError,
 )
+from .api.oauth import (
+    OAuthToken,
+    ShellyOAuthError,
+    ShellyOAuthTransportError,
+    login,
+    sha1_password,
+)
 from .const import (
+    CLOUD_CONTROL_DEFAULT,
     CONF_AUTH_KEY,
+    CONF_CLOUD_CONTROL,
     CONF_CREATE_ALL_INITIALLY,
     CONF_DEVICE_HEALTH_DETECTION,
     CONF_DEVICE_HEALTH_FIRMWARE,
     CONF_ENABLED_DEVICES,
     CONF_LOCAL_GATEWAY_URL,
+    CONF_OAUTH_TOKEN,
     CONF_OFFLINE_AFTER,
     CONF_POLL_INTERVAL,
     CONF_RELAY_FAULT_DETECTION,
@@ -62,10 +83,12 @@ from .const import (
     POLL_INTERVAL_DEFAULT,
     POLL_INTERVAL_MAX,
     POLL_INTERVAL_MIN,
+    REAUTH_CLOUD_CONTROL,
     RELAY_FAULT_DETECTION_DEFAULT,
 )
 from .entities.descriptions import get_model_name
 from .utils import validate_gateway_url
+from .utils.token_store import token_to_storage
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,6 +108,58 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_LOCAL_GATEWAY_URL): str,
     }
 )
+
+
+# Fields of the Shelly account sign-in. ``CONF_PASSWORD`` never reaches
+# ``entry.data``: it is hashed at the boundary and the digest dies with the
+# login request (see ``api/oauth.py``).
+CONF_EMAIL = "email"
+CONF_PASSWORD = "password"  # noqa: S105 — a form field name, not a secret
+
+CLOUD_CONTROL_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_EMAIL): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.EMAIL, autocomplete="username")
+        ),
+        # A password field, so the browser masks it and does not offer to
+        # remember it as ordinary text. The value is hashed the moment the
+        # form is submitted and never stored either way, but a form that
+        # shows an account password in the clear invites the mistake.
+        vol.Required(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.PASSWORD, autocomplete="current-password"
+            )
+        ),
+    }
+)
+
+
+async def _async_sign_in(
+    hass: Any, server_uri: str, user_input: dict[str, Any]
+) -> tuple[OAuthToken | None, dict[str, str]]:
+    """Sign in to the Shelly account and return ``(token, errors)``.
+
+    Shared by the options step that switches cloud control on and the reauth
+    step that renews it, so both treat the password identically: hashed here,
+    never stored, never logged, never carried in the flow's own state.
+    """
+    email = str(user_input.get(CONF_EMAIL, "")).strip()
+    password = str(user_input.get(CONF_PASSWORD, ""))
+    if not email:
+        return None, {CONF_EMAIL: "required"}
+    if not password:
+        return None, {CONF_PASSWORD: "required"}
+
+    session = async_get_clientsession(hass)
+    try:
+        token = await login(session, server_uri, email, sha1_password(password))
+    except ShellyOAuthTransportError:
+        return None, {"base": "cannot_connect"}
+    except ShellyOAuthError:
+        # Deliberately not logged with the server's own words: an OAuth error
+        # body can carry token material.
+        return None, {"base": "invalid_account"}
+    return token, {}
 
 
 def _build_device_options(
@@ -399,8 +474,52 @@ class ShellyCloudDiyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(
         self, entry_data: dict[str, Any]
     ) -> FlowResult:
-        """HA triggers this when ConfigEntryAuthFailed is raised."""
+        """HA triggers this when a credential was rejected.
+
+        Two credentials can be rejected and both land here, so the caller
+        says which one it is (see ``__init__._start_cloud_control_reauth``).
+        Guessing would mean showing the Authorization-cloud-key form for a
+        spent Shelly sign-in, and the user pasting a perfectly good key into
+        it.
+        """
+        if isinstance(entry_data, dict) and entry_data.get(REAUTH_CLOUD_CONTROL):
+            return await self.async_step_reauth_cloud_control()
         return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_cloud_control(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Sign in to the Shelly account again for the cloud control channel.
+
+        Only the token is renewed. The ``auth_key`` the poll runs on is a
+        different credential and is not touched here — a user whose control
+        channel expired has no reason to go hunting for their cloud key.
+        """
+        errors: dict[str, str] = {}
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if entry is None:
+            return self.async_abort(reason="reauth_entry_missing")
+
+        if user_input is not None:
+            token, errors = await _async_sign_in(
+                self.hass, entry.data[CONF_SERVER_URI], user_input
+            )
+            if token is not None:
+                # The one call that writes, reloads and ends the flow. Doing
+                # the three by hand leaves a written token behind if the
+                # reload raises — which it does for an entry that was
+                # disabled or removed while this form sat open.
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={**entry.data, CONF_OAUTH_TOKEN: token_to_storage(token)},
+                    reason="reauth_successful",
+                )
+
+        return self.async_show_form(
+            step_id="reauth_cloud_control",
+            data_schema=CLOUD_CONTROL_SCHEMA,
+            errors=errors,
+        )
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -451,6 +570,15 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
         self._pending_devices: dict[str, dict[str, Any]] = {}
         self._pending_names: dict[str, str] = {}
         self._pending_base_options: dict[str, Any] = {}
+        # Set when the device refresh failed, so the sign-in step knows the
+        # device picker is being skipped and it has to commit itself.
+        self._skip_devices = False
+        # The token from a sign-in in this flow, held until the option that
+        # authorises it is saved. Writing it at the sign-in step would leave
+        # a Shelly ACCOUNT token in storage for a user who then closed the
+        # dialog at the device picker — with the option still off, and with
+        # the step's own text promising nothing had been saved.
+        self._pending_token: OAuthToken | None = None
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -494,6 +622,9 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                             DEVICE_HEALTH_FIRMWARE_DEFAULT,
                         )
                     ),
+                    CONF_CLOUD_CONTROL: bool(
+                        user_input.get(CONF_CLOUD_CONTROL, CLOUD_CONTROL_DEFAULT)
+                    ),
                 }
 
                 # Fetch the current fleet + names so the device-selection
@@ -514,10 +645,26 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                         "device selection stays as previously saved.",
                         err,
                     )
+                    # Saving replaces ``entry.options`` wholesale, so the
+                    # sentence above is only true if the selection is carried
+                    # across explicitly. Without this the user's curated list
+                    # is dropped, and the coordinator's "no explicit
+                    # selection" fallback then materialises every device the
+                    # account can see — because the cloud was briefly
+                    # unreachable.
+                    self._carry_device_selection()
+                    if self._needs_cloud_sign_in():
+                        self._skip_devices = True
+                        return await self.async_step_cloud_control()
                     return self._save(self._pending_base_options)
 
                 self._pending_devices = devices
                 self._pending_names = names
+                if self._needs_cloud_sign_in():
+                    # Ask before the device picker, not after: the sign-in is
+                    # what decides whether the option can be honoured at all,
+                    # and abandoning it must leave nothing half-saved.
+                    return await self.async_step_cloud_control()
                 return await self.async_step_devices()
 
         current_interval = int(
@@ -542,6 +689,9 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                 CONF_DEVICE_HEALTH_FIRMWARE, DEVICE_HEALTH_FIRMWARE_DEFAULT
             )
         )
+        current_cloud_control = bool(
+            self.config_entry.options.get(CONF_CLOUD_CONTROL, CLOUD_CONTROL_DEFAULT)
+        )
 
         schema = vol.Schema(
             {
@@ -561,6 +711,9 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
                 ): bool,
                 vol.Required(
                     CONF_DEVICE_HEALTH_FIRMWARE, default=current_health_firmware
+                ): bool,
+                vol.Required(
+                    CONF_CLOUD_CONTROL, default=current_cloud_control
                 ): bool,
                 vol.Optional(
                     CONF_LOCAL_GATEWAY_URL, default=current_gw
@@ -699,6 +852,71 @@ class ShellyCloudDiyOptionsFlow(OptionsFlow):
             },
         )
 
+    def _carry_device_selection(self) -> None:
+        """Preserve the saved device selection when the picker is skipped."""
+        for key in (CONF_CREATE_ALL_INITIALLY, CONF_ENABLED_DEVICES):
+            if key in self.config_entry.options:
+                self._pending_base_options[key] = self.config_entry.options[key]
+
+    def _needs_cloud_sign_in(self) -> bool:
+        """Whether switching cloud control on still needs a Shelly sign-in."""
+        if not self._pending_base_options.get(CONF_CLOUD_CONTROL):
+            return False
+        return (
+            self._pending_token is None
+            and not self.config_entry.data.get(CONF_OAUTH_TOKEN)
+        )
+
+    async def async_step_cloud_control(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask for the Shelly account sign-in the control channel needs.
+
+        The password is hashed inside :func:`_async_sign_in` and never
+        returns from it; what is stored is the token. Abandoning this form
+        saves nothing at all, so the option cannot end up on without a way
+        to honour it.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            token, errors = await _async_sign_in(
+                self.hass, self.config_entry.data[CONF_SERVER_URI], user_input
+            )
+            if token is not None:
+                # Held, not written — see ``_pending_token``.
+                self._pending_token = token
+                if self._skip_devices:
+                    return self._save(self._pending_base_options)
+                return await self.async_step_devices()
+
+        return self.async_show_form(
+            step_id="cloud_control",
+            data_schema=CLOUD_CONTROL_SCHEMA,
+            errors=errors,
+        )
+
     def _save(self, options: dict[str, Any]) -> FlowResult:
-        """Persist options and return an empty-title entry so HA saves them."""
+        """Persist options — and the sign-in, or its deletion — in one place.
+
+        The credential is written here rather than in the step that obtained
+        it, so it is stored only together with the option that authorises it.
+        A flow the user abandons before this point saves nothing at all,
+        which is what the step's own text promises.
+
+        Switching cloud control off drops a stored token. Keeping an unused
+        account credential "in case they come back" is a liability with no
+        upside — the user who returns pays one form, and the user who left is
+        genuinely left with nothing of theirs held.
+        """
+        data = dict(self.config_entry.data)
+        if options.get(CONF_CLOUD_CONTROL):
+            if self._pending_token is not None:
+                data[CONF_OAUTH_TOKEN] = token_to_storage(self._pending_token)
+        elif data.pop(CONF_OAUTH_TOKEN, None) is not None:
+            _LOGGER.info(
+                "Cloud control switched off; the stored Shelly sign-in was deleted"
+            )
+        if data != self.config_entry.data:
+            self.hass.config_entries.async_update_entry(self.config_entry, data=data)
         return self.async_create_entry(title="", data=options)

--- a/custom_components/shelly_cloud_diy/const.py
+++ b/custom_components/shelly_cloud_diy/const.py
@@ -99,6 +99,50 @@ DEVICE_HEALTH_DETECTION_DEFAULT = True
 CONF_DEVICE_HEALTH_FIRMWARE = "device_health_firmware"
 DEVICE_HEALTH_FIRMWARE_DEFAULT = False
 
+# ── Cloud control for owned devices (opt-in, off by default) ───────
+#
+# Sending a command to a virtual component means leaving the documented
+# Cloud Control API: every documented HTTP route answers 404 for it
+# (measured 2026-08-09, with a known-good ``set/switch`` answering 400 as
+# the negative control), while the cloud WebSocket relay carries the
+# device's own ``Boolean.Set`` and succeeds. That relay is undocumented,
+# Shelly support declared it unsupported on 2026-07-27, it needs the
+# account password once to mint an OAuth token, and it refuses to route to
+# devices the account does not own.
+#
+# Four reasons for an option — and for it defaulting to OFF, unlike the
+# relay-fault and health detectors, which only interpret data the poll
+# already returns. This one adds a credential, a second connection and a
+# channel that can be withdrawn without notice. A user has to be able to
+# say no to that, and saying nothing has to mean no.
+CONF_CLOUD_CONTROL = "cloud_control"
+CLOUD_CONTROL_DEFAULT = False
+
+# ``entry.data`` key holding the OAuth token minted from that sign-in.
+# It lives beside the ``auth_key`` (the poll keeps using that one, and only
+# that one) and never in ``entry.options``: options are handed around by
+# the options flow, echoed into log lines on a reload and read by the
+# diagnostics block, none of which may ever see a token.
+#
+# The password itself is stored NOWHERE. It is hashed at the flow boundary
+# by ``oauth.sha1_password`` and the digest dies with the login request, so
+# a dead refresh token genuinely means "ask the human" — see
+# ``ShellyTokenManager``.
+CONF_OAUTH_TOKEN = "oauth_token"  # noqa: S105 — a key name, not a secret
+
+# Marker put into the reauth flow's data when it is the OAuth token that
+# was rejected rather than the ``auth_key``. Without it the reauth form
+# would ask for the wrong credential — both failures land in the same flow.
+REAUTH_CLOUD_CONTROL = "cloud_control_reauth"
+
+# How often the ownership re-probe wakes while any enabled device is still
+# unclassified. Long, because the pass exists for one situation only: the
+# relay was unreachable (or answered something unfamiliar) when a device
+# was first asked about, so no verdict could be formed. The task exits as
+# soon as every enabled device has one, so a healthy account pays nothing
+# beyond the single probe pass at setup.
+OWNERSHIP_REPROBE_INTERVAL_S = 15 * 60
+
 # ── Historical sync (unchanged from pre-pivot) ─────────────────────
 
 HISTORICAL_SYNC_INTERVAL = 24 * 60 * 60  # daily

--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -1378,10 +1378,11 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         Devices bridged over Bluetooth are out for a harder reason: they
         speak no RPC of their own at all.
 
-        The list is taken once, at setup. A device that joins the account
-        later is classified on the next reload — and ticking a new device in
-        the options *is* a reload — rather than by a watcher that would have
-        to run for the lifetime of Home Assistant to catch a rare event.
+        The list is derived live on every call, not captured at setup. The
+        cloud omits devices from ``all_status`` routinely, so "not in the
+        snapshot at setup" is not the same as "not on the account", and a
+        device that turns up later must still be classified — which is what
+        the re-probe loop uses this for.
         """
         candidates = []
         for device_id, info in self.devices.items():

--- a/custom_components/shelly_cloud_diy/coordinator.py
+++ b/custom_components/shelly_cloud_diy/coordinator.py
@@ -12,6 +12,7 @@ know about the raw HTTP shape.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
 import time
@@ -20,7 +21,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
@@ -35,7 +36,14 @@ from .api.cloud_control import (
     ShellyCloudError,
     ShellyCloudRateLimitError,
 )
+from .api.cloud_ws import (
+    DeviceOwnership,
+    ShellyCloudWebSocket,
+    ShellyCloudWsAuthError,
+)
 from .const import (
+    CLOUD_CONTROL_DEFAULT,
+    CONF_CLOUD_CONTROL,
     CONF_CREATE_ALL_INITIALLY,
     CONF_DEVICE_HEALTH_DETECTION,
     CONF_DEVICE_HEALTH_FIRMWARE,
@@ -47,10 +55,12 @@ from .const import (
     DEVICE_HEALTH_FIRMWARE_DEFAULT,
     DOMAIN,
     OFFLINE_AFTER_DEFAULT,
+    OWNERSHIP_REPROBE_INTERVAL_S,
     POLL_INTERVAL_DEFAULT,
     RELAY_FAULT_DETECTION_DEFAULT,
     SIGNAL_NEW_DEVICE,
     device_gen,
+    is_gen2_status,
 )
 from .device_health import (
     HealthFinding,
@@ -82,6 +92,11 @@ _V2_NAME_LOOKUP_GAP_S = 1.2
 # to decide which online devices need a one-time v2 config fetch so their
 # read-only virtual entities can render real names/units/options. (#9)
 _VIRTUAL_COMPONENT_KEY_RE = re.compile(r"^(number|enum|text|boolean):\d+$")
+
+# The only component this integration can WRITE over the cloud relay. Kept
+# separate from the read-only set above: everything there is rendered, only
+# a boolean can be set (``Boolean.Set``, the one write measured to work).
+_VIRTUAL_BOOLEAN_KEY_RE = re.compile(r"^boolean:(\d+)$")
 
 # ── Deep-sleep (battery) device freshness ─────────────────────────────
 #
@@ -438,6 +453,20 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         # a device that dropped off the cloud at 84 °C is not cooler for
         # having stopped talking about it.
         self.device_health: dict[str, tuple[HealthFinding, ...]] = {}
+
+        # ── Cloud control (opt-in, OFF by default) ────────────────────
+        # Every field below stays inert unless the option is on: no
+        # transport is built, no probe runs, nothing is dispatched. That is
+        # the whole contract of the option — see const.CONF_CLOUD_CONTROL.
+        self._cloud_ws: ShellyCloudWebSocket | None = None
+        # device_id -> DEFINITE ownership verdict. Only ``OWNED`` and
+        # ``NOT_ROUTABLE`` are ever stored: an inconclusive probe is not a
+        # verdict about the device and must never harden into one.
+        self.device_ownership: dict[str, DeviceOwnership] = {}
+        # Devices the relay could not classify, kept apart from the verdicts
+        # above so they are re-asked rather than written off.
+        self._ownership_unresolved: set[str] = set()
+        self._ownership_task: asyncio.Task | None = None
 
     # ── Offline detection bookkeeping ─────────────────────────────────
 
@@ -1284,6 +1313,283 @@ class ShellyCloudCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
 
         # Re-render entities with the real names/units/options straight away.
         self.async_update_listeners()
+
+    # ── Cloud control for owned devices (opt-in) ──────────────────────
+    #
+    # A second, undocumented channel that exists for exactly what the
+    # documented one cannot do: writing a virtual component. It is bolted on
+    # beside the poll, never into it — the poll stays the single source of
+    # state, and every detector built on it keeps reading the same data it
+    # was hardware-confirmed against.
+
+    @property
+    def cloud_control(self) -> bool:
+        """Whether the user opted this entry into the cloud control channel."""
+        return bool(self._options.get(CONF_CLOUD_CONTROL, CLOUD_CONTROL_DEFAULT))
+
+    @property
+    def cloud_control_connected(self) -> bool:
+        """Whether the relay connection is currently open."""
+        ws = self._cloud_ws
+        return ws is not None and ws.connected
+
+    def is_cloud_controllable(self, device_id: str) -> bool:
+        """Whether this device may be given a cloud control entity.
+
+        Three things have to hold at once, and the missing one is the answer
+        to "why has my device no switch": the option is on (there is a
+        transport), the relay answered for this device, and the answer was
+        that it will route to it. Anything less than a definite ``OWNED`` is
+        a no — including "we could not tell".
+        """
+        return (
+            self._cloud_ws is not None
+            and self.device_ownership.get(device_id) is DeviceOwnership.OWNED
+        )
+
+    @property
+    def cloud_control_unclassified(self) -> frozenset[str]:
+        """Devices the relay could not classify this session.
+
+        Exposed as its own reading rather than folded into the verdict map,
+        because it is the opposite of a verdict: it is the set that gets asked
+        again. Diagnostics reports it separately for the same reason.
+        """
+        return frozenset(self._ownership_unresolved)
+
+    def cloud_control_boolean_keys(self, device_id: str) -> list[str]:
+        """Virtual boolean keys on a device that cloud control may write."""
+        status = self.devices.get(device_id, {}).get("status") or {}
+        return sorted(
+            key
+            for key, value in status.items()
+            if _VIRTUAL_BOOLEAN_KEY_RE.match(key) and isinstance(value, dict)
+        )
+
+    def _control_candidates(self) -> list[str]:
+        """Enabled devices worth spending an ownership probe on.
+
+        The plan's wording is "once per enabled Gen2+ device"; this narrows
+        it to the Gen2+ devices that actually carry a virtual boolean, which
+        is the only component this slice can write. A device without one can
+        never gain a control entity whatever the relay answers, so probing it
+        would buy a diagnostics line for a relay round-trip — and on a
+        64-device account that is 60-odd round-trips at every startup.
+        Devices bridged over Bluetooth are out for a harder reason: they
+        speak no RPC of their own at all.
+
+        The list is taken once, at setup. A device that joins the account
+        later is classified on the next reload — and ticking a new device in
+        the options *is* a reload — rather than by a watcher that would have
+        to run for the lifetime of Home Assistant to catch a rare event.
+        """
+        candidates = []
+        for device_id, info in self.devices.items():
+            if not self.is_enabled(device_id):
+                continue
+            status = info.get("status") or {}
+            if device_gen(status) == "GBLE" or not is_gen2_status(status):
+                continue
+            if any(_VIRTUAL_BOOLEAN_KEY_RE.match(key) for key in status):
+                candidates.append(device_id)
+        return sorted(candidates)
+
+    async def async_enable_cloud_control(self, ws: ShellyCloudWebSocket) -> None:
+        """Connect the relay and classify the devices that could use it.
+
+        Raises whatever :meth:`ShellyCloudWebSocket.connect` raises. The
+        caller decides what a failure costs, and the answer there is: the
+        control entities, never the poll.
+        """
+        await ws.connect()
+        self._cloud_ws = ws
+        await self._async_probe_ownership(self._control_candidates())
+        self._async_schedule_ownership_reprobe()
+        verdicts = list(self.device_ownership.values())
+        _LOGGER.info(
+            "Cloud control connected to %s: %d device(s) owned, %d not routable, "
+            "%d unclassified",
+            ws.host,
+            verdicts.count(DeviceOwnership.OWNED),
+            verdicts.count(DeviceOwnership.NOT_ROUTABLE),
+            len(self._ownership_unresolved),
+        )
+
+    async def async_disable_cloud_control(self) -> None:
+        """Close the relay and drop the session's verdicts.
+
+        The verdicts go because they are exactly that — a statement about one
+        session with one account. Carrying them across a reload would let a
+        device keep a control entity built on an answer nobody asked for any
+        more.
+        """
+        task, self._ownership_task = self._ownership_task, None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        ws, self._cloud_ws = self._cloud_ws, None
+        if ws is not None:
+            await ws.disconnect()
+        self.device_ownership.clear()
+        self._ownership_unresolved.clear()
+
+    async def _async_probe_ownership(self, device_ids: list[str]) -> set[str]:
+        """Ask the relay about each id; record only the definite answers.
+
+        Returns the ids that became owned in this pass, so a caller that ran
+        after startup can tell the platforms there is something new to build.
+
+        Ids with a standing verdict are skipped: the relay was asked once and
+        answered definitely, and asking again every quarter of an hour would
+        be traffic for an answer we hold.
+        """
+        ws = self._cloud_ws
+        if ws is None:
+            return set()
+
+        newly_owned: set[str] = set()
+        for index, device_id in enumerate(device_ids):
+            if device_id in self.device_ownership:
+                continue
+            try:
+                verdict = await ws.async_classify_ownership(device_id)
+            except ShellyCloudWsAuthError:
+                # The session is dead, which says nothing about any device.
+                # The transport has already asked for re-authentication; the
+                # rest of the list stays unresolved rather than being judged
+                # on a failure that is not theirs.
+                self._ownership_unresolved.update(device_ids[index:])
+                _LOGGER.warning(
+                    "Cloud control: the relay rejected the session while "
+                    "classifying devices; %d left unclassified",
+                    len(device_ids) - index,
+                )
+                break
+
+            if verdict is DeviceOwnership.UNKNOWN:
+                self._ownership_unresolved.add(device_id)
+                continue
+            self._ownership_unresolved.discard(device_id)
+            self.device_ownership[device_id] = verdict
+            if verdict is DeviceOwnership.OWNED:
+                newly_owned.add(device_id)
+        return newly_owned
+
+    def _async_schedule_ownership_reprobe(self) -> None:
+        """Start the classification loop that runs behind the initial pass.
+
+        Registered on the config entry rather than on ``hass``, so Home
+        Assistant cancels it when the entry unloads even if the teardown
+        below never runs. A background task that outlives its entry is a
+        loop asking a relay that belongs to a session nobody holds any more.
+        """
+        if self._ownership_task is not None:
+            return
+        self._ownership_task = self._entry.async_create_background_task(
+            self.hass,
+            self._async_ownership_reprobe_loop(),
+            f"{DOMAIN} cloud control ownership re-probe",
+        )
+
+    def _unclassified_candidates(self) -> list[str]:
+        """Candidates with no standing verdict — the loop's work list.
+
+        Two kinds end up here, and the second is why this reads the live
+        device list instead of a set frozen at setup:
+
+        * a device the relay could not classify, and
+        * a device that was not a candidate yet when setup ran. The cloud
+          drops devices from ``/device/all_status`` on its own (that is the
+          measured behaviour the offline detector exists for) and an account
+          gains devices, so "the candidates at setup" is not a closed set.
+          Without this, such a device would have no verdict, no switch and —
+          worse — nothing in diagnostics saying so, until a reload.
+        """
+        return sorted(
+            device_id
+            for device_id in self._control_candidates()
+            if device_id not in self.device_ownership
+        )
+
+    async def _async_ownership_reprobe_loop(self) -> None:
+        """Keep asking about devices that have no verdict yet.
+
+        An unclassified device is the one state that must not persist:
+        usually the relay was down or busy when it was asked, and the honest
+        repair is to ask again once it is back rather than let "we could not
+        tell" quietly become "you do not own this".
+
+        A tick with nothing to ask about costs one wake-up and no traffic, so
+        the loop stays for the session rather than exiting when the account
+        happens to be fully classified — a device that appears afterwards has
+        to be picked up too, and the alternative is telling the user to
+        restart Home Assistant.
+        """
+        try:
+            while self._cloud_ws is not None:
+                await asyncio.sleep(OWNERSHIP_REPROBE_INTERVAL_S)
+                # Devices that left the account (or the user's selection) are
+                # no longer candidates; ``_unclassified_candidates`` derives
+                # from the live list, so they simply stop being asked about.
+                self._ownership_unresolved.intersection_update(
+                    d for d in self.devices if self.is_enabled(d)
+                )
+                ws = self._cloud_ws
+                if ws is None or not ws.connected:
+                    continue
+                pending = self._unclassified_candidates()
+                if not pending:
+                    continue
+                newly_owned = await self._async_probe_ownership(pending)
+                for device_id in newly_owned:
+                    # The same signal a rediscovered device fires. Every
+                    # platform already dedupes against its own bookkeeping,
+                    # so this builds the switch that could not be built at
+                    # setup and touches nothing else.
+                    async_dispatcher_send(self.hass, SIGNAL_NEW_DEVICE, device_id)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            self._ownership_task = None
+
+    async def async_set_virtual_boolean(
+        self, device_id: str, component_key: str, value: bool
+    ) -> None:
+        """Set a virtual boolean on an owned device, over the cloud relay.
+
+        Never optimistic, and never quiet. The first consumer is an
+        irrigation controller, where the realistic failure is *the zone did
+        not switch*: a swallowed error there breaks a watering schedule and
+        looks exactly like success. So every failure raises
+        :class:`~homeassistant.exceptions.HomeAssistantError` (the transport's
+        own errors already are one) and surfaces in the UI and in automation
+        traces, and confirmation is asked of the poll rather than assumed.
+        """
+        ws = self._cloud_ws
+        if ws is None:
+            raise HomeAssistantError(
+                "Cloud control is not connected for this Shelly account"
+            )
+        if not self.is_cloud_controllable(device_id):
+            raise HomeAssistantError(
+                f"Shelly Cloud will not route commands to device {device_id}"
+            )
+        match = _VIRTUAL_BOOLEAN_KEY_RE.match(component_key)
+        if match is None:
+            raise HomeAssistantError(
+                f"{component_key} is not a virtual boolean component"
+            )
+
+        await ws.send_jrpc_request(
+            device_id,
+            "Boolean.Set",
+            {"id": int(match.group(1)), "value": bool(value)},
+        )
+        # Ask for the state instead of asserting it. An optimistic write is
+        # precisely what would hide a zone that accepted the command and did
+        # not move; the poll is what can tell the difference.
+        await self.async_request_refresh()
 
     # ── Command dispatch (compat shim for platform files) ─────────────
 

--- a/custom_components/shelly_cloud_diy/diagnostics.py
+++ b/custom_components/shelly_cloud_diy/diagnostics.py
@@ -17,6 +17,8 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
+    CLOUD_CONTROL_DEFAULT,
+    CONF_CLOUD_CONTROL,
     CONF_CREATE_ALL_INITIALLY,
     CONF_ENABLED_DEVICES,
     CONF_LOCAL_GATEWAY_URL,
@@ -56,6 +58,7 @@ KNOWN_OPTION_KEYS = frozenset(
         CONF_ENABLED_DEVICES,
         CONF_LOCAL_GATEWAY_URL,
         CONF_RELAY_FAULT_DETECTION,
+        CONF_CLOUD_CONTROL,
     }
 )
 
@@ -87,6 +90,61 @@ DEVICE_TO_REDACT = {"name", "cloud_name", "ssid", "sta_ip", "ip", "mac"}
 STRUCTURAL_STATUS_KEYS = frozenset(
     {"_updated", "_dev_info", "serial", "ts", "id", "code"}
 )
+
+
+def _cloud_control_diagnostics(
+    options: dict[str, Any], coordinator: Any | None
+) -> dict[str, Any]:
+    """Explain the opt-in control channel, verdict by verdict.
+
+    This block exists for one support question that has no other answer:
+    *why does this device have no switch?* The channel refuses three
+    different ways — the option is off, the relay never came up, or the
+    relay will not route to that particular device — and from the outside
+    all three look identical: a device with a read-only sensor and nothing
+    to press.
+
+    The same two rules as the block below hold, in the same order: nothing
+    from ``entry.data`` is read (the OAuth token lives there, and a
+    diagnostics file is something users paste into public issues), and
+    device ids appear only as fleet-map fingerprints. The token's existence
+    is not reported either — "is there a token" is answered well enough by
+    whether the channel connected, and every extra sentence about a stored
+    credential is one more thing to get wrong later.
+    """
+    # The coordinator's reading where there is one, so this block reports the
+    # option as it is in force rather than as it is stored.
+    enabled = getattr(coordinator, "cloud_control", None)
+    if not isinstance(enabled, bool):
+        enabled = bool(options.get(CONF_CLOUD_CONTROL, CLOUD_CONTROL_DEFAULT))
+    report: dict[str, Any] = {"mode": "on" if enabled else "off"}
+    if not enabled or coordinator is None:
+        return report
+
+    ownership = getattr(coordinator, "device_ownership", None)
+    if not isinstance(ownership, dict):
+        return {**report, "note": "coordinator carries no ownership verdicts"}
+    unresolved = getattr(coordinator, "cloud_control_unclassified", None)
+    unresolved = unresolved if isinstance(unresolved, (set, frozenset)) else set()
+
+    verdicts = {
+        fingerprint(device_id): getattr(verdict, "value", str(verdict))
+        for device_id, verdict in ownership.items()
+    }
+    # Deliberately reported as their own value rather than folded in with the
+    # definite ones: "we could not tell" is a state that resolves itself on
+    # the next probe, and reading it as a verdict is the exact mistake the
+    # coordinator refuses to make.
+    verdicts.update({fingerprint(device_id): "unknown" for device_id in unresolved})
+
+    return {
+        **report,
+        "connected": bool(getattr(coordinator, "cloud_control_connected", False)),
+        "owned": sum(1 for v in verdicts.values() if v == "owned"),
+        "not_routable": sum(1 for v in verdicts.values() if v == "not_routable"),
+        "unclassified": len(unresolved),
+        "verdicts": dict(sorted(verdicts.items())),
+    }
 
 
 def _config_diagnostics(
@@ -178,6 +236,7 @@ def _config_diagnostics(
             },
             "other_option_keys": sorted(set(options) - KNOWN_OPTION_KEYS),
         },
+        "cloud_control": _cloud_control_diagnostics(options, coordinator),
         "devices": devices,
     }
 

--- a/custom_components/shelly_cloud_diy/diagnostics.py
+++ b/custom_components/shelly_cloud_diy/diagnostics.py
@@ -135,6 +135,12 @@ def _cloud_control_diagnostics(
     # definite ones: "we could not tell" is a state that resolves itself on
     # the next probe, and reading it as a verdict is the exact mistake the
     # coordinator refuses to make.
+    #
+    # ⚠ ``unclassified`` counts only devices a probe already answered
+    # inconclusively. A device that appeared after setup has no verdict and
+    # has not been asked yet, so it is missing from this block entirely until
+    # the re-probe loop reaches it — up to fifteen minutes. Read a device
+    # absent from ``verdicts`` as "not asked yet", not as "not owned".
     verdicts.update({fingerprint(device_id): "unknown" for device_id in unresolved})
 
     return {

--- a/custom_components/shelly_cloud_diy/strings.json
+++ b/custom_components/shelly_cloud_diy/strings.json
@@ -47,6 +47,18 @@
           "bulk_action": "\"Tick all\" or \"Untick all\" overrides the manual list below on save.",
           "enabled_devices": "Only ticked devices produce Home Assistant entities."
         }
+      },
+      "reauth_cloud_control": {
+        "title": "Sign in to Shelly again for cloud control",
+        "description": "Shelly Cloud rejected the stored sign-in that the cloud control channel uses. Sign in with your Shelly account to restore control of your virtual components.\n\nYour Authorization cloud key is a different credential and is unaffected — polling has kept running the whole time. The password is used once to sign in and is never stored.",
+        "data": {
+          "email": "Shelly account email",
+          "password": "Shelly account password"
+        },
+        "data_description": {
+          "email": "The email address you use in the Shelly app.",
+          "password": "Used once to sign in and then discarded. Only the resulting token is stored."
+        }
       }
     },
     "error": {
@@ -54,7 +66,8 @@
       "invalid_auth": "Shelly Cloud rejected the Authorization cloud key.",
       "invalid_gateway_url": "Local gateway URL must be http(s) and must not point at localhost.",
       "required": "This field is required.",
-      "unknown": "Unexpected error — see Home Assistant logs."
+      "unknown": "Unexpected error — see Home Assistant logs.",
+      "invalid_account": "Shelly Cloud rejected that email or password."
     },
     "abort": {
       "already_configured": "This Shelly account is already configured.",
@@ -73,7 +86,8 @@
           "relay_fault_detection": "Warn about a relay that no longer opens",
           "local_gateway_url": "Local gateway URL (optional, for EM historical data)",
           "device_health_detection": "Warn about devices in poor health",
-          "device_health_firmware": "Count a pending firmware update as a finding"
+          "device_health_firmware": "Count a pending firmware update as a finding",
+          "cloud_control": "Control virtual components over the cloud (unsupported)"
         },
         "data_description": {
           "poll_interval": "3–60 s. Lower values feel snappier but consume more of Shelly's 1 req/s rate-limit budget.",
@@ -81,7 +95,8 @@
           "relay_fault_detection": "On by default. Watches every switching channel that meters its own output and warns when the relay reports itself as open while a real load is still flowing through it — a contact that has welded shut. Turn this off if a Shelly of yours sits in a two-way circuit, where the other switch can push current through the meter while the relay is genuinely open.",
           "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data.",
           "device_health_detection": "On by default. Interprets data every poll already returns: Wi-Fi signal (warning at -70 dBm, error at -85 dBm), component temperature (70 °C / 85 °C), free memory and free storage (under 20 % / 10 %), a restart the device is still waiting for, and any component reporting its own error. It costs no extra requests. Bluetooth (BLU) devices are judged only on the signal their gateway reports for them, and Gen1 devices are not judged at all. Only a component's own temperature counts, never an external Add-on probe.",
-          "device_health_firmware": "Off by default. Adds \"a firmware update is available\" as a finding. On a typical account most devices have one pending, so switching this on tends to keep the card permanently lit — which is exactly what stops you noticing the findings that matter."
+          "device_health_firmware": "Off by default. Adds \"a firmware update is available\" as a finding. On a typical account most devices have one pending, so switching this on tends to keep the card permanently lit — which is exactly what stops you noticing the findings that matter.",
+          "cloud_control": "Off by default, and worth reading before switching on. Virtual components (an irrigation controller's zones, a script's switch) can be read over the documented Shelly Cloud API but not written — every documented route answers \"no such route\". Switching them is possible only over an **undocumented** channel, which Shelly support declared unsupported on 2026-07-27 and can change or withdraw without notice.\n\nWhat it costs: your Shelly account sign-in (asked for on the next step; the password is used once and never stored) and a second connection to Shelly Cloud.\n\nWhat it gives you: a switch for each virtual boolean, but **only on devices your account owns**. A shared device is refused by Shelly itself, and no switch appears for it. The switch is created **in addition** to the existing read-only sensor of the same component, never instead of it, so nothing you have already built on that sensor breaks.\n\nSwitching this off again deletes the stored sign-in."
         }
       },
       "devices": {
@@ -107,10 +122,25 @@
           "bulk_action": "\"Tick all\" or \"Untick all\" overrides the manual list below on save.",
           "enabled_devices": "Only ticked devices produce Home Assistant entities."
         }
+      },
+      "cloud_control": {
+        "title": "Sign in to Shelly for cloud control",
+        "description": "Cloud control needs your Shelly account sign-in, because the channel it uses accepts an account token rather than the Authorization cloud key.\n\nThe password is used once to sign in and is **never stored** — only the resulting token is, and switching the option off again deletes it. Nothing is saved unless this sign-in succeeds.",
+        "data": {
+          "email": "Shelly account email",
+          "password": "Shelly account password"
+        },
+        "data_description": {
+          "email": "The email address you use in the Shelly app.",
+          "password": "Used once to sign in and then discarded. Only the resulting token is stored."
+        }
       }
     },
     "error": {
-      "invalid_gateway_url": "Local gateway URL must be http(s) and must not point at localhost."
+      "invalid_gateway_url": "Local gateway URL must be http(s) and must not point at localhost.",
+      "invalid_account": "Shelly Cloud rejected that email or password.",
+      "cannot_connect": "Could not reach Shelly Cloud. Check the server URI and your internet connection.",
+      "required": "This field is required."
     }
   },
   "services": {

--- a/custom_components/shelly_cloud_diy/switch.py
+++ b/custom_components/shelly_cloud_diy/switch.py
@@ -1,4 +1,12 @@
-"""Switch platform for Shelly Cloud DIY."""
+"""Switch platform for Shelly Cloud DIY.
+
+Two kinds of switch live here, and they reach the device by different
+roads. The hardware channels (Gen1 ``relays``, Gen2 ``switch:N``) go out
+over the documented Cloud Control API, exactly as before. The virtual
+booleans go over the undocumented cloud WebSocket relay — only when the
+user opted into cloud control, and only on devices that relay said it will
+route to.
+"""
 from __future__ import annotations
 
 import logging
@@ -16,6 +24,26 @@ from .coordinator import ShellyCloudCoordinator, SIGNAL_NEW_DEVICE
 from .entities.base import ShellyBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _controllable_boolean_keys(
+    coordinator: ShellyCloudCoordinator,
+    device_id: str,
+) -> list[str]:
+    """Virtual boolean keys this device may be given a control entity for.
+
+    Both questions go to the coordinator, and both go through ``getattr``.
+    That is not defensive clutter but the platform's half of the opt-in
+    contract: anything that is not a coordinator running with cloud control
+    switched on answers "none", and this platform then behaves exactly as it
+    did before the feature existed. Which components are writable is the
+    coordinator's knowledge — it is the side that has to send the command.
+    """
+    controllable = getattr(coordinator, "is_cloud_controllable", None)
+    boolean_keys = getattr(coordinator, "cloud_control_boolean_keys", None)
+    if not callable(controllable) or not callable(boolean_keys):
+        return []
+    return boolean_keys(device_id) if controllable(device_id) else []
 
 
 async def async_setup_entry(
@@ -57,6 +85,15 @@ async def async_setup_entry(
                     entities.append(ShellySwitch(
                         coordinator, device_id, idx, key, is_gen2=True
                     ))
+
+        # Virtual booleans, over the opt-in cloud control channel only.
+        for key in _controllable_boolean_keys(coordinator, device_id):
+            unique_id = f"{device_id}_{key}_control"
+            if unique_id not in created_entities:
+                created_entities.add(unique_id)
+                entities.append(
+                    ShellyVirtualBooleanSwitch(coordinator, device_id, key)
+                )
 
         if entities:
             _LOGGER.info("Created %d switches for %s", len(entities), device_id)
@@ -193,3 +230,80 @@ class ShellySwitch(ShellyBaseEntity, SwitchEntity):
         """Record the commanded state optimistically until the cloud confirms."""
         key = "output" if self._is_gen2 else "ison"
         self._set_optimistic({key: is_on})
+
+
+class ShellyVirtualBooleanSwitch(ShellyBaseEntity, SwitchEntity):
+    """Writable Gen2/Gen3 virtual boolean (``boolean:<id>``), over the relay.
+
+    Created **in addition** to the read-only binary sensor of the same
+    component, never instead of it. Replacing it would strand every
+    automation and dashboard card already pointing at that sensor, and would
+    do it silently — the entity would simply go unavailable. For a feature
+    whose first consumer is an irrigation controller, "silently stops
+    working" is the exact failure this is designed against. The visible
+    redundancy is the cheaper of the two.
+
+    The state is read from the poll, like every other entity here. The relay
+    only carries the command, and the command is confirmed by the next poll
+    rather than by an optimistic write: a zone that accepted the command and
+    did not move must look different from one that switched.
+    """
+
+    def __init__(
+        self,
+        coordinator: ShellyCloudCoordinator,
+        device_id: str,
+        component_key: str,
+    ) -> None:
+        """Initialise the writable virtual boolean."""
+        super().__init__(coordinator, device_id, 0)
+        self._component_key = component_key
+        # NOT the binary sensor's ``…_value`` id. Reusing that one would move
+        # an existing entity to another platform, which is a migration, and
+        # this is not the change to smuggle one into.
+        self._attr_unique_id = f"{device_id}_{component_key}_control"
+        self._generic_name = f"Boolean {component_key.split(':', 1)[1]}"
+
+    @property
+    def name(self) -> str:
+        """Resolved component name, or the generic fallback.
+
+        The same lazily fetched v2 config the read-only sensor reads, so on
+        an irrigation controller both entities carry the zone name the user
+        typed rather than one of them showing ``boolean:203``.
+        """
+        return self.virtual_component_name(self._component_key) or self._generic_name
+
+    @property
+    def available(self) -> bool:
+        """Available only while the channel that carries the command is up.
+
+        The base class asks whether the *device* is reachable through the
+        cloud, which is the right question for every entity that reads the
+        poll. This one also writes, over a second connection that can be
+        down on its own — and a switch that renders as operable while every
+        press is guaranteed to throw is the polite version of the failure
+        this feature exists to prevent.
+        """
+        return super().available and self.coordinator.cloud_control_connected
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the component's current value as the poll last saw it."""
+        component = self.device_status.get(self._component_key)
+        if not isinstance(component, dict):
+            return None
+        value = component.get("value")
+        return None if value is None else bool(value)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Set the virtual boolean to true."""
+        await self.coordinator.async_set_virtual_boolean(
+            self._device_id, self._component_key, True
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Set the virtual boolean to false."""
+        await self.coordinator.async_set_virtual_boolean(
+            self._device_id, self._component_key, False
+        )

--- a/custom_components/shelly_cloud_diy/translations/de.json
+++ b/custom_components/shelly_cloud_diy/translations/de.json
@@ -47,6 +47,18 @@
           "bulk_action": "\"Alle anhaken\" oder \"Alle abwählen\" überschreibt beim Speichern die manuelle Liste unten. Mit \"Manuelle Auswahl\" zählt die Liste.",
           "enabled_devices": "Nur angehakte Geräte werden als Home-Assistant-Entities angelegt."
         }
+      },
+      "reauth_cloud_control": {
+        "title": "Bei Shelly erneut anmelden (Cloud-Steuerung)",
+        "description": "Die Shelly Cloud hat die gespeicherte Anmeldung der Cloud-Steuerung abgelehnt. Melde dich mit deinem Shelly-Konto an, um die Steuerung virtueller Komponenten wiederherzustellen.\n\nDer Authorization cloud key ist ein anderes Credential und davon nicht betroffen — der Abruf lief die ganze Zeit weiter. Das Passwort wird einmal zur Anmeldung verwendet und nie gespeichert.",
+        "data": {
+          "email": "E-Mail des Shelly-Kontos",
+          "password": "Passwort des Shelly-Kontos"
+        },
+        "data_description": {
+          "email": "Die E-Mail-Adresse, mit der du dich in der Shelly-App anmeldest.",
+          "password": "Wird einmal zur Anmeldung verwendet und danach verworfen. Gespeichert wird nur das daraus entstehende Token."
+        }
       }
     },
     "error": {
@@ -54,7 +66,8 @@
       "invalid_auth": "Shelly Cloud hat den Authorization cloud key abgelehnt.",
       "invalid_gateway_url": "Die lokale Gateway-URL muss http(s) sein und darf nicht auf localhost zeigen.",
       "required": "Dieses Feld ist erforderlich.",
-      "unknown": "Unerwarteter Fehler — siehe Home-Assistant-Logs."
+      "unknown": "Unerwarteter Fehler — siehe Home-Assistant-Logs.",
+      "invalid_account": "Die Shelly Cloud hat diese E-Mail oder das Passwort abgelehnt."
     },
     "abort": {
       "already_configured": "Dieses Shelly-Konto ist bereits konfiguriert.",
@@ -73,7 +86,8 @@
           "relay_fault_detection": "Vor einem Relais warnen, das nicht mehr öffnet",
           "local_gateway_url": "Lokale Gateway-URL (optional, für historische EM-Daten)",
           "device_health_detection": "Vor Geräten in schlechtem Zustand warnen",
-          "device_health_firmware": "Ausstehendes Firmware-Update als Befund werten"
+          "device_health_firmware": "Ausstehendes Firmware-Update als Befund werten",
+          "cloud_control": "Virtuelle Komponenten über die Cloud steuern (nicht unterstützt)"
         },
         "data_description": {
           "poll_interval": "3–60 s. Kleinere Werte fühlen sich flotter an, verbrauchen aber mehr von Shellys 1-req/s-Budget.",
@@ -81,7 +95,8 @@
           "relay_fault_detection": "Standardmäßig an. Beobachtet jeden Schaltkanal, der seinen eigenen Ausgang misst, und warnt, wenn das Relais sich als offen meldet, während weiterhin eine echte Last durch es fließt — ein verschweißter Kontakt. Abschalten, wenn ein Shelly in einer Wechselschaltung sitzt, wo der andere Schalter Strom durch die Messung schicken kann, obwohl das Relais wirklich offen ist.",
           "local_gateway_url": "Nur nötig, wenn ein lokales Shelly-Gateway für historische Energiedaten genutzt wird.",
           "device_health_detection": "Standardmäßig an. Wertet aus, was jeder Abruf ohnehin liefert: WLAN-Signal (Warnung ab -70 dBm, Fehler ab -85 dBm), Komponententemperatur (70 °C / 85 °C), freier Speicher und freier Dateisystem-Platz (unter 20 % / 10 %), ein noch ausstehender Neustart sowie jede Komponente, die selbst einen Fehler meldet. Das kostet keine zusätzlichen Anfragen. Bluetooth-Geräte (BLU) werden nur nach dem Signal beurteilt, das ihr Gateway für sie meldet, Gen1-Geräte gar nicht. Gewertet wird nur die Eigenwärme einer Komponente, nie ein externer Fühler am Add-on.",
-          "device_health_firmware": "Standardmäßig aus. Ergänzt „Firmware-Update verfügbar“ als Befund. Auf einem typischen Konto hat die Mehrheit der Geräte eines offen — eingeschaltet leuchtet die Karte deshalb dauerhaft, und genau das sorgt dafür, dass die wichtigen Befunde untergehen."
+          "device_health_firmware": "Standardmäßig aus. Ergänzt „Firmware-Update verfügbar“ als Befund. Auf einem typischen Konto hat die Mehrheit der Geräte eines offen — eingeschaltet leuchtet die Karte deshalb dauerhaft, und genau das sorgt dafür, dass die wichtigen Befunde untergehen.",
+          "cloud_control": "Standardmäßig aus — und vor dem Einschalten lesenswert. Virtuelle Komponenten (die Zonen eines Bewässerungscomputers, der Schalter eines Skripts) lassen sich über die dokumentierte Shelly-Cloud-API lesen, aber nicht schreiben: jede dokumentierte Route antwortet „diese Route gibt es nicht“. Schalten geht nur über einen **undokumentierten** Kanal, den der Shelly-Support am 27.07.2026 ausdrücklich als nicht unterstützt bezeichnet hat und der jederzeit ohne Ankündigung geändert oder abgeschaltet werden kann.\n\nWas es kostet: die Anmeldung an deinem Shelly-Konto (wird im nächsten Schritt abgefragt; das Passwort wird einmal verwendet und nie gespeichert) und eine zweite Verbindung zur Shelly Cloud.\n\nWas es bringt: je virtuellem Boolean einen Schalter — aber **nur auf Geräten, die deinem Konto gehören**. Ein geteiltes Gerät weist Shelly selbst ab, dafür entsteht kein Schalter. Der Schalter entsteht **zusätzlich** zum bestehenden schreibgeschützten Sensor derselben Komponente, nie an dessen Stelle, damit nichts kaputtgeht, was du darauf schon aufgebaut hast.\n\nDas Abschalten der Option löscht die gespeicherte Anmeldung wieder."
         }
       },
       "devices": {
@@ -107,10 +122,25 @@
           "bulk_action": "\"Alle anhaken\" oder \"Alle abwählen\" überschreibt beim Speichern die manuelle Liste unten. Mit \"Manuelle Auswahl\" zählt die Liste.",
           "enabled_devices": "Nur angehakte Geräte werden als Home-Assistant-Entities angelegt."
         }
+      },
+      "cloud_control": {
+        "title": "Bei Shelly anmelden (Cloud-Steuerung)",
+        "description": "Die Cloud-Steuerung braucht die Anmeldung an deinem Shelly-Konto, weil der genutzte Kanal ein Konto-Token akzeptiert und nicht den Authorization cloud key.\n\nDas Passwort wird einmal zur Anmeldung verwendet und **nie gespeichert** — gespeichert wird nur das daraus entstehende Token, und das Abschalten der Option löscht es wieder. Ohne erfolgreiche Anmeldung wird nichts gespeichert.",
+        "data": {
+          "email": "E-Mail des Shelly-Kontos",
+          "password": "Passwort des Shelly-Kontos"
+        },
+        "data_description": {
+          "email": "Die E-Mail-Adresse, mit der du dich in der Shelly-App anmeldest.",
+          "password": "Wird einmal zur Anmeldung verwendet und danach verworfen. Gespeichert wird nur das daraus entstehende Token."
+        }
       }
     },
     "error": {
-      "invalid_gateway_url": "Die lokale Gateway-URL muss http(s) sein und darf nicht auf localhost zeigen."
+      "invalid_gateway_url": "Die lokale Gateway-URL muss http(s) sein und darf nicht auf localhost zeigen.",
+      "invalid_account": "Die Shelly Cloud hat diese E-Mail oder das Passwort abgelehnt.",
+      "cannot_connect": "Die Shelly Cloud war nicht erreichbar. Prüfe die Server-URI und deine Internetverbindung.",
+      "required": "Dieses Feld ist erforderlich."
     }
   },
   "services": {

--- a/custom_components/shelly_cloud_diy/translations/en.json
+++ b/custom_components/shelly_cloud_diy/translations/en.json
@@ -47,6 +47,18 @@
           "bulk_action": "\"Tick all\" or \"Untick all\" overrides the manual list below on save. Pick \"Manual selection\" to keep the list as-is.",
           "enabled_devices": "Only ticked devices produce Home Assistant entities."
         }
+      },
+      "reauth_cloud_control": {
+        "title": "Sign in to Shelly again for cloud control",
+        "description": "Shelly Cloud rejected the stored sign-in that the cloud control channel uses. Sign in with your Shelly account to restore control of your virtual components.\n\nYour Authorization cloud key is a different credential and is unaffected — polling has kept running the whole time. The password is used once to sign in and is never stored.",
+        "data": {
+          "email": "Shelly account email",
+          "password": "Shelly account password"
+        },
+        "data_description": {
+          "email": "The email address you use in the Shelly app.",
+          "password": "Used once to sign in and then discarded. Only the resulting token is stored."
+        }
       }
     },
     "error": {
@@ -54,7 +66,8 @@
       "invalid_auth": "Shelly Cloud rejected the Authorization cloud key.",
       "invalid_gateway_url": "Local gateway URL must be http(s) and must not point at localhost.",
       "required": "This field is required.",
-      "unknown": "Unexpected error — see Home Assistant logs."
+      "unknown": "Unexpected error — see Home Assistant logs.",
+      "invalid_account": "Shelly Cloud rejected that email or password."
     },
     "abort": {
       "already_configured": "This Shelly account is already configured.",
@@ -73,7 +86,8 @@
           "relay_fault_detection": "Warn about a relay that no longer opens",
           "local_gateway_url": "Local gateway URL (optional, for EM historical data)",
           "device_health_detection": "Warn about devices in poor health",
-          "device_health_firmware": "Count a pending firmware update as a finding"
+          "device_health_firmware": "Count a pending firmware update as a finding",
+          "cloud_control": "Control virtual components over the cloud (unsupported)"
         },
         "data_description": {
           "poll_interval": "3–60 s. Lower values feel snappier but consume more of Shelly's 1 req/s rate-limit budget.",
@@ -81,7 +95,8 @@
           "relay_fault_detection": "On by default. Watches every switching channel that meters its own output and warns when the relay reports itself as open while a real load is still flowing through it — a contact that has welded shut. Turn this off if a Shelly of yours sits in a two-way circuit, where the other switch can push current through the meter while the relay is genuinely open.",
           "local_gateway_url": "Only needed if you use a local Shelly gateway to back-fill historical energy data.",
           "device_health_detection": "On by default. Interprets data every poll already returns: Wi-Fi signal (warning at -70 dBm, error at -85 dBm), component temperature (70 °C / 85 °C), free memory and free storage (under 20 % / 10 %), a restart the device is still waiting for, and any component reporting its own error. It costs no extra requests. Bluetooth (BLU) devices are judged only on the signal their gateway reports for them, and Gen1 devices are not judged at all. Only a component's own temperature counts, never an external Add-on probe.",
-          "device_health_firmware": "Off by default. Adds \"a firmware update is available\" as a finding. On a typical account most devices have one pending, so switching this on tends to keep the card permanently lit — which is exactly what stops you noticing the findings that matter."
+          "device_health_firmware": "Off by default. Adds \"a firmware update is available\" as a finding. On a typical account most devices have one pending, so switching this on tends to keep the card permanently lit — which is exactly what stops you noticing the findings that matter.",
+          "cloud_control": "Off by default, and worth reading before switching on. Virtual components (an irrigation controller's zones, a script's switch) can be read over the documented Shelly Cloud API but not written — every documented route answers \"no such route\". Switching them is possible only over an **undocumented** channel, which Shelly support declared unsupported on 2026-07-27 and can change or withdraw without notice.\n\nWhat it costs: your Shelly account sign-in (asked for on the next step; the password is used once and never stored) and a second connection to Shelly Cloud.\n\nWhat it gives you: a switch for each virtual boolean, but **only on devices your account owns**. A shared device is refused by Shelly itself, and no switch appears for it. The switch is created **in addition** to the existing read-only sensor of the same component, never instead of it, so nothing you have already built on that sensor breaks.\n\nSwitching this off again deletes the stored sign-in."
         }
       },
       "devices": {
@@ -107,10 +122,25 @@
           "bulk_action": "\"Tick all\" or \"Untick all\" overrides the manual list below on save.",
           "enabled_devices": "Only ticked devices produce Home Assistant entities."
         }
+      },
+      "cloud_control": {
+        "title": "Sign in to Shelly for cloud control",
+        "description": "Cloud control needs your Shelly account sign-in, because the channel it uses accepts an account token rather than the Authorization cloud key.\n\nThe password is used once to sign in and is **never stored** — only the resulting token is, and switching the option off again deletes it. Nothing is saved unless this sign-in succeeds.",
+        "data": {
+          "email": "Shelly account email",
+          "password": "Shelly account password"
+        },
+        "data_description": {
+          "email": "The email address you use in the Shelly app.",
+          "password": "Used once to sign in and then discarded. Only the resulting token is stored."
+        }
       }
     },
     "error": {
-      "invalid_gateway_url": "Local gateway URL must be http(s) and must not point at localhost."
+      "invalid_gateway_url": "Local gateway URL must be http(s) and must not point at localhost.",
+      "invalid_account": "Shelly Cloud rejected that email or password.",
+      "cannot_connect": "Could not reach Shelly Cloud. Check the server URI and your internet connection.",
+      "required": "This field is required."
     }
   },
   "services": {

--- a/custom_components/shelly_cloud_diy/utils/__init__.py
+++ b/custom_components/shelly_cloud_diy/utils/__init__.py
@@ -4,10 +4,13 @@ from .csv_converter import (
     parse_shelly_csv_for_import,
 )
 from .http import fetch_csv_from_gateway, validate_gateway_url
+from .token_store import token_from_storage, token_to_storage
 
 __all__ = [
     "parse_shelly_csv",
     "parse_shelly_csv_for_import",
     "fetch_csv_from_gateway",
     "validate_gateway_url",
+    "token_from_storage",
+    "token_to_storage",
 ]

--- a/custom_components/shelly_cloud_diy/utils/token_store.py
+++ b/custom_components/shelly_cloud_diy/utils/token_store.py
@@ -1,0 +1,63 @@
+"""Turning an OAuth token into something ``entry.data`` can hold, and back.
+
+Deliberately its own module rather than a pair of helpers inside the config
+flow or the setup entry point, for the reason ``api/oauth.py`` states about
+itself: the module that *holds* a credential must not know where it is
+stored. This is the other half of that split — the layer that knows the
+storage shape and nothing about how a token is minted or refreshed. Both the
+config flow (which writes the first one) and the setup path (which reads it
+back and writes a rotated one) need the same shape, and one definition is how
+the two stay in agreement.
+
+Nothing here logs. A malformed record returns ``None`` and the caller asks
+the user to sign in again, because the alternative — reporting what was
+wrong with it — means describing a token in a log line.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from ..api.oauth import OAuthToken
+
+# Sub-keys of the stored record. They match the wire field names, which keeps
+# a diagnostics reader honest: this is a token, not an opaque blob.
+KEY_ACCESS = "access_token"  # noqa: S105 — a key name, not a secret
+KEY_REFRESH = "refresh_token"  # noqa: S105 — a key name, not a secret
+KEY_EXPIRES_AT = "expires_at"  # noqa: S105 — a key name, not a secret
+
+
+def token_to_storage(token: OAuthToken) -> dict[str, Any]:
+    """Return the JSON-serialisable record for one token."""
+    return {
+        KEY_ACCESS: token.access_token,
+        KEY_REFRESH: token.refresh_token,
+        KEY_EXPIRES_AT: token.expires_at,
+    }
+
+
+def token_from_storage(raw: Any) -> OAuthToken | None:
+    """Rebuild a token from ``entry.data``, or ``None`` if it is unusable.
+
+    "Unusable" is judged on the access token alone. A record without a
+    refresh token is still worth loading: it works until it expires, and the
+    manager then escalates to re-authentication, which is the honest outcome
+    and better than refusing a session the user could still have used.
+    """
+    if not isinstance(raw, dict):
+        return None
+    access = raw.get(KEY_ACCESS)
+    if not isinstance(access, str) or not access:
+        return None
+    refresh = raw.get(KEY_REFRESH)
+    expires_at = raw.get(KEY_EXPIRES_AT)
+    try:
+        expires_at = float(expires_at)
+    except (TypeError, ValueError):
+        # An unreadable expiry means "refresh at the first opportunity",
+        # never "valid forever".
+        expires_at = 0.0
+    return OAuthToken(
+        access_token=access,
+        expires_at=expires_at,
+        refresh_token=refresh if isinstance(refresh, str) and refresh else None,
+    )

--- a/docs/AUTH_KEY.de.md
+++ b/docs/AUTH_KEY.de.md
@@ -91,11 +91,17 @@ grep -rn "_LOGGER" custom_components/shelly_cloud_diy/ | grep -i "auth\|key\|tok
 ```
 
 **Nicht in die Diagnose-Datei.** Das Diagnose-Modul liest die gespeicherten
-Daten des Config-Eintrags gar nicht an; es exportiert nur den Geräte-Schnappschuss
-und die Fleet-Map, mit geschwärzten Namen, IPs, MACs und SSIDs. Die Datei ist
-rund 130 Zeilen lang, also kurz genug zum vollständigen Lesen:
-`custom_components/shelly_cloud_diy/diagnostics.py`. Das ist wichtig, weil
+*Daten* des Config-Eintrags gar nicht an — dort liegen die Zugangsdaten. Es
+berichtet die **Optionen** des Eintrags (Abrufintervall, welche Geräte du
+freigeschaltet hast, welche Prüfungen laufen), den Geräte-Schnappschuss und die
+Fleet-Map, mit geschwärzten Namen, IPs, MACs und SSIDs und mit Geräte-IDs, die
+auf einen nicht umkehrbaren Fingerabdruck reduziert sind. Das ist wichtig, weil
 Diagnose-Dateien genau das sind, was Leute an öffentliche Fehlerberichte hängen.
+
+```bash
+# Erwartet: nur Kommentare — keine Zeile, die die Daten wirklich liest.
+grep -n "entry.data" custom_components/shelly_cloud_diy/diagnostics.py
+```
 
 **Nicht an mich und an keinen Dritten.** Es gibt keine Telemetrie, keine
 Analytics, kein Crash-Reporting, kein „Nach-Hause-Telefonieren". Die Integration
@@ -130,6 +136,71 @@ Folgen musst du selbst abwägen:
 - wenn du ein Backup zur Fehlersuche weitergibst — an wen auch immer, mich
   eingeschlossen — geh davon aus, dass der Schlüssel mitgegangen ist, und wechsle
   ihn danach
+
+---
+
+## Das zweite Credential — nur wenn du die Cloud-Steuerung einschaltest
+
+Alles bisher Gesagte betrifft den Auth-Key, das einzige Credential einer
+Standard-Installation. Es gibt eine optionale Funktion, die ein zweites braucht,
+und die ist **aus, solange du sie nicht einschaltest**: die Cloud-Steuerung, die
+virtuelle Komponenten schaltet (etwa die Zonen eines Bewässerungscomputers), für
+die die dokumentierte API überhaupt keine Route hat. Was sie tut und warum der
+genutzte Kanal undokumentiert ist, steht in der README.
+
+Das Einschalten fragt nach **E-Mail und Passwort deines Shelly-Kontos**, weil
+der Kanal ein Konto-Token akzeptiert und nicht den Auth-Key. Also, in denselben
+Worten wie oben:
+
+**Das Passwort wird nie gespeichert, und nichts, was I/O macht, sieht es
+überhaupt.** Es wird direkt an der Eingabegrenze in den Digest verwandelt, den
+Shellys Login erwartet, und der Klartext endet dort. Das ist eine strukturelle
+Eigenschaft, kein Versprechen — eine einzige Funktion nimmt den Klartext, alle
+anderen nehmen den Digest:
+
+```bash
+# Sieben Treffer, davon nur zwei Code: die Funktion selbst in api/oauth.py und
+# die eine Aufrufstelle in config_flow.py. Die übrigen fünf sind Kommentare
+# und Docstrings, die dasselbe sagen wie dieser Abschnitt.
+grep -rn "sha1_password" custom_components/shelly_cloud_diy/
+```
+
+**Gespeichert wird das Token**, das die Anmeldung zurückgibt — in derselben
+Datei `core.config_entries` wie der Auth-Key, mit demselben Klartext-Vorbehalt.
+Das Abschalten der Option **löscht es**, das Entfernen der Integration ebenso.
+Das ist der Teil, den ich zusagen kann, weil er meiner ist. Ob ein Wechsel des
+Shelly-Konto-Passworts auch ein bereits ausgestelltes Token ungültig macht, ist
+Shellys Seite und habe ich nicht gemessen — verlass dich also nicht darauf. Der
+verlässliche Weg, es hier loszuwerden, ist das Abschalten der Option.
+
+**Wohin es geht:** drei Form-POSTs, alle an der Aufrufstelle in `api/oauth.py`
+mit `# CREDENTIAL:` markiert — der Login (an Shellys festen Login-Host), der
+Code-Tausch und der Refresh (beide an den Host deines eigenen Kontos, den die
+Login-Antwort selbst benennt). Dazu eine WebSocket-Verbindung an den Host deines
+Kontos, in `api/cloud_ws.py`.
+
+**Nicht ins Log und nicht in ein repr.** Die Token-Klassen überschreiben
+`__repr__`, damit ein Token nicht durch einen f-String oder einen Traceback
+ausgegeben werden kann; eingehende Frames werden vor jeder Debug-Logzeile
+geschwärzt; und kein `aiohttp`-Fehlerobjekt landet je in einer Meldung — dessen
+Text enthält die vollständige Anfrage-URL, und die trägt auf diesem Kanal das
+Token.
+
+**Nicht in die Diagnose.** Die Diagnose-Datei berichtet, ob die Cloud-Steuerung
+an ist, ob sie verbunden ist und ob Shelly für ein Gerät Befehle durchreicht.
+Kein Token, keine E-Mail, keine rohe Geräte-ID.
+
+**Der Schönheitsfehler, genauso offen wie der unten:** das Access-Token reitet
+als Query-Parameter in der WebSocket-Verbindungs-URL mit. So wird Shellys Relay
+adressiert, eine Header-Variante gibt es nicht. Die Abmilderungen sind dieselben
+wie beim Rollladen-Befehl unten — der Empfänger ist Shelly, von dem das Token
+stammt, und die Verbindung ist TLS-verschlüsselt — und der Rest ebenfalls: URLs
+werden großzügiger geloggt als Bodies, auf deren Servern, was ich nicht messen
+kann.
+
+Wenn du die Cloud-Steuerung nie einschaltest, existiert nichts davon in deiner
+Installation: es wird keine Anmeldung abgefragt, kein Token gespeichert und
+keine Verbindung geöffnet.
 
 ---
 
@@ -182,9 +253,12 @@ grep -rn "_auth_key" custom_components/shelly_cloud_diy/
 grep -rnE "session\.(get|post|request)|ws_connect" custom_components/shelly_cloud_diy/
 
 # 3. Jede fest eingetragene URL. Erwartet: Doku-Links aus Fehlermeldungen, die
-#    http/https-Schema-Behandlung in _normalise_base_url und das CSV-Gateway-
-#    Beispiel in einem Docstring. NICHT finden solltest du einen fest
-#    verdrahteten API-Host — die Serveradresse kommt immer aus deiner Konfiguration.
+#    http/https-Schema-Behandlung in _normalise_base_url, das CSV-Gateway-
+#    Beispiel in einem Docstring — und genau EINEN fest verdrahteten API-Host,
+#    api.shelly.cloud/oauth/login in api/oauth.py: Shellys fester Login-Endpunkt,
+#    der nur aufgerufen wird, wenn du die Cloud-Steuerung einschaltest. Nichts,
+#    was der Auth-Key anfasst, hat einen festen Host — für den Abruf kommt die
+#    Serveradresse immer aus deiner Konfiguration.
 grep -rnE "https?://" custom_components/shelly_cloud_diy/
 
 # 4. Beleg, dass der Schlüssel nicht in deinen Logs steht. Im HA-Konfig-

--- a/docs/AUTH_KEY.md
+++ b/docs/AUTH_KEY.md
@@ -87,11 +87,16 @@ grep -rn "_LOGGER" custom_components/shelly_cloud_diy/ | grep -i "auth\|key\|tok
 ```
 
 **Not into diagnostics downloads.** The diagnostics module never reads the
-config entry's stored data; it only exports the device snapshot and the fleet
-map, with names, IPs, MACs and SSIDs redacted. The file is about 130 lines —
-short enough to read in full: `custom_components/shelly_cloud_diy/diagnostics.py`.
-This matters because diagnostics downloads are the thing people attach to public
-bug reports.
+config entry's stored *data* — the credentials live there. It reports the
+entry's **options** (poll interval, which devices you enabled, which detectors
+are on), the device snapshot and the fleet map, with names, IPs, MACs and SSIDs
+redacted and device ids reduced to a non-reversible fingerprint. This matters
+because diagnostics downloads are the thing people attach to public bug reports.
+
+```bash
+# Expect comments only — no line that actually reads the entry's data.
+grep -n "entry.data" custom_components/shelly_cloud_diy/diagnostics.py
+```
 
 **Not to me, and not to any third party.** There is no telemetry, no analytics,
 no crash reporting, no "phone home". The integration declares exactly two
@@ -123,6 +128,67 @@ practical consequences are yours to weigh:
   and anything you upload to cloud storage
 - if you share a backup for debugging — with anyone, including me — assume the
   key went with it, and rotate it afterwards
+
+---
+
+## The second credential — only if you switch cloud control on
+
+Everything above is about the auth key, which is the only credential a default
+install has. There is one optional feature that needs a second one, and it is
+**off unless you turn it on**: cloud control, which switches virtual components
+(an irrigation controller's zones, for instance) that the documented API has no
+route for at all. See the README for what it does and why the channel it uses is
+undocumented.
+
+Switching it on asks for your **Shelly account email and password**, because the
+channel accepts an account token and not the auth key. So, in the same terms as
+above:
+
+**The password is never stored, and nothing that does I/O ever sees it.** It is
+turned into the digest Shelly's login expects at the flow boundary and the
+plaintext is discarded there. That is a structural property, not a promise —
+one function takes the plaintext, every other function takes the digest:
+
+```bash
+# Seven hits, and only two of them are code: the function itself in
+# api/oauth.py, and the single call site in config_flow.py. The other five
+# are comments and docstrings saying the same thing this section says.
+grep -rn "sha1_password" custom_components/shelly_cloud_diy/
+```
+
+**What is stored is the token** that the sign-in returns, in the same
+`core.config_entries` file as the auth key, with the same plain-text caveat.
+Switching the option off again **deletes it**; so does removing the integration.
+That is the part I can state, because it is mine. Whether changing your Shelly
+account password also invalidates an already-issued token is Shelly's side and I
+have not measured it — so do not rely on it. Switching the option off is the
+reliable way to be rid of it here.
+
+**Where it goes:** three form POSTs, all marked `# CREDENTIAL:` at the call site
+in `api/oauth.py` — the login (to Shelly's fixed login host), the code exchange
+and the refresh (both to your account's own host, named by the login response
+itself). And one WebSocket connection, to your account's host, in
+`api/cloud_ws.py`.
+
+**Not into the logs, not into a repr.** The token classes override `__repr__`
+so a token cannot be printed by an f-string or a traceback frame, inbound relay
+frames are redacted before any debug log line, and no `aiohttp` error object is
+ever put into a message — its text embeds the full request URL, which on this
+channel carries the token.
+
+**Not into diagnostics.** The diagnostics file reports whether cloud control is
+on, whether it is connected, and per device whether Shelly will route commands
+to it. No token, no email, no raw device id.
+
+**The wart, stated as plainly as the one below:** the access token rides in the
+WebSocket connect URL as a query parameter. That is how Shelly's relay is
+addressed; there is no header variant. The mitigations are the same as for the
+cover command below — the recipient is Shelly, who issued it, and the connection
+is TLS — and so is the residual: URLs get logged more liberally than bodies, on
+their servers, which I cannot measure.
+
+If you never switch cloud control on, none of this exists in your installation:
+no sign-in is asked for, no token is stored, and no connection is opened.
 
 ---
 
@@ -174,9 +240,12 @@ grep -rn "_auth_key" custom_components/shelly_cloud_diy/
 grep -rnE "session\.(get|post|request)|ws_connect" custom_components/shelly_cloud_diy/
 
 # 3. Every hard-coded URL. Expect: documentation links shown in error messages,
-#    the http/https scheme handling in _normalise_base_url, and the CSV gateway
-#    example in a docstring. What you should NOT find is a hard-coded API host —
-#    the server address always comes from your own configuration.
+#    the http/https scheme handling in _normalise_base_url, the CSV gateway
+#    example in a docstring — and exactly ONE hard-coded API host,
+#    api.shelly.cloud/oauth/login in api/oauth.py, which is Shelly's fixed
+#    login endpoint and is only ever called if you switch cloud control on.
+#    Nothing the auth key touches has a hard-coded host: for the poll, the
+#    server address always comes from your own configuration.
 grep -rnE "https?://" custom_components/shelly_cloud_diy/
 
 # 4. Prove the key is not in your own logs. Run this in your HA config

--- a/tests/test_cloud_control.py
+++ b/tests/test_cloud_control.py
@@ -1,0 +1,1053 @@
+"""Unit tests for wiring the cloud control channel into Home Assistant.
+
+The transport has its own tests (``test_oauth.py``, ``test_cloud_ws.py``).
+These are about the four promises the *wiring* makes, because each one is a
+promise a user can only check by trusting it:
+
+1. **Off means off.** With the option unset — which is every existing install
+   — nothing is constructed: no sign-in, no second connection, no probe, no
+   entity. The existing suite is the other half of that proof; it passes
+   unmodified.
+2. **A shared device offers no control entity**, and neither does one the
+   relay could not classify. "We could not tell" is re-asked, never promoted
+   to a verdict.
+3. **A failed command is loud.** Every failure raises; a success asks the
+   poll what happened rather than asserting it.
+4. **No credential reaches a log line or a diagnostics dump.**
+
+Everything runs against a fake relay and hand-built coordinators, the way the
+rest of this suite does: no network, no running Home Assistant, and every
+credential an obvious fake.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import json
+import logging
+import textwrap
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+import custom_components.shelly_cloud_diy as integration
+from custom_components.shelly_cloud_diy import config_flow, diagnostics
+from custom_components.shelly_cloud_diy import switch as switch_platform
+from custom_components.shelly_cloud_diy.api.cloud_ws import (
+    DeviceOwnership,
+    ShellyCloudWsAuthError,
+    ShellyCloudWsCommandError,
+    ShellyCloudWsTimeoutError,
+)
+from custom_components.shelly_cloud_diy.api.oauth import OAuthToken
+from custom_components.shelly_cloud_diy import coordinator as coordinator_module
+from custom_components.shelly_cloud_diy.const import (
+    CLOUD_CONTROL_DEFAULT,
+    CONF_CLOUD_CONTROL,
+    CONF_OAUTH_TOKEN,
+    SIGNAL_NEW_DEVICE,
+)
+from custom_components.shelly_cloud_diy.coordinator import ShellyCloudCoordinator
+from custom_components.shelly_cloud_diy.utils.token_store import (
+    token_from_storage,
+    token_to_storage,
+)
+
+# Obvious fakes. Nothing here is, or resembles, a real credential.
+FAKE_ACCESS = "FAKE-ACCESS-TOKEN-never-in-a-log-1234"  # noqa: S105
+FAKE_REFRESH = "FAKE-REFRESH-TOKEN-never-in-a-log-987"  # noqa: S105
+FAKE_PASSWORD = "correct-horse-battery-staple-FAKE"  # noqa: S105
+FAKE_EMAIL = "nobody@example.invalid"
+
+OWNED_ID = "5432044e0001"
+SHARED_ID = "5432044e0002"
+MURKY_ID = "5432044e0003"
+PLAIN_ID = "5432044e0004"
+
+SERVER_URI = "https://shelly-42-eu.shelly.cloud"
+
+# A Gen2 status carrying one virtual boolean (an irrigation zone) …
+ZONE_STATUS: dict[str, Any] = {
+    "sys": {"mac": "AABBCC"},
+    "switch:0": {"output": False},
+    "boolean:200": {"value": False},
+    "boolean:201": {"value": True},
+}
+# … and one carrying none, which can never gain a control entity.
+PLAIN_STATUS: dict[str, Any] = {"sys": {"mac": "DDEEFF"}, "switch:0": {"output": True}}
+
+
+class _FakeRelay:
+    """Stands in for ``ShellyCloudWebSocket``: records, answers, never talks."""
+
+    host = "shelly-42-eu.shelly.cloud"
+
+    def __init__(
+        self,
+        verdicts: dict[str, Any] | None = None,
+        *,
+        command_error: Exception | None = None,
+        connected: bool = True,
+    ) -> None:
+        self._verdicts = verdicts or {}
+        self._command_error = command_error
+        self._connected = connected
+        self.connect_calls = 0
+        self.disconnect_calls = 0
+        self.probes: list[str] = []
+        self.sent: list[tuple[str, str, dict]] = []
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self._connected = False
+
+    async def async_classify_ownership(self, device_id: str) -> DeviceOwnership:
+        self.probes.append(device_id)
+        answer = self._verdicts.get(device_id, DeviceOwnership.UNKNOWN)
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+    async def send_jrpc_request(
+        self, device_id: str, method: str, params: dict | None = None, **_: Any
+    ) -> dict:
+        self.sent.append((device_id, method, params or {}))
+        if self._command_error is not None:
+            raise self._command_error
+        return {}
+
+
+def _coordinator(
+    devices: dict[str, dict[str, Any]] | None = None,
+    *,
+    options: dict[str, Any] | None = None,
+    ws: _FakeRelay | None = None,
+    real_tasks: bool = False,
+) -> ShellyCloudCoordinator:
+    """Build a coordinator by hand, as the rest of this suite does.
+
+    Constructing the real one drags in Home Assistant's frame-reporting
+    machinery; ``test_coordinator_init.py`` is the guard that ``__init__``
+    really assigns what the poll path reads.
+    """
+    tasks: list[Any] = []
+
+    def _create_task(hass: Any, coro: Any, name: str) -> Any:
+        """Stand in for ``ConfigEntry.async_create_background_task``.
+
+        The re-probe loop is an ENTRY background task, so Home Assistant
+        cancels it with the entry. By default the fake only records the name
+        and closes the coroutine; ``real_tasks`` runs it for the tests that
+        are about the loop itself.
+        """
+        tasks.append(name)
+        if real_tasks:
+            return asyncio.get_running_loop().create_task(coro)
+        coro.close()
+        return SimpleNamespace(done=lambda: True, cancel=lambda: None)
+
+    coordinator = object.__new__(ShellyCloudCoordinator)
+    coordinator._entry = SimpleNamespace(
+        entry_id="e1",
+        options=dict(options or {}),
+        data={},
+        async_create_background_task=_create_task,
+    )
+    coordinator.devices = devices if devices is not None else {}
+    coordinator.device_names = {}
+    coordinator.virtual_configs = {}
+    coordinator.device_ownership = {}
+    coordinator._ownership_unresolved = set()
+    coordinator._ownership_task = None
+    coordinator._cloud_ws = ws
+    coordinator.last_update_success = True
+    coordinator.data = coordinator.devices
+
+    coordinator.hass = SimpleNamespace(data={"shelly_cloud_diy": {"e1": coordinator}})
+    coordinator.background_tasks = tasks
+
+    refreshes: list[int] = []
+    coordinator.refreshes = refreshes
+
+    async def _request_refresh() -> None:
+        refreshes.append(1)
+
+    coordinator.async_request_refresh = _request_refresh
+    return coordinator
+
+
+def _devices(*ids: str, status: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        device_id: {"status": dict(status or ZONE_STATUS), "online": True}
+        for device_id in ids
+    }
+
+
+class _Entry:
+    """Stands in for a ConfigEntry that holds both credentials."""
+
+    def __init__(self, options: dict[str, Any]) -> None:
+        self.entry_id = "e1"
+        self.data = {
+            "auth_key": "NOTAREALKEY-shouldneverappear",
+            "server_uri": SERVER_URI,
+            CONF_OAUTH_TOKEN: {
+                "access_token": FAKE_ACCESS,
+                "refresh_token": FAKE_REFRESH,
+                "expires_at": 1.0,
+            },
+        }
+        self.options = options
+
+
+# ── 1. Off means off ──────────────────────────────────────────────────
+
+
+def test_cloud_control_is_off_unless_the_user_asks_for_it() -> None:
+    assert _coordinator().cloud_control is False
+    assert _coordinator(options={CONF_CLOUD_CONTROL: True}).cloud_control is True
+
+
+def test_nothing_is_controllable_without_a_transport() -> None:
+    """Even a stored verdict is inert while no relay is connected."""
+    coordinator = _coordinator(_devices(OWNED_ID))
+    coordinator.device_ownership[OWNED_ID] = DeviceOwnership.OWNED
+    assert coordinator.is_cloud_controllable(OWNED_ID) is False
+
+
+def test_setup_reaches_cloud_control_only_from_inside_the_option_check() -> None:
+    """A static guard, for a failure a behavioural test cannot see.
+
+    The promise "with the option off, nothing happens" is positional: it holds
+    because one call sits inside one ``if``. A rebase that lifts the call out
+    of the block would still import, still pass every other test, and would
+    quietly sign every existing install in to Shelly Cloud.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(integration.async_setup_entry)))
+
+    def _calls(node: ast.AST) -> list[ast.Call]:
+        return [
+            n
+            for n in ast.walk(node)
+            if isinstance(n, ast.Call)
+            and getattr(n.func, "id", "") == "_async_setup_cloud_control"
+        ]
+
+    assert len(_calls(tree)) == 1, "exactly one entry point into cloud control"
+    guarded = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and "cloud_control" in ast.dump(node.test)
+        and _calls(node)
+    ]
+    assert guarded, "the call must sit behind the cloud-control check"
+    # Polarity, not just position: a negated test would still be a test.
+    for node in guarded:
+        assert not isinstance(node.test, ast.UnaryOp), "the guard must not be negated"
+        assert not [n for n in ast.walk(node.test) if isinstance(n, ast.Not)]
+    # And the option it reads defaults to off.
+    assert CLOUD_CONTROL_DEFAULT is False
+
+
+def test_a_coordinator_without_cloud_control_builds_no_control_switch() -> None:
+    """The platform's half of the contract, exercised through the real setup."""
+    coordinator = _coordinator(_devices(OWNED_ID))
+    added = _run_switch_setup(coordinator)
+
+    assert [e.unique_id for e in added] == [f"{OWNED_ID}_switch_0"]
+
+
+def test_a_bare_stub_coordinator_is_treated_as_switched_off() -> None:
+    """Anything that is not a coordinator with the feature answers "none"."""
+    assert switch_platform._controllable_boolean_keys(SimpleNamespace(), OWNED_ID) == []
+
+
+# ── 2. Ownership: probe once, cache, never harden a non-answer ────────
+
+
+def _enable(coordinator: ShellyCloudCoordinator, ws: _FakeRelay) -> None:
+    asyncio.run(coordinator.async_enable_cloud_control(ws))
+
+
+def test_an_owned_device_gets_a_switch_beside_its_read_only_sensor() -> None:
+    coordinator = _coordinator(
+        _devices(OWNED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, _FakeRelay({OWNED_ID: DeviceOwnership.OWNED}))
+
+    added = _run_switch_setup(coordinator)
+    unique_ids = {e.unique_id for e in added}
+
+    assert f"{OWNED_ID}_boolean:200_control" in unique_ids
+    assert f"{OWNED_ID}_boolean:201_control" in unique_ids
+    # The relay switch is untouched, and so is the binary sensor's unique id:
+    # the control entity is additive, never a rename of an existing one.
+    assert f"{OWNED_ID}_switch_0" in unique_ids
+    assert f"{OWNED_ID}_boolean:200_value" not in unique_ids
+
+
+def test_a_device_the_relay_refuses_gets_no_control_switch() -> None:
+    coordinator = _coordinator(
+        _devices(SHARED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, _FakeRelay({SHARED_ID: DeviceOwnership.NOT_ROUTABLE}))
+
+    assert coordinator.device_ownership[SHARED_ID] is DeviceOwnership.NOT_ROUTABLE
+    assert [e.unique_id for e in _run_switch_setup(coordinator)] == [
+        f"{SHARED_ID}_switch_0"
+    ]
+
+
+def test_an_unclassified_device_gets_no_switch_and_no_verdict() -> None:
+    coordinator = _coordinator(
+        _devices(MURKY_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, _FakeRelay({MURKY_ID: DeviceOwnership.UNKNOWN}))
+
+    assert MURKY_ID not in coordinator.device_ownership, "UNKNOWN is not a verdict"
+    assert MURKY_ID in coordinator._ownership_unresolved
+    assert coordinator.is_cloud_controllable(MURKY_ID) is False
+    assert [e.unique_id for e in _run_switch_setup(coordinator)] == [
+        f"{MURKY_ID}_switch_0"
+    ]
+
+
+def test_a_definite_verdict_is_never_probed_twice() -> None:
+    coordinator = _coordinator(
+        _devices(OWNED_ID, SHARED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    relay = _FakeRelay(
+        {OWNED_ID: DeviceOwnership.OWNED, SHARED_ID: DeviceOwnership.NOT_ROUTABLE}
+    )
+    _enable(coordinator, relay)
+    asyncio.run(coordinator._async_probe_ownership([OWNED_ID, SHARED_ID]))
+
+    assert sorted(relay.probes) == [OWNED_ID, SHARED_ID]
+
+
+def test_an_unclassified_device_is_asked_again_and_can_become_owned() -> None:
+    """The point of not storing UNKNOWN: the next answer is allowed to differ."""
+    coordinator = _coordinator(
+        _devices(MURKY_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, _FakeRelay({MURKY_ID: DeviceOwnership.UNKNOWN}))
+
+    coordinator._cloud_ws = _FakeRelay({MURKY_ID: DeviceOwnership.OWNED})
+    newly_owned = asyncio.run(coordinator._async_probe_ownership([MURKY_ID]))
+
+    assert newly_owned == {MURKY_ID}
+    assert coordinator.device_ownership[MURKY_ID] is DeviceOwnership.OWNED
+    assert coordinator._ownership_unresolved == set()
+
+
+def test_only_gen2_devices_carrying_a_virtual_boolean_are_probed() -> None:
+    """One relay round-trip is cheap; sixty at every startup are not.
+
+    A device without a virtual boolean can never gain a control entity, so a
+    probe would buy a diagnostics line and nothing else.
+    """
+    devices = {
+        OWNED_ID: {"status": dict(ZONE_STATUS)},
+        PLAIN_ID: {"status": dict(PLAIN_STATUS)},
+        "blegateway01": {
+            "status": {"_dev_info": {"gen": "GBLE"}, "temperature:0": {"tC": 20}}
+        },
+        "gen1device01": {"status": {"relays": [{"ison": True}]}},
+    }
+    coordinator = _coordinator(devices, options={CONF_CLOUD_CONTROL: True})
+
+    assert coordinator._control_candidates() == [OWNED_ID]
+
+
+def test_a_device_the_user_unticked_is_not_probed() -> None:
+    coordinator = _coordinator(
+        _devices(OWNED_ID, SHARED_ID),
+        options={CONF_CLOUD_CONTROL: True, "enabled_devices": [OWNED_ID]},
+    )
+    assert coordinator._control_candidates() == [OWNED_ID]
+
+
+def test_a_rejected_session_leaves_the_remaining_devices_unclassified() -> None:
+    """The session died, which says nothing about any device."""
+    coordinator = _coordinator(
+        _devices(OWNED_ID, SHARED_ID, MURKY_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    coordinator._cloud_ws = _FakeRelay(
+        {
+            OWNED_ID: DeviceOwnership.OWNED,
+            SHARED_ID: ShellyCloudWsAuthError("session rejected"),
+        }
+    )
+    asyncio.run(
+        coordinator._async_probe_ownership([OWNED_ID, SHARED_ID, MURKY_ID])
+    )
+
+    # What was answered before the session died stands; the rest is left
+    # unresolved rather than judged on a failure that is not theirs.
+    assert coordinator.device_ownership == {OWNED_ID: DeviceOwnership.OWNED}
+    assert coordinator._ownership_unresolved == {SHARED_ID, MURKY_ID}
+
+
+def test_the_classification_loop_runs_for_the_session() -> None:
+    """It does not stop at "everything classified for now".
+
+    The account is not a closed set: the cloud drops devices from a poll on
+    its own, and accounts gain devices. A loop that exited would leave those
+    with no verdict, no switch, and nothing in diagnostics explaining it —
+    until someone reloaded the entry.
+    """
+    resolved = _coordinator(_devices(OWNED_ID), options={CONF_CLOUD_CONTROL: True})
+    _enable(resolved, _FakeRelay({OWNED_ID: DeviceOwnership.OWNED}))
+    assert len(resolved.background_tasks) == 1
+
+    murky = _coordinator(_devices(MURKY_ID), options={CONF_CLOUD_CONTROL: True})
+    _enable(murky, _FakeRelay({MURKY_ID: DeviceOwnership.UNKNOWN}))
+    assert len(murky.background_tasks) == 1
+
+
+def test_the_loop_reclassifies_and_tells_the_platforms(monkeypatch) -> None:
+    """The loop itself, run for real rather than asserted about."""
+    monkeypatch.setattr(coordinator_module, "OWNERSHIP_REPROBE_INTERVAL_S", 0.01)
+    dispatched: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        coordinator_module,
+        "async_dispatcher_send",
+        lambda hass, signal, device_id: dispatched.append((signal, device_id)),
+    )
+
+    async def _scenario() -> ShellyCloudCoordinator:
+        coordinator = _coordinator(
+            _devices(MURKY_ID), options={CONF_CLOUD_CONTROL: True}, real_tasks=True
+        )
+        await coordinator.async_enable_cloud_control(
+            _FakeRelay({MURKY_ID: DeviceOwnership.UNKNOWN})
+        )
+        assert coordinator.device_ownership == {}, "no verdict was formed"
+
+        # The relay is back and now answers definitely.
+        coordinator._cloud_ws = _FakeRelay({MURKY_ID: DeviceOwnership.OWNED})
+        for _ in range(200):
+            await asyncio.sleep(0.01)
+            if coordinator.device_ownership:
+                break
+        await coordinator.async_disable_cloud_control()
+        return coordinator
+
+    coordinator = asyncio.run(_scenario())
+
+    assert dispatched == [(SIGNAL_NEW_DEVICE, MURKY_ID)], (
+        "the platform has to be told, or the switch is only built on a reload"
+    )
+    assert coordinator._ownership_task is None, "teardown cancels the loop"
+
+
+def test_a_device_that_appears_after_setup_is_classified_too(monkeypatch) -> None:
+    """The first snapshot is not a closed set — the cloud omits devices."""
+    monkeypatch.setattr(coordinator_module, "OWNERSHIP_REPROBE_INTERVAL_S", 0.01)
+    dispatched: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        coordinator_module,
+        "async_dispatcher_send",
+        lambda hass, signal, device_id: dispatched.append((signal, device_id)),
+    )
+
+    async def _scenario() -> ShellyCloudCoordinator:
+        # Nothing to probe at setup: the device is not in the snapshot yet.
+        coordinator = _coordinator(
+            {}, options={CONF_CLOUD_CONTROL: True}, real_tasks=True
+        )
+        relay = _FakeRelay({OWNED_ID: DeviceOwnership.OWNED})
+        await coordinator.async_enable_cloud_control(relay)
+        assert relay.probes == []
+
+        coordinator.devices.update(_devices(OWNED_ID))
+        for _ in range(200):
+            await asyncio.sleep(0.01)
+            if coordinator.device_ownership:
+                break
+        await coordinator.async_disable_cloud_control()
+        return coordinator
+
+    coordinator = asyncio.run(_scenario())
+
+    assert dispatched == [(SIGNAL_NEW_DEVICE, OWNED_ID)]
+
+
+# ── 3. Commands: never optimistic, never quiet ────────────────────────
+
+
+def test_a_successful_command_asks_the_poll_for_the_truth() -> None:
+    relay = _FakeRelay({OWNED_ID: DeviceOwnership.OWNED})
+    coordinator = _coordinator(
+        _devices(OWNED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, relay)
+
+    asyncio.run(coordinator.async_set_virtual_boolean(OWNED_ID, "boolean:200", True))
+
+    assert relay.sent == [
+        (OWNED_ID, "Boolean.Set", {"id": 200, "value": True})
+    ]
+    assert coordinator.refreshes == [1], "the state comes from the poll, not from us"
+
+
+def test_a_refused_command_raises() -> None:
+    relay = _FakeRelay(
+        {OWNED_ID: DeviceOwnership.OWNED},
+        command_error=ShellyCloudWsCommandError("refused", code="WRONG_ID"),
+    )
+    coordinator = _coordinator(
+        _devices(OWNED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, relay)
+
+    with pytest.raises(ShellyCloudWsCommandError):
+        asyncio.run(
+            coordinator.async_set_virtual_boolean(OWNED_ID, "boolean:200", True)
+        )
+    assert coordinator.refreshes == [], "a failed command confirms nothing"
+
+
+def test_an_unanswered_command_raises_rather_than_reporting_success() -> None:
+    relay = _FakeRelay(
+        {OWNED_ID: DeviceOwnership.OWNED},
+        command_error=ShellyCloudWsTimeoutError("no answer"),
+    )
+    coordinator = _coordinator(
+        _devices(OWNED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, relay)
+
+    with pytest.raises(ShellyCloudWsTimeoutError):
+        asyncio.run(
+            coordinator.async_set_virtual_boolean(OWNED_ID, "boolean:200", False)
+        )
+
+
+def test_a_command_without_a_connection_raises() -> None:
+    coordinator = _coordinator(_devices(OWNED_ID))
+    with pytest.raises(HomeAssistantError):
+        asyncio.run(
+            coordinator.async_set_virtual_boolean(OWNED_ID, "boolean:200", True)
+        )
+
+
+def test_a_command_to_a_device_the_relay_will_not_route_to_raises() -> None:
+    coordinator = _coordinator(
+        _devices(SHARED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, _FakeRelay({SHARED_ID: DeviceOwnership.NOT_ROUTABLE}))
+
+    with pytest.raises(HomeAssistantError):
+        asyncio.run(
+            coordinator.async_set_virtual_boolean(SHARED_ID, "boolean:200", True)
+        )
+
+
+def test_the_switch_entity_drives_the_coordinator_and_reads_the_poll() -> None:
+    relay = _FakeRelay({OWNED_ID: DeviceOwnership.OWNED})
+    coordinator = _coordinator(
+        _devices(OWNED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, relay)
+
+    entity = next(
+        e
+        for e in _run_switch_setup(coordinator)
+        if e.unique_id == f"{OWNED_ID}_boolean:200_control"
+    )
+    assert entity.is_on is False
+
+    asyncio.run(entity.async_turn_on())
+    assert relay.sent == [(OWNED_ID, "Boolean.Set", {"id": 200, "value": True})]
+    # Still off: nothing was written optimistically, the poll has not run yet.
+    assert entity.is_on is False
+
+
+def test_the_control_switch_goes_unavailable_when_the_channel_does() -> None:
+    """A switch that renders as operable while every press throws is a lie."""
+    relay = _FakeRelay({OWNED_ID: DeviceOwnership.OWNED})
+    coordinator = _coordinator(
+        _devices(OWNED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, relay)
+
+    added = _run_switch_setup(coordinator)
+    control = next(e for e in added if e.unique_id.endswith("_control"))
+    relay_switch = next(e for e in added if e.unique_id.endswith("_switch_0"))
+    assert control.available is True
+
+    relay._connected = False
+    assert control.available is False
+    # The entity that runs over the documented HTTP path is unaffected.
+    assert relay_switch.available is True
+
+
+def test_the_switch_borrows_the_name_the_read_only_sensor_uses() -> None:
+    coordinator = _coordinator(
+        _devices(OWNED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    coordinator.virtual_configs = {
+        OWNED_ID: {
+            "boolean:200": {"role": "zone0"},
+            "service:0": {"zones": [{"name": "Vegetable bed"}]},
+        }
+    }
+    _enable(coordinator, _FakeRelay({OWNED_ID: DeviceOwnership.OWNED}))
+
+    entity = next(
+        e
+        for e in _run_switch_setup(coordinator)
+        if e.unique_id == f"{OWNED_ID}_boolean:200_control"
+    )
+    assert entity.name == "Vegetable bed"
+
+
+# ── 4. Teardown ───────────────────────────────────────────────────────
+
+
+def test_disabling_closes_the_relay_and_drops_the_session_verdicts() -> None:
+    relay = _FakeRelay({OWNED_ID: DeviceOwnership.OWNED})
+    coordinator = _coordinator(
+        _devices(OWNED_ID), options={CONF_CLOUD_CONTROL: True}
+    )
+    _enable(coordinator, relay)
+
+    asyncio.run(coordinator.async_disable_cloud_control())
+
+    assert relay.disconnect_calls == 1
+    assert coordinator.device_ownership == {}
+    assert coordinator._ownership_unresolved == set()
+    assert coordinator._cloud_ws is None
+
+
+# ── 4b. Setup: an optional channel must never cost the poll ───────────
+
+
+def _setup_cloud_control(
+    monkeypatch,
+    entry: Any,
+    coordinator: ShellyCloudCoordinator,
+    *,
+    failure: Exception | None = None,
+) -> tuple[list[Any], _FakeRelay]:
+    """Run the entry-level wiring with the transport faked out.
+
+    Returns the re-authentication requests it made, and the relay it built,
+    so a caller can check the socket was closed behind a failure.
+    """
+    relay = _FakeRelay()
+
+    async def _enable(ws: Any) -> None:
+        if failure is not None:
+            raise failure
+        coordinator._cloud_ws = ws
+
+    coordinator.async_enable_cloud_control = _enable
+
+    reauths: list[Any] = []
+    monkeypatch.setattr(
+        integration, "async_get_clientsession", lambda hass: SimpleNamespace()
+    )
+    monkeypatch.setattr(
+        integration,
+        "ShellyTokenManager",
+        lambda *args, **kwargs: SimpleNamespace(
+            async_get_token=None, async_force_refresh=None
+        ),
+    )
+    monkeypatch.setattr(
+        integration, "ShellyCloudWebSocket", lambda *args, **kwargs: relay
+    )
+    monkeypatch.setattr(
+        integration,
+        "_start_cloud_control_reauth",
+        lambda hass, config_entry: reauths.append(config_entry),
+    )
+
+    asyncio.run(
+        integration._async_setup_cloud_control(
+            SimpleNamespace(), entry, coordinator
+        )
+    )
+    return reauths, relay
+
+
+def test_a_relay_that_will_not_connect_costs_the_switches_and_nothing_else(
+    monkeypatch, caplog
+) -> None:
+    """Setup must survive it: the entry's real job is the poll."""
+    entry = _Entry({CONF_CLOUD_CONTROL: True})
+    coordinator = _coordinator(_devices(OWNED_ID), options=entry.options)
+
+    with caplog.at_level(logging.DEBUG):
+        reauths, relay = _setup_cloud_control(
+            monkeypatch,
+            entry,
+            coordinator,
+            failure=ShellyCloudWsTimeoutError("relay did not connect"),
+        )
+
+    assert reauths == [], "a dead relay is not a credential problem"
+    assert coordinator._cloud_ws is None
+    assert relay.disconnect_calls == 1, "a half-open socket must not be left behind"
+    assert [e.unique_id for e in _run_switch_setup(coordinator)] == [
+        f"{OWNED_ID}_switch_0"
+    ]
+    for secret in (FAKE_ACCESS, FAKE_REFRESH):
+        assert secret not in caplog.text
+
+
+def test_a_spent_sign_in_asks_the_user_instead_of_failing_the_entry(
+    monkeypatch,
+) -> None:
+    from homeassistant.exceptions import ConfigEntryAuthFailed
+
+    entry = _Entry({CONF_CLOUD_CONTROL: True})
+    coordinator = _coordinator(_devices(OWNED_ID), options=entry.options)
+
+    reauths, relay = _setup_cloud_control(
+        monkeypatch,
+        entry,
+        coordinator,
+        failure=ConfigEntryAuthFailed("no refresh token"),
+    )
+
+    assert reauths == [entry]
+    assert relay.disconnect_calls == 1
+
+
+def test_an_entry_with_no_stored_sign_in_asks_for_one_without_connecting(
+    monkeypatch,
+) -> None:
+    entry = _Entry({CONF_CLOUD_CONTROL: True})
+    del entry.data[CONF_OAUTH_TOKEN]
+    coordinator = _coordinator(_devices(OWNED_ID), options=entry.options)
+
+    reauths, relay = _setup_cloud_control(monkeypatch, entry, coordinator)
+
+    assert reauths == [entry]
+    assert coordinator._cloud_ws is None
+    assert relay.connect_calls == 0, "nothing is contacted without a sign-in"
+
+
+# ── 4c. Entry lifecycle: reloads, token storage, reauth routing ──────
+
+
+def _flow_hass(entry: Any) -> Any:
+    """A hass stub an options flow can read its entry through."""
+    updates: list[dict[str, Any]] = []
+
+    def _update(config_entry: Any, **kwargs: Any) -> None:
+        if "data" in kwargs:
+            config_entry.data = dict(kwargs["data"])
+        updates.append(kwargs)
+
+    return SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_known_entry=lambda entry_id: entry,
+            async_get_entry=lambda entry_id: entry,
+            async_update_entry=_update,
+        ),
+        updates=updates,
+    )
+
+
+def _options_flow(entry: Any) -> Any:
+    flow = config_flow.ShellyCloudDiyOptionsFlow()
+    flow.hass = _flow_hass(entry)
+    flow.handler = entry.entry_id
+    return flow
+
+
+def test_a_token_refresh_does_not_reload_the_entry() -> None:
+    """A rotated token is a write to entry.data, not a reason to reload.
+
+    Home Assistant fires the update listener for both, and reloading would
+    tear the poll down and rebuild every entity because a background refresh
+    happened.
+    """
+    reloads: list[str] = []
+    entry = _Entry({CONF_CLOUD_CONTROL: True})
+    hass = SimpleNamespace(
+        data={
+            "shelly_cloud_diy": {
+                f"{entry.entry_id}_options": dict(entry.options),
+            }
+        },
+        config_entries=SimpleNamespace(
+            async_reload=_recorder(reloads),
+        ),
+    )
+
+    asyncio.run(integration._async_options_updated(hass, entry))
+    assert reloads == []
+
+    # An actual options change still reloads.
+    entry.options = {CONF_CLOUD_CONTROL: False}
+    asyncio.run(integration._async_options_updated(hass, entry))
+    assert reloads == [entry.entry_id]
+
+
+def _recorder(sink: list[str]) -> Any:
+    async def _record(entry_id: str) -> None:
+        sink.append(entry_id)
+
+    return _record
+
+
+def test_a_refresh_never_writes_a_token_back_into_an_entry_that_has_none(
+    monkeypatch,
+) -> None:
+    """The user switched cloud control off; a refresh in flight must not undo it."""
+    entry = _Entry({CONF_CLOUD_CONTROL: True})
+    coordinator = _coordinator(_devices(OWNED_ID), options=entry.options)
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        integration, "async_get_clientsession", lambda hass: SimpleNamespace()
+    )
+    monkeypatch.setattr(
+        integration, "ShellyCloudWebSocket", lambda *a, **k: _FakeRelay()
+    )
+    monkeypatch.setattr(
+        integration,
+        "ShellyTokenManager",
+        lambda *args, **kwargs: captured.setdefault(
+            "manager", SimpleNamespace(**kwargs, async_get_token=None,
+                                       async_force_refresh=None)
+        ),
+    )
+    monkeypatch.setattr(
+        integration, "_start_cloud_control_reauth", lambda hass, e: None
+    )
+
+    updates: list[Any] = []
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_update_entry=lambda e, **kw: updates.append(kw)
+        )
+    )
+
+    async def _enable(ws: Any) -> None:
+        coordinator._cloud_ws = ws
+
+    coordinator.async_enable_cloud_control = _enable
+    asyncio.run(integration._async_setup_cloud_control(hass, entry, coordinator))
+
+    persist = captured["manager"].on_token_refreshed
+    rotated = OAuthToken(
+        access_token=FAKE_ACCESS, expires_at=99.0, refresh_token="ROTATED-FAKE"
+    )
+
+    # A rotation while the token is still stored is written through …
+    asyncio.run(persist(rotated))
+    assert len(updates) == 1
+
+    # … but once the user has deleted it, nothing puts it back.
+    del entry.data[CONF_OAUTH_TOKEN]
+    asyncio.run(persist(rotated))
+    assert len(updates) == 1
+
+
+def test_reauth_routes_to_the_credential_that_was_actually_rejected() -> None:
+    """Both credentials fail into one flow, so the caller has to say which."""
+    from custom_components.shelly_cloud_diy.const import REAUTH_CLOUD_CONTROL
+
+    flow = config_flow.ShellyCloudDiyConfigFlow()
+    entry = _Entry({CONF_CLOUD_CONTROL: True})
+    flow.hass = _flow_hass(entry)
+    flow.context = {"entry_id": entry.entry_id}
+
+    cloud = asyncio.run(flow.async_step_reauth({REAUTH_CLOUD_CONTROL: True}))
+    assert cloud["step_id"] == "reauth_cloud_control"
+
+    key = asyncio.run(flow.async_step_reauth({}))
+    assert key["step_id"] == "reauth_confirm"
+
+
+def test_the_options_flow_stores_the_token_only_with_the_option(monkeypatch) -> None:
+    """A flow abandoned after the sign-in must leave nothing behind."""
+    entry = _Entry({})
+    del entry.data[CONF_OAUTH_TOKEN]
+    flow = _options_flow(entry)
+    flow._pending_base_options = {CONF_CLOUD_CONTROL: True}
+
+    monkeypatch.setattr(
+        config_flow,
+        "_async_sign_in",
+        _fake_sign_in(
+            OAuthToken(
+                access_token=FAKE_ACCESS, expires_at=1.0, refresh_token=FAKE_REFRESH
+            )
+        ),
+    )
+
+    assert flow._needs_cloud_sign_in() is True
+    asyncio.run(
+        flow.async_step_cloud_control({"email": FAKE_EMAIL, "password": FAKE_PASSWORD})
+    )
+    # Signed in — and nothing written: the user could still close the dialog.
+    assert CONF_OAUTH_TOKEN not in entry.data
+    assert flow._needs_cloud_sign_in() is False
+
+    flow._save({CONF_CLOUD_CONTROL: True})
+    assert entry.data[CONF_OAUTH_TOKEN]["access_token"] == FAKE_ACCESS
+
+
+def test_switching_the_option_off_deletes_the_stored_sign_in() -> None:
+    entry = _Entry({CONF_CLOUD_CONTROL: True})
+    flow = _options_flow(entry)
+
+    flow._save({CONF_CLOUD_CONTROL: False})
+
+    assert CONF_OAUTH_TOKEN not in entry.data
+    assert entry.data["auth_key"], "the poll's own credential is untouched"
+
+
+def test_skipping_the_device_step_keeps_the_device_selection() -> None:
+    """Saving replaces the options wholesale, so the selection must be carried.
+
+    Without this a cloud hiccup during an options save would drop the user's
+    curated device list — and the coordinator's "no explicit selection"
+    fallback would then materialise every device on the account.
+    """
+    entry = _Entry({CONF_CLOUD_CONTROL: False, "enabled_devices": [OWNED_ID]})
+    flow = _options_flow(entry)
+    flow._pending_base_options = {CONF_CLOUD_CONTROL: False}
+
+    flow._carry_device_selection()
+
+    assert flow._pending_base_options["enabled_devices"] == [OWNED_ID]
+
+
+def _fake_sign_in(token: OAuthToken | None) -> Any:
+    async def _sign_in(hass: Any, server_uri: str, user_input: dict) -> Any:
+        return token, {}
+
+    return _sign_in
+
+
+# ── 5. Nothing secret escapes ─────────────────────────────────────────
+
+
+def test_the_diagnostics_block_carries_no_token_and_no_raw_device_id() -> None:
+    entry = _Entry({CONF_CLOUD_CONTROL: True, "create_all_initially": True})
+    coordinator = _coordinator(
+        _devices(OWNED_ID, SHARED_ID, MURKY_ID),
+        options=entry.options,
+        ws=_FakeRelay(),
+    )
+    coordinator.device_ownership = {
+        OWNED_ID: DeviceOwnership.OWNED,
+        SHARED_ID: DeviceOwnership.NOT_ROUTABLE,
+    }
+    coordinator._ownership_unresolved = {MURKY_ID}
+
+    dumped = json.dumps(diagnostics._config_diagnostics(entry, coordinator))
+
+    for secret in (FAKE_ACCESS, FAKE_REFRESH, "NOTAREALKEY-shouldneverappear"):
+        assert secret not in dumped
+    for device_id in (OWNED_ID, SHARED_ID, MURKY_ID):
+        assert device_id not in dumped
+
+    block = diagnostics._config_diagnostics(entry, coordinator)["cloud_control"]
+    assert block["mode"] == "on"
+    assert (block["owned"], block["not_routable"], block["unclassified"]) == (1, 1, 1)
+
+
+def test_the_diagnostics_block_says_off_without_reading_anything_else() -> None:
+    entry = _Entry({})
+    block = diagnostics._config_diagnostics(entry, None)["cloud_control"]
+    assert block == {"mode": "off"}
+
+
+def test_signing_in_never_logs_the_password_or_its_digest(monkeypatch, caplog) -> None:
+    """The one place a plaintext password exists, and the one that must not talk."""
+    from custom_components.shelly_cloud_diy.api.oauth import (
+        ShellyOAuthError,
+        sha1_password,
+    )
+
+    seen: dict[str, Any] = {}
+
+    async def _fake_login(session, server_uri, email, password_sha1):
+        seen["email"] = email
+        seen["digest"] = password_sha1
+        raise ShellyOAuthError("OAuth request rejected (HTTP 401)")
+
+    monkeypatch.setattr(config_flow, "login", _fake_login)
+    monkeypatch.setattr(
+        config_flow, "async_get_clientsession", lambda hass: SimpleNamespace()
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        token, errors = asyncio.run(
+            config_flow._async_sign_in(
+                SimpleNamespace(),
+                SERVER_URI,
+                {"email": FAKE_EMAIL, "password": FAKE_PASSWORD},
+            )
+        )
+
+    assert token is None
+    assert errors == {"base": "invalid_account"}
+    # The plaintext never left the boundary, and neither half is in the log.
+    assert seen["digest"] == sha1_password(FAKE_PASSWORD)
+    assert FAKE_PASSWORD not in caplog.text
+    assert seen["digest"] not in caplog.text
+    assert FAKE_PASSWORD not in json.dumps(errors)
+
+
+def test_a_stored_token_survives_a_round_trip_and_a_broken_one_does_not() -> None:
+    token = OAuthToken(
+        access_token=FAKE_ACCESS, expires_at=123.5, refresh_token=FAKE_REFRESH
+    )
+    restored = token_from_storage(token_to_storage(token))
+
+    assert restored == token
+    # A record whose expiry is unreadable means "refresh at once", never
+    # "valid forever".
+    assert token_from_storage({"access_token": FAKE_ACCESS}).expires_at == 0.0
+    assert token_from_storage({"refresh_token": FAKE_REFRESH}) is None
+    assert token_from_storage(None) is None
+    # And the repr of what we store still refuses to print the token.
+    assert FAKE_ACCESS not in repr(restored)
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _run_switch_setup(coordinator: ShellyCloudCoordinator) -> list[Any]:
+    """Run the real switch platform setup against a hand-built coordinator.
+
+    The dispatcher is stubbed out for the same reason the other platform
+    tests stub it: connecting a signal needs a running Home Assistant, and
+    what is under test here is which entities the builder returns.
+    """
+    added: list[Any] = []
+    hass = SimpleNamespace(data={"shelly_cloud_diy": {"e1": coordinator}})
+    entry = SimpleNamespace(entry_id="e1", async_on_unload=lambda cb: None)
+
+    original = switch_platform.async_dispatcher_connect
+    switch_platform.async_dispatcher_connect = lambda *args, **kwargs: (lambda: None)
+    try:
+        asyncio.run(
+            switch_platform.async_setup_entry(
+                hass, entry, lambda ents: added.extend(ents)
+            )
+        )
+    finally:
+        switch_platform.async_dispatcher_connect = original
+    return added

--- a/tests/test_cloud_control.py
+++ b/tests/test_cloud_control.py
@@ -754,13 +754,16 @@ def _flow_hass(entry: Any) -> Any:
             config_entry.data = dict(kwargs["data"])
         updates.append(kwargs)
 
+    reloads: list[str] = []
     return SimpleNamespace(
         config_entries=SimpleNamespace(
             async_get_known_entry=lambda entry_id: entry,
             async_get_entry=lambda entry_id: entry,
             async_update_entry=_update,
+            async_schedule_reload=reloads.append,
         ),
         updates=updates,
+        reloads=reloads,
     )
 
 
@@ -1051,3 +1054,87 @@ def _run_switch_setup(coordinator: ShellyCloudCoordinator) -> list[Any]:
     finally:
         switch_platform.async_dispatcher_connect = original
     return added
+
+
+# ── Regressions found in review, after the feature was already written ──
+
+
+def test_a_failed_setup_cannot_strand_the_relay() -> None:
+    """Two teardown paths, because neither one covers both failures.
+
+    Home Assistant never calls a component's ``async_unload_entry`` for an
+    entry that is not LOADED — ``ConfigEntry.async_unload`` short-circuits —
+    so a setup that raises after the channel is up would leave the socket,
+    its reconnect ladder and the ownership loop running forever, refreshing
+    a token for an entry that never came up. The on-unload callback covers
+    that for the ``ConfigEntry*`` failures; it does NOT cover the generic
+    exception branch, which is the only one Home Assistant does not process
+    on-unload callbacks for. Hence both, and hence a static test: this is a
+    positional property no behavioural test of a working setup can see.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(integration.async_setup_entry)))
+    dumped = ast.dump(tree)
+
+    assert "async_on_unload" in dumped and "async_disable_cloud_control" in dumped, (
+        "setup must register the channel teardown as an on-unload callback"
+    )
+
+    handlers = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ExceptHandler)
+        and "async_disable_cloud_control" in ast.dump(node)
+    ]
+    assert handlers, (
+        "the rest of setup must be wrapped so the generic-exception branch, "
+        "where Home Assistant runs no on-unload callbacks, still closes the "
+        "channel"
+    )
+    # The handler must re-raise: swallowing here would report a broken entry
+    # as set up.
+    assert any(
+        isinstance(node, ast.Raise) and node.exc is None
+        for handler in handlers
+        for node in ast.walk(handler)
+    ), "the handler must re-raise, not swallow the setup failure"
+
+
+def test_a_fresh_sign_in_with_unchanged_options_still_reloads() -> None:
+    """Writing a token that nothing acts on is the same as not writing it.
+
+    Reachable, not theoretical: when a token is rejected the entry keeps
+    ``cloud_control: True`` with no usable credential, and a user who signs
+    in again through Options rather than the repair card changes no option at
+    all. Neither write reaches a listener then — the data write is correctly
+    ignored because the options did not change, and Home Assistant fires no
+    listener for an options write that changes nothing — so without an
+    explicit reload the entry would sit with a valid token and a dead channel
+    until the next restart.
+    """
+    entry = _Entry({CONF_CLOUD_CONTROL: True})
+    del entry.data[CONF_OAUTH_TOKEN]  # the state a rejected session leaves
+    flow = _options_flow(entry)
+    flow._pending_token = OAuthToken(
+        access_token=FAKE_ACCESS, expires_at=9e9, refresh_token=FAKE_REFRESH
+    )
+
+    flow._save(dict(entry.options))
+
+    assert CONF_OAUTH_TOKEN in entry.data, "the sign-in must be stored"
+    assert flow.hass.reloads == [entry.entry_id], (
+        "a stored sign-in that nothing reloads leaves the channel dead"
+    )
+
+
+def test_an_options_change_is_not_reloaded_twice() -> None:
+    """The explicit reload is only for the case no listener will cover."""
+    entry = _Entry({CONF_CLOUD_CONTROL: False})
+    flow = _options_flow(entry)
+    flow._pending_token = OAuthToken(
+        access_token=FAKE_ACCESS, expires_at=9e9, refresh_token=FAKE_REFRESH
+    )
+
+    # Options genuinely change, so the ordinary listener path reloads.
+    flow._save({CONF_CLOUD_CONTROL: True})
+
+    assert flow.hass.reloads == [], "the update listener already covers this"

--- a/tests/test_cloud_ws.py
+++ b/tests/test_cloud_ws.py
@@ -1,0 +1,619 @@
+"""Unit tests for the Shelly Cloud WebSocket relay transport.
+
+The relay is a command channel for devices the documented HTTP API cannot
+reach, and its first consumer switches irrigation valves. Three properties
+matter more than any individual call:
+
+1. **Failure is loud.** Every path raises a typed error. A caller must never be
+   able to confuse "the zone switched" with "nobody answered".
+2. **``WRONG_ID`` is a verdict, not a fault.** It is the measured signal for a
+   device this session cannot route to — measured *with* a negative control,
+   since deliberately malformed ids return the identical error. Treating it as a
+   transport problem would put the connection into a reconnect loop over a
+   perfectly healthy socket.
+3. **The access token rides in the connect URL**, so a handshake failure hands
+   ``aiohttp`` a full token-bearing URL that its own ``__str__`` will happily
+   print at ERROR level. The tests reproduce exactly that and then search
+   everything the code produced for the token.
+
+Driven through the real transport with a hand-rolled fake socket: no network,
+no running Home Assistant, and every credential a fake literal.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import aiohttp
+import pytest
+import yarl
+from multidict import CIMultiDict, CIMultiDictProxy
+
+from custom_components.shelly_cloud_diy.api import cloud_ws
+from custom_components.shelly_cloud_diy.api.cloud_ws import (
+    DeviceOwnership,
+    ShellyCloudWebSocket,
+    ShellyCloudWsAuthError,
+    ShellyCloudWsCommandError,
+    ShellyCloudWsNotConnectedError,
+    ShellyCloudWsTimeoutError,
+    ShellyCloudWsTransportError,
+)
+
+FAKE_TOKEN = "FAKE-ACCESS-TOKEN-do-not-log-55555555"  # noqa: S105
+ACCOUNT_HOST = "shelly-42-eu.shelly.cloud"
+SERVER_URI = f"https://{ACCOUNT_HOST}"
+DEVICE_ID = "5432044e0001"
+
+_REAL_SLEEP = asyncio.sleep
+_CLOSE = object()
+
+
+def _text_frame(payload: dict[str, Any]) -> SimpleNamespace:
+    """One inbound TEXT message, shaped like ``aiohttp.WSMessage``."""
+    return SimpleNamespace(
+        type=aiohttp.WSMsgType.TEXT, data=json.dumps(payload), extra=None
+    )
+
+
+class _FakeWebSocket:
+    """A socket that answers what a ``responder`` decides, and nothing else."""
+
+    def __init__(
+        self,
+        responder=None,
+        *,
+        close_code: int | None = None,
+        close_immediately: bool = False,
+    ) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self.closed = False
+        self.close_code = close_code
+        self._responder = responder
+        self._queue: asyncio.Queue = asyncio.Queue()
+        if close_immediately:
+            self._queue.put_nowait(_CLOSE)
+
+    async def send_json(self, frame: dict[str, Any]) -> None:
+        self.sent.append(frame)
+        if self._responder is None:
+            return
+        reply = self._responder(frame)
+        if reply is not None:
+            self._queue.put_nowait(_text_frame(reply))
+
+    def push(self, frame: dict[str, Any]) -> None:
+        """Deliver an unsolicited frame, the way a push-enabled relay would."""
+        self._queue.put_nowait(_text_frame(frame))
+
+    def __aiter__(self) -> _FakeWebSocket:
+        return self
+
+    async def __anext__(self) -> SimpleNamespace:
+        message = await self._queue.get()
+        if message is _CLOSE:
+            raise StopAsyncIteration
+        return message
+
+    async def close(self) -> None:
+        self.closed = True
+        self._queue.put_nowait(_CLOSE)
+
+    def exception(self) -> BaseException | None:
+        return None
+
+
+class _FakeSession:
+    """Hands out sockets (or raises) and records every URL it was given."""
+
+    def __init__(self, factory) -> None:
+        self._factory = factory
+        self.urls: list[str] = []
+
+    async def ws_connect(self, url: str, **kwargs: Any):  # noqa: ANN401
+        self.urls.append(url)
+        result = self._factory(len(self.urls) - 1)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+def _client(session: _FakeSession, **kwargs: Any) -> ShellyCloudWebSocket:
+    async def _token() -> str:
+        return FAKE_TOKEN
+
+    return ShellyCloudWebSocket(session, SERVER_URI, _token, **kwargs)
+
+
+def _answer(response: dict[str, Any]):
+    """A responder that answers every request with ``response``."""
+
+    def responder(frame: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "event": "Shelly:JrpcResponse",
+            "trid": frame["trid"],
+            "deviceId": frame["deviceId"],
+            "response": response,
+        }
+
+    return responder
+
+
+def _handshake_error(url: str, status: int) -> aiohttp.WSServerHandshakeError:
+    """The real aiohttp error — its ``__str__`` embeds the token-bearing URL."""
+    parsed = yarl.URL(url)
+    info = aiohttp.RequestInfo(
+        url=parsed, method="GET", headers=CIMultiDictProxy(CIMultiDict()), real_url=parsed
+    )
+    return aiohttp.WSServerHandshakeError(
+        info, (), status=status, message="Invalid response status"
+    )
+
+
+# ── The round trip ──────────────────────────────────────────────────────────
+
+
+def test_a_command_round_trip_returns_the_rpc_result():
+    """The generic relay call: a device's own RPC, sent through the cloud."""
+
+    async def scenario():
+        ws = _FakeWebSocket(_answer({"was_on": False}))
+        client = _client(_FakeSession(lambda _: ws))
+        await client.connect()
+        result = await client.send_jrpc_request(
+            DEVICE_ID, "Boolean.Set", {"id": 200, "value": True}
+        )
+        await client.disconnect()
+        return ws.sent, result
+
+    sent, result = asyncio.run(scenario())
+
+    assert result == {"was_on": False}
+    assert sent == [
+        {
+            "event": "Shelly:JrpcRequest",
+            "trid": 1,
+            "deviceId": DEVICE_ID,
+            "method": "Boolean.Set",
+            "params": {"id": 200, "value": True},
+        }
+    ]
+
+
+def test_a_silent_relay_raises_instead_of_returning_none():
+    """The harvested transport returned ``None`` here. That is the bug this slice fixes.
+
+    "No answer" is the single most dangerous outcome for a valve: the caller
+    must be told, not handed a falsy value that reads like a normal result.
+    """
+
+    async def scenario():
+        client = _client(_FakeSession(lambda _: _FakeWebSocket(lambda frame: None)))
+        await client.connect()
+        try:
+            with pytest.raises(ShellyCloudWsTimeoutError):
+                await client.send_jrpc_request(DEVICE_ID, "Boolean.Set", timeout=0.05)
+        finally:
+            await client.disconnect()
+
+    asyncio.run(scenario())
+
+
+def test_sending_without_a_connection_raises():
+    """A command issued before the transport is up is an error, not a no-op."""
+    client = _client(_FakeSession(lambda _: _FakeWebSocket()))
+    with pytest.raises(ShellyCloudWsNotConnectedError):
+        asyncio.run(client.send_jrpc_request(DEVICE_ID, "Boolean.Set"))
+
+
+def test_a_dropped_connection_fails_the_request_in_flight():
+    """A lost answer must surface immediately, not after the full timeout.
+
+    Waiting out the timeout would be survivable; silently resolving would not.
+    """
+
+    async def scenario():
+        ws = _FakeWebSocket(lambda frame: None)
+        client = _client(_FakeSession(lambda _: ws))
+        await client.connect()
+        pending = asyncio.create_task(
+            client.send_jrpc_request(DEVICE_ID, "Boolean.Set", timeout=30)
+        )
+        await _REAL_SLEEP(0)
+        await ws.close()
+        with pytest.raises(ShellyCloudWsNotConnectedError):
+            await asyncio.wait_for(pending, timeout=1)
+        await client.disconnect()
+
+    asyncio.run(scenario())
+
+
+def test_a_failed_first_connection_is_reported_to_the_caller():
+    """An opt-in control channel that cannot come up has to say so at setup."""
+
+    async def scenario():
+        session = _FakeSession(lambda _: aiohttp.ClientConnectorError(None, OSError("no route")))
+        client = _client(session)
+        with pytest.raises(ShellyCloudWsTransportError):
+            await client.connect()
+        assert client.connected is False
+        # No background task is left retrying behind the caller's back.
+        assert client._task is None  # noqa: SLF001
+
+    asyncio.run(scenario())
+
+
+# ── Ownership ───────────────────────────────────────────────────────────────
+
+
+def test_an_answering_device_is_owned():
+    async def scenario():
+        client = _client(
+            _FakeSession(lambda _: _FakeWebSocket(_answer({"id": DEVICE_ID, "gen": 3})))
+        )
+        await client.connect()
+        verdict = await client.async_classify_ownership(DEVICE_ID)
+        await client.disconnect()
+        return verdict
+
+    assert asyncio.run(scenario()) is DeviceOwnership.OWNED
+
+
+def test_wrong_id_is_a_verdict_about_the_device_not_a_transport_fault():
+    """``WRONG_ID`` means "this session cannot route there" — shared, or gone.
+
+    The connection is healthy afterwards and nothing escalates: a refused route
+    must not look like a broken socket, or a single shared device would put the
+    whole transport into a reconnect loop.
+    """
+
+    async def scenario():
+        client = _client(_FakeSession(lambda _: _FakeWebSocket(_answer({"error": "WRONG_ID"}))))
+        await client.connect()
+        verdict = await client.async_classify_ownership(DEVICE_ID)
+        state = (client.connected, client.auth_failed)
+        with pytest.raises(ShellyCloudWsCommandError) as excinfo:
+            await client.send_jrpc_request(DEVICE_ID, "Boolean.Set", {"id": 200})
+        await client.disconnect()
+        return verdict, state, excinfo.value
+
+    verdict, (connected, auth_failed), err = asyncio.run(scenario())
+
+    assert verdict is DeviceOwnership.NOT_ROUTABLE
+    assert connected is True
+    assert auth_failed is False
+    assert err.code == "WRONG_ID"
+    # A command failure is still a failure — the classifier is what interprets
+    # the code, the command path must not swallow it.
+    assert not isinstance(err, ShellyCloudWsTimeoutError)
+
+
+def test_an_unfamiliar_relay_error_is_unknown_rather_than_a_guess():
+    """``UNKNOWN`` keeps a probe that could not decide from posing as one that did."""
+
+    async def scenario():
+        client = _client(
+            _FakeSession(lambda _: _FakeWebSocket(_answer({"error": "BAD_REQUEST"})))
+        )
+        await client.connect()
+        verdict = await client.async_classify_ownership(DEVICE_ID)
+        await client.disconnect()
+        return verdict
+
+    assert asyncio.run(scenario()) is DeviceOwnership.UNKNOWN
+
+
+def test_a_silent_relay_makes_ownership_unknown_not_not_routable():
+    """A timeout says nothing about ownership, and must not be read as a refusal."""
+
+    async def scenario():
+        client = _client(
+            _FakeSession(lambda _: _FakeWebSocket(lambda frame: None)),
+            request_timeout_s=0.05,
+        )
+        await client.connect()
+        verdict = await client.async_classify_ownership(DEVICE_ID)
+        await client.disconnect()
+        return verdict
+
+    assert asyncio.run(scenario()) is DeviceOwnership.UNKNOWN
+
+
+def test_the_ownership_probe_is_one_cheap_call():
+    """One ``Shelly.GetDeviceInfo`` per device, per session — not per poll."""
+
+    async def scenario():
+        ws = _FakeWebSocket(_answer({"id": DEVICE_ID}))
+        client = _client(_FakeSession(lambda _: ws))
+        await client.connect()
+        await client.async_classify_ownership(DEVICE_ID)
+        await client.disconnect()
+        return ws.sent
+
+    sent = asyncio.run(scenario())
+    assert [frame["method"] for frame in sent] == ["Shelly.GetDeviceInfo"]
+    assert sent[0]["params"] == {}
+
+
+# ── Authentication ──────────────────────────────────────────────────────────
+
+
+def test_unauthorized_signals_reauth_and_does_not_retry():
+    """A rejected session token stays rejected; only a human can fix it.
+
+    So it raises, asks Home Assistant for re-authentication exactly once, and
+    reconnects zero times — a retry loop here would hammer the account with a
+    credential the relay has already refused.
+    """
+    reauths: list[int] = []
+
+    async def scenario():
+        client = _client(
+            _FakeSession(lambda _: _FakeWebSocket(_answer({"error": "UNAUTHORIZED"}))),
+            on_reauth=lambda: reauths.append(1),
+        )
+        await client.connect()
+        with pytest.raises(ShellyCloudWsAuthError):
+            await client.send_jrpc_request(DEVICE_ID, "Boolean.Set", {"id": 200})
+        # Give any (unwanted) reconnect attempt room to happen.
+        for _ in range(10):
+            await _REAL_SLEEP(0)
+        state = (client.auth_failed, len(client._session.urls))  # noqa: SLF001
+        await client.disconnect()
+        return state
+
+    auth_failed, connect_attempts = asyncio.run(scenario())
+
+    assert reauths == [1]
+    assert auth_failed is True
+    assert connect_attempts == 1
+
+
+def test_a_rejected_handshake_refreshes_the_token_before_retrying(monkeypatch):
+    """A 4401-style rejection on a live connection is worth one fresh token.
+
+    The refresh hook runs before the backoff sleep, so the next attempt carries
+    the new token rather than replaying the rejected one.
+    """
+    refreshes: list[int] = []
+    sleeps: list[float] = []
+
+    async def _refresh() -> str:
+        refreshes.append(1)
+        return FAKE_TOKEN
+
+    async def _sleep(delay: float) -> None:
+        sleeps.append(delay)
+        await _REAL_SLEEP(0)
+
+    def factory(attempt: int):
+        if attempt == 0:
+            return _FakeWebSocket(close_code=4401, close_immediately=True)
+        return _FakeWebSocket(_answer({"ok": True}))
+
+    async def scenario():
+        client = _client(_FakeSession(factory), on_token_rejected=_refresh)
+        await client.connect()
+        for _ in range(20):
+            await _REAL_SLEEP(0)
+        attempts = len(client._session.urls)  # noqa: SLF001
+        await client.disconnect()
+        return attempts
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    attempts = asyncio.run(scenario())
+
+    assert refreshes == [1]
+    assert attempts >= 2
+
+
+# ── Reconnect ladder ────────────────────────────────────────────────────────
+
+
+def test_the_backoff_grows_and_stays_bounded(monkeypatch):
+    """A flapping relay must be backed off from, and never backed off forever.
+
+    A connection that dies straight away is a failing connection wearing a
+    clean-close hat, so it does not reset the ladder — otherwise the backoff
+    switches itself off in exactly the situation it exists for. The cap is what
+    guarantees the socket still comes back after a long cloud outage.
+    """
+    sleeps: list[float] = []
+    enough = asyncio.Event()
+
+    async def _sleep(delay: float) -> None:
+        sleeps.append(delay)
+        if len(sleeps) >= 12:
+            enough.set()
+        await _REAL_SLEEP(0)
+
+    async def scenario():
+        client = _client(
+            _FakeSession(lambda _: _FakeWebSocket(close_immediately=True))
+        )
+        await client.connect()
+        await asyncio.wait_for(enough.wait(), timeout=5)
+        await client.disconnect()
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    asyncio.run(scenario())
+
+    ceiling = cloud_ws._RECONNECT_MAX_S * (1 + cloud_ws._RECONNECT_JITTER)  # noqa: SLF001
+    assert all(0 < delay <= ceiling for delay in sleeps)
+    assert sleeps[0] < sleeps[3] < sleeps[6]  # the ladder actually climbs
+    assert max(sleeps) >= cloud_ws._RECONNECT_MAX_S  # and reaches its cap  # noqa: SLF001
+    assert sleeps[-1] <= ceiling  # and stops there
+
+
+def test_jitter_keeps_instances_from_reconnecting_in_lock_step(monkeypatch):
+    """Identical clients must not all come back in the same second."""
+    sleeps: list[float] = []
+
+    async def _sleep(delay: float) -> None:
+        sleeps.append(delay)
+        if len(sleeps) >= 8:
+            raise asyncio.CancelledError
+        await _REAL_SLEEP(0)
+
+    async def scenario():
+        client = _client(_FakeSession(lambda _: _FakeWebSocket(close_immediately=True)))
+        await client.connect()
+        for _ in range(200):
+            await _REAL_SLEEP(0)
+            if len(sleeps) >= 8:
+                break
+        await client.disconnect()
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    asyncio.run(scenario())
+
+    # Every delay carries a random component, so no two runs are identical and
+    # the values are not the bare ladder steps.
+    assert any(delay != round(delay) for delay in sleeps)
+
+
+# ── Push stays deleted ──────────────────────────────────────────────────────
+
+
+def test_unsolicited_frames_are_dropped():
+    """The poll owns state. A push frame must change nothing here.
+
+    The fields the freshness bookkeeping reads are not in a relay frame, so a
+    transport that fed them to the coordinator would corrupt the three
+    hardware-confirmed detectors built on the poll.
+    """
+
+    async def scenario():
+        ws = _FakeWebSocket(_answer({"ok": True}))
+        client = _client(_FakeSession(lambda _: ws))
+        await client.connect()
+        ws.push({"event": "Shelly:StatusOnChange", "status": {"switch:0": {"output": True}}})
+        ws.push({"event": "Shelly:Online", "online": True})
+        await _REAL_SLEEP(0)
+        result = await client.send_jrpc_request(DEVICE_ID, "Shelly.GetDeviceInfo")
+        connected = client.connected
+        await client.disconnect()
+        return result, connected
+
+    result, connected = asyncio.run(scenario())
+    assert result == {"ok": True}
+    assert connected is True
+
+
+def test_the_module_carries_no_push_machinery():
+    """A structural guard, because this deletion is the point of the slice.
+
+    The file was renamed away from ``websocket.py`` so nobody re-adds the status
+    path by reflex; this test is the half of that rename which does not depend
+    on anyone noticing the name.
+    """
+    source = Path(cloud_ws.__file__).read_text(encoding="utf-8")
+    for banned in (
+        "StatusOnChangeRequest",
+        "_request_status_after_connect",
+        "message_handler",
+        "Shelly:CommandRequest",
+    ):
+        assert banned not in source, f"push-era construct is back: {banned}"
+
+
+# ── Secrecy ─────────────────────────────────────────────────────────────────
+
+
+def test_the_token_never_reaches_a_log_record_or_a_repr(caplog):
+    """The whole leak surface in one test.
+
+    A handshake failure is the dangerous case: ``aiohttp``'s own error message
+    contains the full ``?t=<token>`` URL, ERROR logging is on by default, and
+    one careless ``%s`` would put an account credential into everybody's log.
+    """
+    caplog.set_level(logging.DEBUG)
+    url = f"wss://{ACCOUNT_HOST}:6113/shelly/wss/hk_sock?t={FAKE_TOKEN}"
+    assert FAKE_TOKEN in str(_handshake_error(url, 500))  # the trap is real
+
+    async def scenario():
+        # A working session first, so the DEBUG frame dumps are exercised too.
+        ws = _FakeWebSocket(_answer({"ok": True}))
+        client = _client(_FakeSession(lambda _: ws))
+        await client.connect()
+        await client.send_jrpc_request(DEVICE_ID, "Boolean.Set", {"id": 200})
+        ws.push({"event": "Shelly:StatusOnChange", "t": FAKE_TOKEN})
+        await _REAL_SLEEP(0)
+        rendering = repr(client)
+        await client.disconnect()
+
+        # Then a handshake rejection, whose exception embeds the token URL.
+        failing = _client(_FakeSession(lambda _: _handshake_error(url, 500)))
+        with pytest.raises(ShellyCloudWsTransportError) as excinfo:
+            await failing.connect()
+        return rendering, str(excinfo.value)
+
+    client_repr, error_message = asyncio.run(scenario())
+
+    formatter = logging.Formatter("%(levelname)s %(name)s %(message)s")
+    rendered = "\n".join(formatter.format(record) for record in caplog.records)
+    assert rendered  # something must have been logged for the search to mean anything
+    assert FAKE_TOKEN not in rendered
+    assert FAKE_TOKEN not in client_repr
+    assert FAKE_TOKEN not in error_message
+    assert "?t=" not in error_message
+    assert ACCOUNT_HOST in error_message  # still says which host failed
+
+
+def test_an_auth_rejected_handshake_is_typed_and_sanitised():
+    """A 401 handshake is an auth failure, and still carries no token."""
+    url = f"wss://{ACCOUNT_HOST}:6113/shelly/wss/hk_sock?t={FAKE_TOKEN}"
+
+    async def scenario():
+        client = _client(_FakeSession(lambda _: _handshake_error(url, 401)))
+        with pytest.raises(ShellyCloudWsAuthError) as excinfo:
+            await client.connect()
+        return str(excinfo.value)
+
+    message = asyncio.run(scenario())
+    assert FAKE_TOKEN not in message
+    assert "401" in message
+
+
+def test_redaction_covers_nested_frames():
+    """``_redact`` is what stands between a DEBUG dump and a leaked token."""
+    frame = {
+        "event": "Shelly:JrpcRequest",
+        "params": {"token": FAKE_TOKEN, "nested": [{"access_token": FAKE_TOKEN}]},
+        "deviceId": DEVICE_ID,
+    }
+    rendered = json.dumps(cloud_ws._redact(frame))  # noqa: SLF001
+    assert FAKE_TOKEN not in rendered
+    assert DEVICE_ID in rendered  # a device id is not a secret; the frame stays useful
+    assert frame["params"]["token"] == FAKE_TOKEN  # and the original is untouched
+
+
+# ── Small pure helpers ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "server_uri",
+    [ACCOUNT_HOST, f"https://{ACCOUNT_HOST}", f"https://{ACCOUNT_HOST}/", f"{ACCOUNT_HOST}:443"],
+)
+def test_the_host_is_normalised_from_whatever_the_entry_stored(server_uri):
+    """The entry holds whatever the Shelly app showed the user."""
+    assert ShellyCloudWebSocket._normalise_host(server_uri) == ACCOUNT_HOST  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        ("WRONG_ID", "WRONG_ID"),
+        ({"message": "WRONG_ID"}, "WRONG_ID"),
+        ({"code": -114}, "-114"),
+        (["nonsense"], "UNKNOWN"),
+        ("x" * 200, "x" * 64),
+    ],
+)
+def test_relay_error_codes_are_reduced_to_something_short(error, expected):
+    """The code goes into an exception message, so it is capped, not trusted."""
+    assert cloud_ws._relay_error_code(error) == expected  # noqa: SLF001

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,430 @@
+"""Unit tests for the Shelly Cloud OAuth client and its token manager.
+
+Two things are being protected here, and only one of them is behaviour.
+
+**Behaviour.** Every failure path must raise a typed exception rather than hand
+back ``None``. The consumer of this module is a control channel for water
+valves; a caller that cannot tell a token apart from the absence of one will
+happily report a command as sent.
+
+**Secrecy.** The password digest and the tokens must not reach a log record, an
+exception message or a ``repr``. That is not something a reviewer can keep true
+by reading — a dataclass' generated ``repr`` leaks a token into any f-string
+that touches it, and ``aiohttp``'s own errors carry the request URL in their
+message. So the tests drive the real code with a fake transport and then search
+everything it produced for the credential literals.
+
+Every credential in this file is a fake literal. No network, no running Home
+Assistant, no real account.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import aiohttp
+import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+from custom_components.shelly_cloud_diy.api import oauth
+from custom_components.shelly_cloud_diy.api.oauth import (
+    OAuthToken,
+    ShellyOAuthError,
+    ShellyOAuthRateLimitError,
+    ShellyOAuthTransportError,
+    ShellyTokenManager,
+    login,
+    refresh_token,
+    sha1_password,
+)
+
+# ── Fake credentials. Nothing here is real, and nothing here may ever be. ──
+FAKE_EMAIL = "nobody@example.invalid"
+FAKE_PASSWORD = "correct-horse-battery-staple"  # noqa: S105
+FAKE_ACCESS = "FAKE-ACCESS-TOKEN-11111111"  # noqa: S105
+FAKE_REFRESH = "FAKE-REFRESH-TOKEN-22222222"  # noqa: S105
+FAKE_SECOND_ACCESS = "FAKE-ACCESS-TOKEN-33333333"  # noqa: S105
+
+ACCOUNT_HOST = "shelly-42-eu.shelly.cloud"
+SERVER_URI = f"https://{ACCOUNT_HOST}"
+
+
+def _jwt(claims: dict[str, Any]) -> str:
+    """Build a signature-free JWT. The client reads claims, never verifies."""
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+def _login_code(user_api_url: str = SERVER_URI) -> str:
+    return _jwt({"user_api_url": user_api_url, "sub": "nobody"})
+
+
+class _FakeResponse:
+    """Enough of ``aiohttp.ClientResponse`` for :func:`oauth._post_form`."""
+
+    def __init__(self, status: int, payload: Any = None, text: str = "") -> None:
+        self.status = status
+        self._payload = payload
+        self._text = text or json.dumps(payload if payload is not None else {})
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def text(self) -> str:
+        return self._text
+
+    async def json(self, content_type: str | None = None) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise aiohttp.ClientResponseError(
+                SimpleNamespace(real_url=f"https://{ACCOUNT_HOST}/oauth/auth"),
+                (),
+                status=self.status,
+                message="fake failure",
+            )
+
+
+class _FakeSession:
+    """Records every form POST and replays canned responses."""
+
+    def __init__(self, handler) -> None:
+        self._handler = handler
+        self.calls: list[tuple[str, dict[str, str]]] = []
+
+    def post(self, url: str, data=None, timeout=None):  # noqa: ANN001 - aiohttp shape
+        self.calls.append((url, dict(data or {})))
+        return self._handler(url, dict(data or {}))
+
+
+def _standard_handler(
+    *, token: str = FAKE_ACCESS, refresh: str | None = FAKE_REFRESH
+):
+    """A cloud that answers the verified two-step flow."""
+
+    def handler(url: str, payload: dict[str, str]) -> _FakeResponse:
+        if url.endswith("/oauth/login"):
+            return _FakeResponse(200, {"isok": True, "data": {"code": _login_code()}})
+        if url.endswith("/oauth/auth"):
+            body: dict[str, Any] = {
+                "access_token": token,
+                "token_type": "Bearer",
+                "expires_in": 43200,
+            }
+            if refresh is not None:
+                body["refresh_token"] = refresh
+            return _FakeResponse(200, body)
+        raise AssertionError(f"unexpected URL {url}")
+
+    return handler
+
+
+# ── The sign-in flow ────────────────────────────────────────────────────────
+
+
+def test_login_follows_the_account_host_from_the_code():
+    """The exchange must hit the host the login code names, not the one passed in.
+
+    The account is the authority on its own regional host; the caller's stored
+    URI is only the fallback. Getting this backwards works fine on a
+    single-region account and fails for everyone else.
+    """
+    session = _FakeSession(_standard_handler())
+    token = asyncio.run(
+        login(session, "https://wrong-host.invalid", FAKE_EMAIL, sha1_password(FAKE_PASSWORD))
+    )
+
+    assert token.access_token == FAKE_ACCESS
+    assert token.refresh_token == FAKE_REFRESH
+    assert token.expires_at > time.time()
+    login_url, login_payload = session.calls[0]
+    exchange_url, _ = session.calls[1]
+    assert login_url == oauth.OAUTH_LOGIN_URL
+    assert exchange_url == f"{SERVER_URI}/oauth/auth"
+    # The plaintext password never leaves the boundary function.
+    assert login_payload["password"] == sha1_password(FAKE_PASSWORD)
+    assert FAKE_PASSWORD not in json.dumps(login_payload)
+
+
+def test_missing_access_token_raises_instead_of_returning_none():
+    """A renamed field must fail loudly at setup, not half-configure an entry."""
+
+    def handler(url: str, payload: dict[str, str]) -> _FakeResponse:
+        if url.endswith("/oauth/login"):
+            return _FakeResponse(200, {"data": {"code": _login_code()}})
+        return _FakeResponse(200, {"token_type": "Bearer"})
+
+    with pytest.raises(ShellyOAuthError):
+        asyncio.run(
+            login(_FakeSession(handler), SERVER_URI, FAKE_EMAIL, sha1_password("x"))
+        )
+
+
+def test_missing_login_code_raises():
+    """Same rule one step earlier: no ``code`` is a failure, not an empty string."""
+
+    def handler(url: str, payload: dict[str, str]) -> _FakeResponse:
+        return _FakeResponse(200, {"isok": True, "data": {}})
+
+    with pytest.raises(ShellyOAuthError):
+        asyncio.run(
+            login(_FakeSession(handler), SERVER_URI, FAKE_EMAIL, sha1_password("x"))
+        )
+
+
+def test_rejected_credentials_raise_a_sanitised_error():
+    """A 401 carries a status code — never the server body or the payload."""
+
+    def handler(url: str, payload: dict[str, str]) -> _FakeResponse:
+        return _FakeResponse(
+            401, {"isok": False, "errors": {"invalid_credentials": FAKE_ACCESS}}
+        )
+
+    with pytest.raises(ShellyOAuthError) as excinfo:
+        asyncio.run(
+            oauth.request_code(_FakeSession(handler), FAKE_EMAIL, sha1_password(FAKE_PASSWORD))
+        )
+    message = str(excinfo.value)
+    assert "401" in message
+    assert FAKE_ACCESS not in message
+    assert sha1_password(FAKE_PASSWORD) not in message
+
+
+def test_rate_limit_is_not_mistaken_for_bad_credentials(monkeypatch):
+    """Shelly reports its 1 req/s limit as HTTP 401 with a ``max_req`` body.
+
+    Only the body separates it from a rejected credential, and mistaking one
+    for the other would push a working account into a re-authentication prompt.
+    """
+    monkeypatch.setattr(oauth.asyncio, "sleep", _instant_sleep)
+    body = '{"isok": false, "errors": {"max_req": "Request limit reached!"}}'
+
+    def handler(url: str, payload: dict[str, str]) -> _FakeResponse:
+        return _FakeResponse(401, json.loads(body), text=body)
+
+    with pytest.raises(ShellyOAuthRateLimitError):
+        asyncio.run(
+            oauth.request_code(_FakeSession(handler), FAKE_EMAIL, sha1_password("x"))
+        )
+
+
+def test_transport_failure_never_quotes_the_aiohttp_error():
+    """``ClientResponseError.__str__`` embeds the request URL — report the type."""
+
+    def handler(url: str, payload: dict[str, str]) -> _FakeResponse:
+        return _FakeResponse(500, {"boom": True})
+
+    with pytest.raises(ShellyOAuthTransportError) as excinfo:
+        asyncio.run(
+            oauth.request_code(_FakeSession(handler), FAKE_EMAIL, sha1_password("x"))
+        )
+    assert "ClientResponseError" in str(excinfo.value)
+
+
+async def _instant_sleep(delay: float) -> None:
+    """Replacement for ``asyncio.sleep`` so a backoff costs no wall-clock time."""
+    return None
+
+
+# ── Refresh ─────────────────────────────────────────────────────────────────
+
+
+def test_refresh_keeps_a_non_rotating_secret():
+    """Measured: the refresh token does not rotate.
+
+    A response without one is the normal case; treating it as "the secret is
+    gone" would strand the account after its very first refresh.
+    """
+    session = _FakeSession(_standard_handler(token=FAKE_SECOND_ACCESS, refresh=None))
+    token = asyncio.run(refresh_token(session, SERVER_URI, FAKE_REFRESH))
+
+    assert token.access_token == FAKE_SECOND_ACCESS
+    assert token.refresh_token == FAKE_REFRESH
+    url, payload = session.calls[0]
+    assert url == f"{SERVER_URI}/oauth/auth"
+    assert payload["grant_type"] == "refresh_token"
+
+
+def test_refresh_prefers_a_rotated_secret_when_one_arrives():
+    """If the server ever starts rotating, the new secret wins."""
+    rotated = "FAKE-REFRESH-TOKEN-44444444"  # noqa: S105
+    session = _FakeSession(_standard_handler(refresh=rotated))
+    token = asyncio.run(refresh_token(session, SERVER_URI, FAKE_REFRESH))
+    assert token.refresh_token == rotated
+
+
+def test_expiry_falls_back_when_the_token_is_unreadable():
+    """A malformed token yields a short TTL rather than an exception.
+
+    The caller still holds a usable token; it simply refreshes sooner. Raising
+    here would turn a cosmetic wire change into a dead integration.
+    """
+    session = _FakeSession(
+        lambda url, payload: _FakeResponse(200, {"access_token": "not-a-jwt"})
+    )
+    token = asyncio.run(refresh_token(session, SERVER_URI, FAKE_REFRESH))
+    assert 0 < token.expires_at - time.time() <= oauth.TOKEN_FALLBACK_TTL_S
+
+
+# ── Token manager ───────────────────────────────────────────────────────────
+
+
+def test_a_valid_token_is_served_without_a_round_trip():
+    """The ordinary case must cost no traffic — the budget is 1 req/s."""
+    session = _FakeSession(_standard_handler())
+    manager = ShellyTokenManager(
+        session,
+        SERVER_URI,
+        token=OAuthToken(FAKE_ACCESS, time.time() + 86400, FAKE_REFRESH),
+    )
+    assert asyncio.run(manager.async_get_token()) == FAKE_ACCESS
+    assert session.calls == []
+
+
+def test_a_token_near_expiry_is_refreshed_and_handed_to_the_caller():
+    """Proactive refresh, so the prompt arrives before an outage, not after."""
+    saved: list[OAuthToken] = []
+
+    async def _save(token: OAuthToken) -> None:
+        saved.append(token)
+
+    manager = ShellyTokenManager(
+        _FakeSession(_standard_handler(token=FAKE_SECOND_ACCESS)),
+        SERVER_URI,
+        token=OAuthToken(FAKE_ACCESS, time.time() + 5, FAKE_REFRESH),
+        on_token_refreshed=_save,
+    )
+    assert asyncio.run(manager.async_get_token()) == FAKE_SECOND_ACCESS
+    assert [t.access_token for t in saved] == [FAKE_SECOND_ACCESS]
+    assert manager.auth_failed is False
+
+
+def test_concurrent_callers_trigger_a_single_refresh():
+    """Reconnect storms must not become request storms against a 1 req/s budget."""
+    session = _FakeSession(_standard_handler(token=FAKE_SECOND_ACCESS))
+    manager = ShellyTokenManager(
+        session,
+        SERVER_URI,
+        token=OAuthToken(FAKE_ACCESS, time.time() - 1, FAKE_REFRESH),
+    )
+
+    async def _race() -> list[str]:
+        return await asyncio.gather(*(manager.async_get_token() for _ in range(5)))
+
+    assert asyncio.run(_race()) == [FAKE_SECOND_ACCESS] * 5
+    assert len(session.calls) == 1
+
+
+def test_no_refresh_token_asks_the_user_rather_than_guessing():
+    """No password is stored, so a missing refresh secret genuinely needs a human."""
+    manager = ShellyTokenManager(_FakeSession(_standard_handler()), SERVER_URI)
+    with pytest.raises(ConfigEntryAuthFailed):
+        asyncio.run(manager.async_get_token())
+    assert manager.auth_failed is True
+
+
+def test_a_rejected_refresh_escalates_to_reauth():
+    """A refused refresh token is a credential failure, and is reported as one."""
+    manager = ShellyTokenManager(
+        _FakeSession(lambda url, payload: _FakeResponse(401, {"isok": False})),
+        SERVER_URI,
+        token=OAuthToken(FAKE_ACCESS, time.time() - 1, FAKE_REFRESH),
+    )
+    with pytest.raises(ConfigEntryAuthFailed):
+        asyncio.run(manager.async_force_refresh())
+    assert manager.auth_failed is True
+
+
+def test_a_rate_limited_refresh_does_not_escalate(monkeypatch):
+    """A rate limit says nothing about the credential.
+
+    Escalating it would drag a perfectly good account through a sign-in prompt
+    because the Shelly app happened to make a request in the same second.
+    """
+    monkeypatch.setattr(oauth.asyncio, "sleep", _instant_sleep)
+    body = '{"isok": false, "errors": {"max_req": "Request limit reached!"}}'
+    manager = ShellyTokenManager(
+        _FakeSession(lambda url, payload: _FakeResponse(401, json.loads(body), text=body)),
+        SERVER_URI,
+        token=OAuthToken(FAKE_ACCESS, time.time() - 1, FAKE_REFRESH),
+    )
+    with pytest.raises(ShellyOAuthRateLimitError):
+        asyncio.run(manager.async_get_token())
+    assert manager.auth_failed is False
+
+
+def test_a_failing_store_does_not_take_the_session_down():
+    """Persistence is the caller's business; its failure is not the session's."""
+
+    async def _explode(token: OAuthToken) -> None:
+        raise RuntimeError("disk full")
+
+    manager = ShellyTokenManager(
+        _FakeSession(_standard_handler(token=FAKE_SECOND_ACCESS)),
+        SERVER_URI,
+        token=OAuthToken(FAKE_ACCESS, time.time() - 1, FAKE_REFRESH),
+        on_token_refreshed=_explode,
+    )
+    assert asyncio.run(manager.async_get_token()) == FAKE_SECOND_ACCESS
+
+
+# ── Secrecy ─────────────────────────────────────────────────────────────────
+
+
+def test_a_token_cannot_be_printed():
+    """The redacting ``__repr__`` is load-bearing, not decoration.
+
+    A dataclass' generated repr puts the token into every f-string, log
+    argument and traceback frame summary that touches the object.
+    """
+    token = OAuthToken(FAKE_ACCESS, time.time() + 60, FAKE_REFRESH)
+    for rendering in (repr(token), f"{token}", str(token), str([token]), str({"t": token})):
+        assert FAKE_ACCESS not in rendering
+        assert FAKE_REFRESH not in rendering
+    assert "expires_at" in repr(token)
+
+
+def test_the_manager_cannot_be_printed():
+    manager = ShellyTokenManager(
+        _FakeSession(_standard_handler()),
+        SERVER_URI,
+        token=OAuthToken(FAKE_ACCESS, time.time() + 60, FAKE_REFRESH),
+    )
+    assert FAKE_ACCESS not in repr(manager)
+    assert FAKE_REFRESH not in repr(manager)
+
+
+def test_no_credential_reaches_a_log_record(caplog):
+    """Drive the real sign-in and refresh at DEBUG, then search the output.
+
+    Formatting each record the way ``logging`` would is the point: a leak
+    hidden in a lazy ``%s`` argument is invisible to a search of the format
+    strings alone.
+    """
+    caplog.set_level(logging.DEBUG)
+    session = _FakeSession(_standard_handler())
+    token = asyncio.run(
+        login(session, SERVER_URI, FAKE_EMAIL, sha1_password(FAKE_PASSWORD))
+    )
+    manager = ShellyTokenManager(session, SERVER_URI, token=token)
+    asyncio.run(manager.async_force_refresh())
+
+    formatter = logging.Formatter("%(levelname)s %(name)s %(message)s")
+    rendered = "\n".join(formatter.format(record) for record in caplog.records)
+    assert rendered  # the flow must actually have logged something to search
+    for secret in (
+        FAKE_ACCESS,
+        FAKE_REFRESH,
+        FAKE_PASSWORD,
+        sha1_password(FAKE_PASSWORD),
+    ):
+        assert secret not in rendered


### PR DESCRIPTION
Closes the half of #20 that was actually asked for: the six FK-06X sprinkler zones have been readable and unswitchable since 2026-08-09.

**Opt-in, off by default, and labelled as riding an undocumented channel.**

## Why the cloud WebSocket

Measured on real hardware in August, with a negative control: `Boolean.Set` on a virtual component **succeeds** over the relay, while **every** documented HTTP cloud route returns **404** for the same operation — and a known-good `set/switch` returns **400** on the same rig, so those 404s are genuinely "no such route", not wrong parameters.

## Scope: control only, no push

**The poll does not change — the coordinator diff removes exactly one line, an import.**

Push was deliberately not built. The offline detector, the relay-fault detector and the health checks are all hardware-confirmed against the poll, and the fields `checkin_marker()` depends on are **not in a WS frame at all** — feeding frames into the coordinator would corrupt the freshness bookkeeping the offline sensor stands on. Control does not need push, and #20 does not either.

## Ownership is probed, because it cannot be read

None of the **62** distinct top-level keys across the 64-device reference snapshot names an owner, a share or a permission. So the relay is asked: one `Shelly.GetDeviceInfo` per candidate device, and `WRONG_ID` means "this session cannot route here" — measured behaviour, including the negative control that malformed ids return the identical error.

Only definite verdicts are cached. `UNKNOWN` stays unresolved and is re-asked while the relay is up, so an inconclusive probe never hardens into a verdict. Only devices that actually carry a `boolean:<id>` are probed at all.

## The switch is additive

It is created **alongside** the existing read-only binary sensor, not instead of it. Replacing it would strand every automation and dashboard card already pointing at the sensor — silently, since the entity would simply go unavailable. For a feature whose first consumer waters a garden, a silent break is the failure being designed against. Visible redundancy is not.

## Failure is loud, by construction

- A command that cannot be routed **raises**; it never returns quietly.
- The switch goes **unavailable** when the relay is down, rather than rendering as operable while every press is guaranteed to throw.
- Success is confirmed **by asking the poll**, never by writing the state optimistically — an optimistic write is exactly what hides a zone that accepted the command and did not move.

## Credentials

The password is hashed inside `sha1_password` and never stored; the token goes to `entry.data` while the poll keeps using the `auth_key` untouched. A failed WS handshake raises an aiohttp error whose `__str__` embeds the **full connect URL including the token** — so every connect failure is re-raised with the query string stripped, and no aiohttp error object is ever interpolated. Diagnostics report the channel's state and the ownership verdicts (as fleet-map fingerprints) but deliberately **not** whether a token exists.

## With the option off

No OAuth, no WebSocket, no probe, no entity, no task. **Every existing test passes unmodified** — that is the proof rather than the claim.

One fix outside the feature: the update listener no longer reloads the entry when only `entry.data` changed. A rotated OAuth token is such a write, and reloading for it would tear down the poll and rebuild every entity because a token refreshed in the background.

## Verification

- **486 passed / 2 skipped** on HA 2025.1.4 (py3.12), **487 / 1** on HA 2026.7.2 (py3.14)
- The transport's two suites were mutation-tested: 11 deliberate regressions, each caught by the test that claims it
- All three translation files parse, en/de key sets identical

## Not yet verified — the one remaining operator step

The fake cloud in `.planning/livetest/` has no WS relay, so the end-to-end proof is still outstanding: one real sign-in and one zone switched. Everything up to that point is built and tested.

Deliberately **not** `Fixes #20`. The issue stays open until the reporter confirms it on his own
FK-06X: nothing here has been proven against that hardware, the end-to-end path is unverified,
and auto-closing an issue on a merge would tell him it is solved before anyone knows it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XarCtwJ7JnsgAgaUytQhQs
